### PR TITLE
V-bon: dry-run/verify로 후보 N개 기계 순위

### DIFF
--- a/mydocs/working/llm_verifier_best_of_n.md
+++ b/mydocs/working/llm_verifier_best_of_n.md
@@ -1,0 +1,91 @@
+---
+kind: working
+status: active
+issue: 5489
+---
+
+# V-bon Best-of-N 기계 순위 (#5489)
+
+작업 브랜치: `feat/v-bon-best-of-n`
+대상: `tools/llm_verifier/best_of_n/` · `mydocs/working/llm_verifier_best_of_n.md`
+
+## 한 줄
+
+후보 N개의 **최종 산출**을 기존 dry-run / `--verify` / `ir-diff` 봉투 필드만으로 순위 매긴다. 산문 점수와 V-step(`process_steps`, #5490)은 없다.
+
+## 이슈가 요구한 것 / 하지 말라는 것
+
+요구:
+
+- LLM-as-Verifier CLAIM V-bon
+- 기계 필드: `changedCount`, `invalid`, `verify.identical`, `exitClass`
+- 각 후보 집합에 `expectedRank`
+- 파일 소유권은 `tools/llm_verifier/best_of_n/` 과 이 문서뿐
+- `cargo fmt --all -- --check`, base `devel`, 한국어 PR, `closes #5489`
+
+하지 말라는 것:
+
+- 산문 점수
+- 과정 단계 보상(`process_steps` — V-step / #5490)
+- `gym/` 변경
+- 새 rhwp CLI
+- `git add -A`
+- 금지 워크트리(`rhwp`, `rhwp-desk*`, `rhwp-handoff`, `rhwp-scaffold-final`, `rhwp-doc-repro`)
+
+## 순위 키 (작을수록 좋음)
+
+1. `invalid` 비어 있음/거짓 > 채워짐/참
+2. `exitClass` 0 > 3 > 4 > 1 > 2 (성공 > 판정실패 > 쪽검증 > IO > 사용법)
+3. `verify.identical` true > 없음(dry-run/`null`) > false
+4. `|changedCount - intendedChangedCount|`, 그다음 `changedCount`
+5. 동률은 `candidateId` 로 안정 정렬. 같은 비교키는 경쟁 순위(1,1,3)
+
+`ir-diff` 의 최상위 `identical`/`diffCount` 는 기존 봉투에서 `verify.identical`/`changedCount` 로 끌어올린다.
+
+## 만진 경로 / 만지지 않은 경로
+
+만짐:
+
+- `tools/llm_verifier/best_of_n/` (순위기, 봉투 lift, 코퍼스 생성, 픽스처, 스키마, 테스트)
+- `mydocs/working/llm_verifier_best_of_n.md`
+
+만지지 않음:
+
+- `Cargo.toml` 워크스페이스 (소유권 밖)
+- `gym/`
+- V-step / `process_steps`
+- 다른 `tools/llm_verifier/*` 축
+
+## 코퍼스
+
+- 생성: `python tools/llm_verifier/best_of_n/generate_corpus.py`
+- 한 레코드 = 후보 집합 N개 + 네 필드 + `expectedRank`
+- 주석 패딩 없음. 집합 식별키 `(command, mode, sample, intended, n, candidate fingerprints)` 유일
+- 명령 가족: fill-fields, csv-to-table, ir-diff, convert, replace-text, redact, set-cell, csv-to-chart, sanitize, run
+- 모드: dry-run / verify / ir-diff
+
+## 시험 명령
+
+```text
+python tools/llm_verifier/best_of_n/test_rank.py
+python tools/llm_verifier/best_of_n/test_envelopes.py
+python tools/llm_verifier/best_of_n/test_corpus.py
+```
+
+실측: 16 + 3 + 7 = 26 tests OK.
+
+## fmt 게이트
+
+```text
+cargo fmt --all -- --check
+```
+
+워크스페이스에 Rust 를 추가하지 않았다. 기존 멤버만 검사한다.
+
+## PR 메모
+
+- base `devel`
+- `closes #5489`
+- `--body-file` UTF-8 without BOM
+- origin `kevin9327`
+- 제목·본문 한국어

--- a/tools/llm_verifier/best_of_n/README.md
+++ b/tools/llm_verifier/best_of_n/README.md
@@ -1,0 +1,26 @@
+# V-bon — Best-of-N outcome ranking
+
+LLM-as-verifier axis 4 (`closes #5489`). Rank N final candidate outputs
+from existing `dry-run` / `--verify` / `ir-diff` envelopes.
+
+Ranking key (lower is better):
+
+1. `invalid` unset/empty beats set
+2. `exitClass` 0 > 3 > 4 > 1 > 2
+3. `verify.identical` true > missing > false
+4. `|changedCount - intendedChangedCount|`, then `changedCount`
+5. `candidateId` (stable)
+
+There is no prose score. `process_steps` is V-step (`#5490`) and is refused.
+
+```text
+python test_rank.py
+python generate_corpus.py
+python -m tools.llm_verifier.best_of_n --check-corpus
+```
+
+Run the last command from the repository root, or:
+
+```text
+python test_corpus.py
+```

--- a/tools/llm_verifier/best_of_n/__init__.py
+++ b/tools/llm_verifier/best_of_n/__init__.py
@@ -1,0 +1,44 @@
+"""V-bon: rank N candidate outcomes from existing dry-run / --verify / ir-diff envelopes.
+
+Outcome ranking only. process_steps and prose scores are out of scope.
+"""
+
+try:
+    from .envelopes import lift_envelope, parse_exit_class
+    from .rank import (
+        CLAIM_ID,
+        SCHEMA_VERSION,
+        OutcomeKey,
+        RankedCandidate,
+        RankedSet,
+        rank_candidates,
+        rank_set,
+    )
+    from .schema import CandidateOutcome, CommandFamily, Mode
+except ImportError:  # script / unittest from this directory
+    from envelopes import lift_envelope, parse_exit_class
+    from rank import (
+        CLAIM_ID,
+        SCHEMA_VERSION,
+        OutcomeKey,
+        RankedCandidate,
+        RankedSet,
+        rank_candidates,
+        rank_set,
+    )
+    from schema import CandidateOutcome, CommandFamily, Mode
+
+__all__ = [
+    "CLAIM_ID",
+    "SCHEMA_VERSION",
+    "CandidateOutcome",
+    "CommandFamily",
+    "Mode",
+    "OutcomeKey",
+    "RankedCandidate",
+    "RankedSet",
+    "lift_envelope",
+    "parse_exit_class",
+    "rank_candidates",
+    "rank_set",
+]

--- a/tools/llm_verifier/best_of_n/__main__.py
+++ b/tools/llm_verifier/best_of_n/__main__.py
@@ -1,0 +1,65 @@
+"""CLI: rank a set JSON or verify the committed corpus."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from .rank import expected_ranks_match, rank_mapping
+except ImportError:
+    from rank import expected_ranks_match, rank_mapping
+
+HERE = Path(__file__).resolve().parent
+
+
+def check_corpus(corpus_dir: Path) -> int:
+    manifest = json.loads((corpus_dir / "manifest.json").read_text(encoding="utf-8"))
+    errors = 0
+    seen: set[str] = set()
+    for shard in manifest["shards"]:
+        path = HERE / shard["path"]
+        if not path.is_file():
+            # manifest paths are relative to package root
+            path = HERE / Path(shard["path"]).name
+            if not path.is_file():
+                path = corpus_dir / Path(shard["path"]).name
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        for blob in payload:
+            sid = blob["setId"]
+            if sid in seen:
+                print(f"duplicate setId {sid}", file=sys.stderr)
+                errors += 1
+            seen.add(sid)
+            if "process_steps" in blob or "processSteps" in blob:
+                print(f"{sid}: process_steps is forbidden", file=sys.stderr)
+                errors += 1
+            mismatches = expected_ranks_match(blob)
+            for item in mismatches:
+                print(f"{sid}: {item}", file=sys.stderr)
+                errors += 1
+    print(json.dumps({"sets": len(seen), "errors": errors, "lineCount": manifest["lineCount"]}))
+    return 0 if errors == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--set-json", type=Path)
+    parser.add_argument("--check-corpus", action="store_true")
+    parser.add_argument("--corpus-dir", type=Path, default=HERE / "corpus")
+    args = parser.parse_args(argv)
+    if args.check_corpus:
+        return check_corpus(args.corpus_dir)
+    if args.set_json is None:
+        parser.error("pass --set-json or --check-corpus")
+    blob = json.loads(args.set_json.read_text(encoding="utf-8"))
+    ranked = rank_mapping(blob)
+    json.dump(ranked.to_json(), sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/llm_verifier/best_of_n/corpus/manifest.json
+++ b/tools/llm_verifier/best_of_n/corpus/manifest.json
@@ -1,0 +1,236 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "V-bon",
+  "kind": "bestOfNCorpus",
+  "setCount": 1728,
+  "shardCount": 27,
+  "lineCount": 345833,
+  "minLines": 102000,
+  "minSets": 1666,
+  "setsPerShard": 64,
+  "rankFields": [
+    "changedCount",
+    "invalid",
+    "verify.identical",
+    "exitClass"
+  ],
+  "forbidden": [
+    "process_steps",
+    "processSteps",
+    "proseScore",
+    "llmScore"
+  ],
+  "byCommand": {
+    "convert": 98,
+    "csv-to-chart": 196,
+    "csv-to-table": 196,
+    "fill-fields": 258,
+    "ir-diff": 98,
+    "redact": 196,
+    "replace-text": 196,
+    "run": 98,
+    "sanitize": 196,
+    "set-cell": 196
+  },
+  "byMode": {
+    "dry-run": 686,
+    "ir-diff": 98,
+    "verify": 944
+  },
+  "shards": [
+    {
+      "path": "corpus/shard_0000.json",
+      "sets": 64,
+      "lines": 13316,
+      "first": "v-bon-000001",
+      "last": "v-bon-000064"
+    },
+    {
+      "path": "corpus/shard_0001.json",
+      "sets": 64,
+      "lines": 16139,
+      "first": "v-bon-000065",
+      "last": "v-bon-000128"
+    },
+    {
+      "path": "corpus/shard_0002.json",
+      "sets": 64,
+      "lines": 15142,
+      "first": "v-bon-000129",
+      "last": "v-bon-000192"
+    },
+    {
+      "path": "corpus/shard_0003.json",
+      "sets": 64,
+      "lines": 13535,
+      "first": "v-bon-000193",
+      "last": "v-bon-000256"
+    },
+    {
+      "path": "corpus/shard_0004.json",
+      "sets": 64,
+      "lines": 17444,
+      "first": "v-bon-000257",
+      "last": "v-bon-000320"
+    },
+    {
+      "path": "corpus/shard_0005.json",
+      "sets": 64,
+      "lines": 15151,
+      "first": "v-bon-000321",
+      "last": "v-bon-000384"
+    },
+    {
+      "path": "corpus/shard_0006.json",
+      "sets": 64,
+      "lines": 10025,
+      "first": "v-bon-000385",
+      "last": "v-bon-000448"
+    },
+    {
+      "path": "corpus/shard_0007.json",
+      "sets": 64,
+      "lines": 11904,
+      "first": "v-bon-000449",
+      "last": "v-bon-000512"
+    },
+    {
+      "path": "corpus/shard_0008.json",
+      "sets": 64,
+      "lines": 11528,
+      "first": "v-bon-000513",
+      "last": "v-bon-000576"
+    },
+    {
+      "path": "corpus/shard_0009.json",
+      "sets": 64,
+      "lines": 9984,
+      "first": "v-bon-000577",
+      "last": "v-bon-000640"
+    },
+    {
+      "path": "corpus/shard_0010.json",
+      "sets": 64,
+      "lines": 12418,
+      "first": "v-bon-000641",
+      "last": "v-bon-000704"
+    },
+    {
+      "path": "corpus/shard_0011.json",
+      "sets": 64,
+      "lines": 10094,
+      "first": "v-bon-000705",
+      "last": "v-bon-000768"
+    },
+    {
+      "path": "corpus/shard_0012.json",
+      "sets": 64,
+      "lines": 9342,
+      "first": "v-bon-000769",
+      "last": "v-bon-000832"
+    },
+    {
+      "path": "corpus/shard_0013.json",
+      "sets": 64,
+      "lines": 11898,
+      "first": "v-bon-000833",
+      "last": "v-bon-000896"
+    },
+    {
+      "path": "corpus/shard_0014.json",
+      "sets": 64,
+      "lines": 11885,
+      "first": "v-bon-000897",
+      "last": "v-bon-000960"
+    },
+    {
+      "path": "corpus/shard_0015.json",
+      "sets": 64,
+      "lines": 11297,
+      "first": "v-bon-000961",
+      "last": "v-bon-001024"
+    },
+    {
+      "path": "corpus/shard_0016.json",
+      "sets": 64,
+      "lines": 13886,
+      "first": "v-bon-001025",
+      "last": "v-bon-001088"
+    },
+    {
+      "path": "corpus/shard_0017.json",
+      "sets": 64,
+      "lines": 9776,
+      "first": "v-bon-001089",
+      "last": "v-bon-001152"
+    },
+    {
+      "path": "corpus/shard_0018.json",
+      "sets": 64,
+      "lines": 11176,
+      "first": "v-bon-001153",
+      "last": "v-bon-001216"
+    },
+    {
+      "path": "corpus/shard_0019.json",
+      "sets": 64,
+      "lines": 16295,
+      "first": "v-bon-001217",
+      "last": "v-bon-001280"
+    },
+    {
+      "path": "corpus/shard_0020.json",
+      "sets": 64,
+      "lines": 15088,
+      "first": "v-bon-001281",
+      "last": "v-bon-001344"
+    },
+    {
+      "path": "corpus/shard_0021.json",
+      "sets": 64,
+      "lines": 14798,
+      "first": "v-bon-001345",
+      "last": "v-bon-001408"
+    },
+    {
+      "path": "corpus/shard_0022.json",
+      "sets": 64,
+      "lines": 11684,
+      "first": "v-bon-001409",
+      "last": "v-bon-001472"
+    },
+    {
+      "path": "corpus/shard_0023.json",
+      "sets": 64,
+      "lines": 9692,
+      "first": "v-bon-001473",
+      "last": "v-bon-001536"
+    },
+    {
+      "path": "corpus/shard_0024.json",
+      "sets": 64,
+      "lines": 12367,
+      "first": "v-bon-001537",
+      "last": "v-bon-001600"
+    },
+    {
+      "path": "corpus/shard_0025.json",
+      "sets": 64,
+      "lines": 16688,
+      "first": "v-bon-001601",
+      "last": "v-bon-001664"
+    },
+    {
+      "path": "corpus/shard_0026.json",
+      "sets": 64,
+      "lines": 13281,
+      "first": "v-bon-001665",
+      "last": "v-bon-001728"
+    }
+  ],
+  "notes": [
+    "Each record is a distinct N-candidate outcome set, not comment padding.",
+    "expectedRank is rank.py of changedCount/invalid/verify.identical/exitClass.",
+    "V-step process_steps is out of scope (#5490)."
+  ]
+}

--- a/tools/llm_verifier/best_of_n/corpus/shard_0000.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0000.json
@@ -1,0 +1,13316 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000001",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/고시/2016/0002.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 2,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2016/0002.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/고시/2016/0002.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2016/0002.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/고시/2016/0002.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000002",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/고시/2016/0003.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 3,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2016/0003.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0002-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/고시/2016/0003.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2016/0003.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0015-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 1,
+              "value": "계좌번호-0015-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 2,
+              "value": "계좌번호-0015-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/고시/2016/0003.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000003",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/고시/2016/0004.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 4,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2016/0004.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0003-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0003-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0003-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-0003-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/고시/2016/0004.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2016/0004.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0016-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0016-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0016-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0016-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/고시/2016/0004.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000004",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/고시/2016/0005.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 5,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2016/0005.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/고시/2016/0005.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2016/0005.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/고시/2016/0005.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000005",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/고시/2016/0006.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 6,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2016/0006.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0005-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0005-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0005-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0005-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/고시/2016/0006.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2016/0006.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0018-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0018-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0018-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0018-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/고시/2016/0006.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000006",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/고시/2016/0007.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 7,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2016/0007.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0006-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0006-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0006-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0006-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/고시/2016/0007.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2016/0007.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0019-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0019-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0019-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0019-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/고시/2016/0007.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000007",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/고시/2016/0008.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 8,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2016/0008.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/고시/2016/0008.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2016/0008.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/고시/2016/0008.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000008",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/고시/2016/0009.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 9,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2016/0009.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0008-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0008-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0008-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0008-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/고시/2016/0009.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2016/0009.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0021-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0021-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0021-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0021-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/고시/2016/0009.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000009",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/고시/2016/0010.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 10,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2016/0010.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0009-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0009-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0009-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0009-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/고시/2016/0010.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2016/0010.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0022-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0022-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0022-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0022-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/고시/2016/0010.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000010",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/고시/2016/0011.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 11,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2016/0011.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0010-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0010-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0010-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0010-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/고시/2016/0011.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2016/0011.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/고시/2016/0011.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000011",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/고시/2016/0012.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 12,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2016/0012.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0011-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0011-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0011-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0011-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2016/0012.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2016/0012.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2016/0012.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000012",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/고시/2016/0013.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 13,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2016/0013.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0012-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0012-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0012-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0012-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/고시/2016/0013.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2016/0013.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/고시/2016/0013.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000013",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/고시/2016/0014.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 14,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2016/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0013-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0013-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0013-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0013-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2016/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2016/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0026-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0026-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0026-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0026-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2016/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000014",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/고시/2016/0015.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 15,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2016/0015.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2016/0015.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2016/0015.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2016/0015.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000015",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/고시/2016/0016.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 16,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2016/0016.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/고시/2016/0016.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2016/0016.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0028-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 1,
+              "value": "담당부서-0028-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/고시/2016/0016.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2016/0016.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0041-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 1,
+              "value": "생년월일-0041-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 2,
+              "value": "생년월일-0041-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 3,
+              "value": "생년월일-0041-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/고시/2016/0016.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000016",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/고시/2016/0017.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 17,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2016/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0016-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0016-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 2,
+              "value": "주민등록번호-0016-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2016/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2016/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0029-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-0029-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 2,
+              "value": "담당자-0029-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 3,
+              "value": "담당자-0029-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2016/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2016/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0042-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0042-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 2,
+              "value": "주소-0042-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 3,
+              "value": "주소-0042-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2016/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000017",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/고시/2016/0018.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 18,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2016/0018.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/고시/2016/0018.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2016/0018.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/고시/2016/0018.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2016/0018.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/고시/2016/0018.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000018",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/고시/2016/0019.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 19,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2016/0019.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0018-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0018-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0018-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-0018-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/고시/2016/0019.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2016/0019.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0031-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0031-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0031-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/고시/2016/0019.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2016/0019.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0044-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0044-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0044-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/고시/2016/0019.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000019",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/고시/2016/0020.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 20,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2016/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0019-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0019-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0019-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0019-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/고시/2016/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2016/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0032-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0032-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0032-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0032-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/고시/2016/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2016/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0045-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0045-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0045-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/고시/2016/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000020",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/고시/2016/0021.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 21,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2016/0021.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/고시/2016/0021.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2016/0021.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/고시/2016/0021.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2016/0021.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0046-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0046-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0046-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0046-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/고시/2016/0021.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000021",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/고시/2016/0022.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 22,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2016/0022.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0021-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0021-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0021-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0021-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/고시/2016/0022.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2016/0022.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0034-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0034-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0034-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0034-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/고시/2016/0022.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2016/0022.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0047-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0047-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0047-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0047-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/고시/2016/0022.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000022",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/고시/2016/0023.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 23,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2016/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0022-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0022-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0022-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0022-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/고시/2016/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2016/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0035-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0035-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0035-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0035-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/고시/2016/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2016/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0048-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0048-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0048-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0048-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/고시/2016/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000023",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/고시/2016/0024.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 24,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2016/0024.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0023-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0023-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0023-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0023-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2016/0024.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2016/0024.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2016/0024.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2016/0024.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0049-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0049-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0049-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0049-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2016/0024.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000024",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/고시/2016/0025.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 25,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2016/0025.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0024-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0024-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0024-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0024-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/고시/2016/0025.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2016/0025.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/고시/2016/0025.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2016/0025.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/고시/2016/0025.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000025",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/고시/2016/0026.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 26,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2016/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0025-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0025-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0025-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0025-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/고시/2016/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2016/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/고시/2016/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2016/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0051-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0051-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0051-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0051-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/고시/2016/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000026",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/고시/2016/0027.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 27,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2016/0027.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0026-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0026-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0026-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0026-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2016/0027.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2016/0027.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0039-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0039-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0039-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0039-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2016/0027.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2016/0027.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0052-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0052-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0052-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0052-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2016/0027.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000027",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/고시/2016/0028.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 28,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2016/0028.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2016/0028.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2016/0028.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2016/0028.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2016/0028.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2016/0028.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000028",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/고시/2016/0029.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 29,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2016/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0028-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0028-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0028-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0028-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2016/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2016/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0041-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0041-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0041-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0041-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2016/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2016/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0054-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0054-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0054-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0054-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2016/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000029",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/고시/2016/0030.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 30,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2016/0030.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0029-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-0029-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2016/0030.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2016/0030.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0042-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0042-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 2,
+              "value": "주소-0042-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2016/0030.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2016/0030.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0055-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 1,
+              "value": "계좌번호-0055-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 2,
+              "value": "계좌번호-0055-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 3,
+              "value": "계좌번호-0055-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2016/0030.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2016/0030.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0068-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 1,
+              "value": "담당부서-0068-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 2,
+              "value": "담당부서-0068-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 3,
+              "value": "담당부서-0068-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2016/0030.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000030",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/고시/2016/0031.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 31,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2016/0031.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/고시/2016/0031.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2016/0031.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/고시/2016/0031.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2016/0031.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/고시/2016/0031.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2016/0031.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/고시/2016/0031.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000031",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/고시/2016/0032.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "고시",
+    "year": 2016,
+    "serial": 32,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2016/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0031-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0031-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 1,
+              "value": "시행일자-0031-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 1,
+              "value": "수신-0031-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/고시/2016/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2016/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0044-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0044-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/고시/2016/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2016/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0057-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0057-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/고시/2016/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2016/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0070-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0070-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/고시/2016/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000032",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/훈령/2016/0033.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 33,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2016/0033.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0032-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0032-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0032-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 1,
+              "value": "수신-0032-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/훈령/2016/0033.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2016/0033.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0045-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0045-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0045-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 1,
+              "value": "사업자등록번호-0045-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/훈령/2016/0033.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2016/0033.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0058-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0058-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/훈령/2016/0033.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2016/0033.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0071-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/훈령/2016/0033.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000033",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/훈령/2016/0034.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 34,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2016/0034.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2016/0034.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2016/0034.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2016/0034.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2016/0034.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0059-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0059-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0059-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0059-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2016/0034.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2016/0034.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2016/0034.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000034",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/훈령/2016/0035.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 35,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2016/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0034-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0034-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0034-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0034-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/훈령/2016/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2016/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0047-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0047-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0047-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0047-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/훈령/2016/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2016/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0060-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0060-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0060-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0060-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/훈령/2016/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2016/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/훈령/2016/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000035",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/훈령/2016/0036.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 36,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2016/0036.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0035-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0035-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0035-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0035-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/훈령/2016/0036.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2016/0036.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0048-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0048-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0048-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0048-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/훈령/2016/0036.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2016/0036.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0061-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0061-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0061-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/훈령/2016/0036.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2016/0036.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/훈령/2016/0036.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000036",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/훈령/2016/0037.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 37,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2016/0037.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0036-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0036-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0036-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0036-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/훈령/2016/0037.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2016/0037.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/훈령/2016/0037.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2016/0037.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0062-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0062-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0062-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0062-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/훈령/2016/0037.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2016/0037.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0075-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0075-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0075-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0075-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/훈령/2016/0037.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000037",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/훈령/2016/0038.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 38,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2016/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0037-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0037-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0037-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0037-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/훈령/2016/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2016/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/훈령/2016/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2016/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/훈령/2016/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2016/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/훈령/2016/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000038",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/훈령/2016/0039.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 39,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2016/0039.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0038-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0038-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0038-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0038-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2016/0039.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2016/0039.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2016/0039.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2016/0039.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0064-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0064-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0064-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0064-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2016/0039.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2016/0039.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0077-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0077-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0077-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0077-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2016/0039.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000039",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/훈령/2016/0040.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 40,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2016/0040.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0039-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0039-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0039-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0039-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2016/0040.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2016/0040.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0052-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0052-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0052-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0052-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2016/0040.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2016/0040.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0065-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0065-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0065-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0065-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2016/0040.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2016/0040.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0078-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0078-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0078-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0078-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2016/0040.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000040",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/훈령/2016/0041.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 41,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2016/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2016/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2016/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2016/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2016/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2016/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2016/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2016/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000041",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/훈령/2016/0042.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 42,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2016/0042.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0041-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0041-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0041-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0041-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/훈령/2016/0042.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2016/0042.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0054-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0054-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0054-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0054-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/훈령/2016/0042.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2016/0042.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0067-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0067-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0067-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0067-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/훈령/2016/0042.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2016/0042.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0080-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0080-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0080-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0080-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/훈령/2016/0042.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000042",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/훈령/2016/0043.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 43,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2016/0043.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0042-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0042-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0042-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0042-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2016/0043.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2016/0043.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0055-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0055-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0055-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0055-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2016/0043.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2016/0043.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 25,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0068-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0068-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0068-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0068-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2016/0043.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2016/0043.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0081-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0081-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0081-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0081-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2016/0043.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000043",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 44,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2016/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2016/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2016/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2016/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2016/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2016/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000044",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 45,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0044-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-0044-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 2,
+              "value": "전자우편-0044-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 3,
+              "value": "전자우편-0044-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2016/0045.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0057-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2016/0045.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0070-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2016/0045.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0083-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2016/0045.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2016/0045.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0096-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0096-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 2,
+              "value": "주민등록번호-0096-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 3,
+              "value": "주민등록번호-0096-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2016/0045.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000045",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 46,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0045-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0045-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 1,
+              "value": "사업자등록번호-0045-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0045-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2016/0046.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0058-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0058-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-0058-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 1,
+              "value": "처리기한-0058-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2016/0046.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0071-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2016/0046.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2016/0046.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2016/0046.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2016/0046.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000046",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 47,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2016/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2016/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0072-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0072-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0072-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2016/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2016/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2016/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0098-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0098-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0098-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2016/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000047",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 48,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0047-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0047-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0047-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0047-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2016/0048.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0060-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0060-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0060-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0060-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2016/0048.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0073-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0073-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0073-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0073-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2016/0048.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2016/0048.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2016/0048.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2016/0048.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000048",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 49,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0048-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0048-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0048-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0048-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2016/0049.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0061-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0061-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0061-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2016/0049.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0074-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0074-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2016/0049.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2016/0049.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2016/0049.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0100-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0100-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0100-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0100-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2016/0049.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000049",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/훈령/2016/0050.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 50,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2016/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0049-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0049-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0049-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0049-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/훈령/2016/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2016/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/훈령/2016/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2016/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0075-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0075-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0075-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0075-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/훈령/2016/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2016/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0088-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0088-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0088-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0088-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/훈령/2016/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2016/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0101-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0101-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0101-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0101-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/훈령/2016/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000050",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/훈령/2016/0051.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 51,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2016/0051.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0050-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0050-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0050-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0050-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/훈령/2016/0051.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2016/0051.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/훈령/2016/0051.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2016/0051.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/훈령/2016/0051.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2016/0051.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/훈령/2016/0051.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2016/0051.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/훈령/2016/0051.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000051",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/훈령/2016/0052.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 52,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2016/0052.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0051-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0051-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0051-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0051-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/훈령/2016/0052.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2016/0052.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/훈령/2016/0052.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2016/0052.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0077-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0077-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0077-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0077-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/훈령/2016/0052.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2016/0052.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0090-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0090-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0090-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0090-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/훈령/2016/0052.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2016/0052.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0103-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0103-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0103-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0103-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/훈령/2016/0052.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000052",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 53,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0052-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0052-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0052-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0052-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/훈령/2016/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0065-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0065-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0065-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0065-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/훈령/2016/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0078-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0078-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0078-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0078-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/훈령/2016/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0091-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0091-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0091-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0091-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/훈령/2016/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2016/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0104-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0104-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0104-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0104-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/훈령/2016/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000053",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 54,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/훈령/2016/0054.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/훈령/2016/0054.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/훈령/2016/0054.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/훈령/2016/0054.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2016/0054.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/훈령/2016/0054.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000054",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/훈령/2016/0055.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 55,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2016/0055.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0054-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0054-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0054-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0054-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/훈령/2016/0055.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2016/0055.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0067-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0067-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0067-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0067-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/훈령/2016/0055.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2016/0055.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0080-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0080-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0080-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0080-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/훈령/2016/0055.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2016/0055.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0093-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0093-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0093-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0093-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/훈령/2016/0055.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2016/0055.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0106-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0106-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0106-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0106-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/훈령/2016/0055.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000055",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 56,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0055-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0055-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0055-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0055-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2016/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0068-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0068-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0068-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0068-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2016/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0081-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0081-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0081-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0081-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2016/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0094-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0094-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0094-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0094-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2016/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2016/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0107-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0107-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0107-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0107-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2016/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000056",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/훈령/2016/0057.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 57,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2016/0057.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/훈령/2016/0057.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2016/0057.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/훈령/2016/0057.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2016/0057.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/훈령/2016/0057.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2016/0057.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/훈령/2016/0057.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2016/0057.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0108-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0108-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0108-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0108-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/훈령/2016/0057.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000057",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/훈령/2016/0058.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 58,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0057-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0057-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 2,
+              "value": "면허번호-0057-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 3,
+              "value": "면허번호-0057-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0109-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-0109-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 2,
+              "value": "담당자-0109-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2016/0058.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/훈령/2016/0058.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000058",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 59,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0058-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-0058-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 2,
+              "value": "시설위치-0058-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 3,
+              "value": "시설위치-0058-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0071-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 1,
+              "value": "시행일자-0071-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 2,
+              "value": "시행일자-0071-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 3,
+              "value": "시행일자-0071-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2016/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2016/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000059",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 60,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0085-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0085-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0111-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0111-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2016/0060.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0124-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0124-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-0124-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2016/0060.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000060",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 61,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0060-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0060-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0060-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0073-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0073-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0073-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0086-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0086-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0086-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0086-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2016/0061.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2016/0061.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000061",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 62,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0061-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0061-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0061-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0074-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0074-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0087-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0113-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0113-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0113-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0113-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2016/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0126-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0126-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0126-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0126-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2016/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000062",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/훈령/2016/0063.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 63,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0062-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0062-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0062-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0062-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0088-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0088-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0088-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0088-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0101-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0101-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0101-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0101-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0114-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0114-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0114-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0114-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2016/0063.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0127-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0127-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0127-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0127-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/훈령/2016/0063.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000063",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "훈령",
+    "year": 2016,
+    "serial": 64,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0063-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0063-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0063-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0063-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2016/0064.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2016/0064.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000064",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/예규/2016/0065.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 65,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0064-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0064-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0064-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0064-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0090-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0090-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0090-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0090-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0103-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0103-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0103-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0103-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0116-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0116-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0116-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0116-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2016/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0129-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0129-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0129-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0129-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/예규/2016/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0001.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0001.json
@@ -1,0 +1,16139 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000065",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 66,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0065-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0065-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0065-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0065-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0078-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0078-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0078-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0078-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0091-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0091-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0091-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0091-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0104-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0104-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0104-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0104-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0117-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0117-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0117-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0117-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2016/0066.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0130-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0130-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0130-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0130-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/예규/2016/0066.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000066",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/예규/2016/0067.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 67,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2016/0067.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/예규/2016/0067.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000067",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/예규/2016/0068.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 68,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0067-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0067-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0067-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0067-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0080-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0080-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0080-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0080-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0093-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0093-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0093-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0093-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0106-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0106-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0106-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0106-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0119-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0119-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0119-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0119-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2016/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0132-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0132-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0132-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0132-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/예규/2016/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000068",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/예규/2016/0069.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 69,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0068-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0068-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0068-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0068-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0081-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0081-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0081-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0081-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0094-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0094-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0094-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0094-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0107-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0107-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0107-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0107-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0120-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0120-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0120-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0120-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2016/0069.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0133-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0133-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0133-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0133-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/예규/2016/0069.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000069",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/예규/2016/0070.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 70,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0121-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0121-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0121-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0121-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 18
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2016/0070.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/예규/2016/0070.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 18
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000070",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 71,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0070-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0070-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0070-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0070-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0083-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0083-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0083-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0083-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0096-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0096-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0096-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0096-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0109-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0109-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0109-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0109-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0122-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0122-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0122-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0122-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2016/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예규/2016/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000071",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 72,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0071-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 1,
+              "value": "시행일자-0071-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 2,
+              "value": "시행일자-0071-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 3,
+              "value": "시행일자-0071-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0084-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-0084-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 2,
+              "value": "전자우편-0084-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 3,
+              "value": "전자우편-0084-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2016/0072.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/예규/2016/0072.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000072",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/예규/2016/0073.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 73,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0098-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0124-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0137-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0137-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2016/0073.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0150-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-0150-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 2,
+              "value": "문서번호-0150-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예규/2016/0073.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000073",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/예규/2016/0074.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 74,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0073-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0073-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0086-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0086-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0099-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0099-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 1,
+              "value": "처리기한-0099-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 1,
+              "value": "신청인-0099-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2016/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/예규/2016/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000074",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 75,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0074-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0074-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0087-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0126-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0126-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0126-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0139-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0139-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0139-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 1,
+              "value": "처리기한-0139-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2016/0075.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0152-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0152-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0152-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 1,
+              "value": "수신-0152-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/예규/2016/0075.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000075",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 76,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0075-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0075-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0075-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0075-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0101-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0101-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0101-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0101-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0114-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0114-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0114-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0114-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0127-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0127-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0127-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0127-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0140-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0140-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0140-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0140-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2016/0076.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0153-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0153-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0153-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0153-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2016/0076.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000076",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 77,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0076-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0076-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0076-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0076-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2016/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/예규/2016/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000077",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 78,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0077-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0077-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0077-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0103-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0103-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0103-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0103-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0116-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0116-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0116-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0116-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0129-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0129-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0129-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0129-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0142-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0142-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0142-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0142-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2016/0078.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0155-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0155-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0155-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0155-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2016/0078.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000078",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 79,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0078-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0078-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0078-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0078-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0091-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0091-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0091-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0091-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0104-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0104-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0104-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0104-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0117-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0117-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0117-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0117-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0130-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0130-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0130-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0130-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0143-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0143-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0143-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0143-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2016/0079.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0156-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0156-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0156-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0156-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2016/0079.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000079",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 80,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2016/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0157-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0157-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0157-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0157-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2016/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000080",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 81,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0080-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0080-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0080-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0080-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0093-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0093-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0093-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0093-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0106-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0106-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0106-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0106-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0119-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0119-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0119-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0119-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0132-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0132-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0132-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0132-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0145-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0145-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0145-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0145-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2016/0081.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0158-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0158-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0158-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0158-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2016/0081.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000081",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/예규/2016/0082.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 82,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0081-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0081-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0081-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0081-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0094-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0094-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0094-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0094-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0107-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0107-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0107-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0107-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0120-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0120-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0120-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0120-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0133-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0133-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0133-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0133-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0146-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0146-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0146-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0146-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2016/0082.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0159-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0159-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0159-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0159-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/예규/2016/0082.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000082",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/예규/2016/0083.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 83,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0134-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0134-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0134-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0134-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 15
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 15
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2016/0083.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0160-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0160-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0160-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0160-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/예규/2016/0083.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000083",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/예규/2016/0084.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 84,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0083-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0083-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0083-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0083-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0096-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0096-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0096-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0096-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0109-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0109-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0109-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0109-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0122-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0122-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0122-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0122-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0135-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0135-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0135-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0135-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2016/0084.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/예규/2016/0084.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000084",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/예규/2016/0085.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 85,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 25,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0084-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0084-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0084-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0084-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0097-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0097-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0097-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0097-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0110-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0110-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0110-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0110-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0123-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0123-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0123-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0123-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0136-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0136-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0136-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0136-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2016/0085.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0162-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0162-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0162-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0162-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/예규/2016/0085.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000085",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/예규/2016/0086.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 86,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0150-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0163-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0163-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2016/0086.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0176-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0176-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 2,
+              "value": "주민등록번호-0176-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/예규/2016/0086.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000086",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/예규/2016/0087.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 87,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0086-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0099-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0112-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 1,
+              "value": "수신-0112-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 2,
+              "value": "수신-0112-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 3,
+              "value": "수신-0112-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2016/0087.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/예규/2016/0087.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000087",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 88,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0087-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0139-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0139-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0152-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0152-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 1,
+              "value": "수신-0152-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 1,
+              "value": "제목-0152-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0165-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0165-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 1,
+              "value": "사업자등록번호-0165-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0165-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2016/0088.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0178-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0178-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2016/0088.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000088",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/예규/2016/0089.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 89,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0088-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0088-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0088-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0114-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0114-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0114-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0127-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0127-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0127-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 1,
+              "value": "대표자-0127-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0140-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0140-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0140-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 1,
+              "value": "신청인-0140-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0153-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0153-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0153-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 1,
+              "value": "제목-0153-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0166-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0166-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0166-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0166-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2016/0089.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0179-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0179-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0179-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 1,
+              "value": "처리기한-0179-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/예규/2016/0089.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000089",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/예규/2016/0090.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 90,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0089-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0089-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0089-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0089-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2016/0090.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/예규/2016/0090.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000090",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 91,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0090-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0090-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0116-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0116-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0116-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0116-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0129-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0129-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0129-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0129-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0142-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0142-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0142-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0142-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0155-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0155-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0155-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0155-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0168-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0168-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0168-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0168-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2016/0091.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0181-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0181-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0181-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0181-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2016/0091.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000091",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 92,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0091-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0091-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0091-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0091-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0104-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0104-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0104-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0104-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0117-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0117-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0117-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0117-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0130-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0130-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0130-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0130-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0143-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0143-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0143-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0143-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0156-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0156-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0156-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0156-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0169-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0169-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0169-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0169-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2016/0092.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0182-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0182-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0182-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0182-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2016/0092.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000092",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 93,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0170-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0170-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0170-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0170-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2016/0093.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2016/0093.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000093",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 94,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0093-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0093-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0093-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0093-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0106-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0106-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0106-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0106-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0119-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0119-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0119-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0119-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0132-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0132-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0132-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0132-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0145-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0145-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0145-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0145-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0158-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0158-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0158-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0158-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0171-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0171-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0171-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0171-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2016/0094.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2016/0094.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000094",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/예규/2016/0095.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 95,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0094-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0094-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0094-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0094-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0107-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0107-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0107-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0107-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0120-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0120-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0120-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0120-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0133-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0133-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0133-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0133-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0146-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0146-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0146-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0146-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0159-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0159-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0159-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0159-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0172-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0172-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0172-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0172-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2016/0095.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/예규/2016/0095.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000095",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예규",
+    "year": 2016,
+    "serial": 96,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0147-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0147-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0147-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0147-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0173-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0173-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0173-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0173-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2016/0096.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0186-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0186-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0186-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0186-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예규/2016/0096.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000096",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/공고/2016/0097.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 97,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0096-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0096-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0096-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0096-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0109-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0109-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0109-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0109-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0122-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0122-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0122-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0122-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0135-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0135-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0135-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0135-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0148-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0148-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0148-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0148-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2016/0097.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/공고/2016/0097.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000097",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 98,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0097-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0097-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0097-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0097-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0110-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0110-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0110-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0110-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0123-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0123-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0123-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0123-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0136-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0136-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0136-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0136-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0149-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0149-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0149-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0149-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0175-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0175-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0175-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0175-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2016/0098.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0188-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0188-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0188-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0188-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/공고/2016/0098.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000098",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/공고/2016/0099.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 99,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0124-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0124-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0124-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0124-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 21
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 21
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0150-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0150-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0150-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0150-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0163-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0163-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0163-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0163-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0176-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0176-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0176-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0176-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2016/0099.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0189-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0189-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0189-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0189-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/공고/2016/0099.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000099",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/공고/2016/0100.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 100,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2016/0100.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2016/0100.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000100",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/공고/2016/0101.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 101,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2016/0101.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2016/0101.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000101",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/공고/2016/0102.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 102,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2016/0102.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2016/0102.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000102",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/공고/2016/0103.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 103,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2016/0103.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2016/0103.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000103",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/공고/2016/0104.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 104,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2016/0104.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2016/0104.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0116-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0116-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0116-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0116-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000104",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/공고/2016/0105.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 105,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2016/0105.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0104-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0104-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0104-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0104-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2016/0105.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0117-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0117-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0117-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0117-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000105",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/공고/2016/0106.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 106,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2016/0106.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0105-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0105-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0105-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0105-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2016/0106.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0118-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0118-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0118-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0118-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000106",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/공고/2016/0107.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 107,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2016/0107.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0106-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0106-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0106-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0106-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2016/0107.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0119-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0119-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0119-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0119-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000107",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/공고/2016/0108.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 108,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2016/0108.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2016/0108.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000108",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/공고/2016/0109.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 109,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2016/0109.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2016/0109.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000109",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/공고/2016/0110.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 110,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2016/0110.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2016/0110.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000110",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/공고/2016/0111.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 111,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2016/0111.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2016/0111.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000111",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/공고/2016/0112.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 112,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2016/0112.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2016/0112.hwp",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0124-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0124-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0124-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0124-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000112",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/공고/2016/0113.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 113,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2016/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0112-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0112-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0112-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0112-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2016/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0125-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0125-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0125-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0125-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000113",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/공고/2016/0114.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 114,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2016/0114.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0113-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 1,
+              "value": "제목-0113-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2016/0114.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0126-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0126-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 2,
+              "value": "법인명-0126-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 3,
+              "value": "법인명-0126-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2016/0114.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000114",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/공고/2016/0115.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 115,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2016/0115.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2016/0115.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2016/0115.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000115",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/공고/2016/0116.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 116,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2016/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2016/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2016/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000116",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/공고/2016/0117.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 117,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2016/0117.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2016/0117.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2016/0117.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000117",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/공고/2016/0118.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 118,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2016/0118.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2016/0118.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2016/0118.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000118",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/공고/2016/0119.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 119,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2016/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2016/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2016/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000119",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/공고/2016/0120.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 120,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2016/0120.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2016/0120.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0132-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0132-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0132-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0132-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2016/0120.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0145-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0145-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0145-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0145-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000120",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/공고/2016/0121.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 121,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2016/0121.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0120-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0120-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0120-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0120-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2016/0121.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0133-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0133-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0133-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0133-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2016/0121.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0146-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0146-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0146-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0146-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000121",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/공고/2016/0122.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 122,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2016/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0121-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0121-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0121-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0121-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2016/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0134-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0134-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0134-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0134-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2016/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0147-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0147-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0147-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0147-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000122",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/공고/2016/0123.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 123,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2016/0123.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0122-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0122-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0122-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0122-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2016/0123.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0135-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0135-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0135-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0135-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2016/0123.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000123",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/공고/2016/0124.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 124,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2016/0124.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2016/0124.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2016/0124.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000124",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/공고/2016/0125.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 125,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2016/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2016/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2016/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000125",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/공고/2016/0126.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 126,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2016/0126.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2016/0126.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2016/0126.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000126",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/공고/2016/0127.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 127,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2016/0127.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2016/0127.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2016/0127.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000127",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/공고/2016/0128.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "공고",
+    "year": 2016,
+    "serial": 128,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2016/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2016/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0140-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 1,
+              "value": "신청인-0140-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 2,
+              "value": "신청인-0140-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 3,
+              "value": "신청인-0140-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2016/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2016/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0166-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000128",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/지침/2016/0129.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 129,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2016/0129.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0128-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2016/0129.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0141-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 1,
+              "value": "생년월일-0141-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2016/0129.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0154-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 1,
+              "value": "금액-0154-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 2,
+              "value": "금액-0154-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2016/0129.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0167-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 1,
+              "value": "대표자-0167-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 2,
+              "value": "대표자-0167-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 3,
+              "value": "대표자-0167-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0002.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0002.json
@@ -1,0 +1,15142 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000129",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/지침/2016/0130.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 130,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2016/0130.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0129-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0129-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-0129-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-0129-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2016/0130.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0142-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0142-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0142-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0142-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2016/0130.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0155-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2016/0130.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000130",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/지침/2016/0131.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 131,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2016/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0130-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0130-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2016/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0143-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2016/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2016/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000131",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/지침/2016/0132.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 132,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2016/0132.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2016/0132.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2016/0132.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2016/0132.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000132",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/지침/2016/0133.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 133,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2016/0133.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2016/0133.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2016/0133.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2016/0133.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000133",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/지침/2016/0134.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 134,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2016/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2016/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2016/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2016/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000134",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/지침/2016/0135.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 135,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2016/0135.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2016/0135.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2016/0135.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2016/0135.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0173-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0173-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0173-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0173-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000135",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/지침/2016/0136.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 136,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2016/0136.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2016/0136.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0148-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0148-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0148-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0148-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2016/0136.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0161-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0161-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0161-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0161-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2016/0136.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0174-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0174-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0174-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0174-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000136",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/지침/2016/0137.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 137,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2016/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0136-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0136-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0136-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0136-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2016/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0149-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0149-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0149-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0149-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2016/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0162-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0162-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0162-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0162-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2016/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0175-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0175-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0175-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0175-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000137",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/지침/2016/0138.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 138,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2016/0138.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0137-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0137-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0137-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0137-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2016/0138.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0150-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0150-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0150-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0150-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2016/0138.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0163-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0163-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0163-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0163-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2016/0138.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0176-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0176-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0176-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0176-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000138",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/지침/2016/0139.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 139,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2016/0139.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0138-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0138-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0138-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0138-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2016/0139.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0151-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0151-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0151-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0151-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2016/0139.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2016/0139.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000139",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/지침/2016/0140.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 140,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2016/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2016/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2016/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2016/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000140",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/지침/2016/0141.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 141,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2016/0141.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2016/0141.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2016/0141.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2016/0141.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000141",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 142,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2016/0142.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000142",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 143,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0181-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 1,
+              "value": "생년월일-0181-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 2,
+              "value": "생년월일-0181-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 3,
+              "value": "생년월일-0181-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2016/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0194-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000143",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 144,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0156-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0156-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0156-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0156-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0169-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0169-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0182-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0182-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0182-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2016/0144.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0195-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0195-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 1,
+              "value": "계좌번호-0195-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0195-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000144",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 145,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0144-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0144-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0144-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0157-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0157-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0157-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0157-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0170-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0170-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0170-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-0170-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0183-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0183-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0183-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0183-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2016/0145.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0196-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0196-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000145",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/지침/2016/0146.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 146,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2016/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0145-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0145-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0145-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0145-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2016/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0158-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0158-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0158-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0158-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2016/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0171-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0171-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0171-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2016/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0184-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0184-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2016/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000146",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/지침/2016/0147.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 147,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2016/0147.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0146-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0146-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0146-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0146-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2016/0147.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0159-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0159-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0159-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2016/0147.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2016/0147.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2016/0147.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000147",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/지침/2016/0148.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 148,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2016/0148.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2016/0148.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2016/0148.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2016/0148.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2016/0148.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000148",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/지침/2016/0149.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 149,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2016/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2016/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2016/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2016/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2016/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000149",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/지침/2016/0150.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 150,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2016/0150.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2016/0150.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2016/0150.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2016/0150.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2016/0150.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000150",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/지침/2016/0151.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 151,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2016/0151.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2016/0151.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2016/0151.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2016/0151.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0189-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0189-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0189-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0189-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2016/0151.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0202-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0202-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0202-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0202-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000151",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 152,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0164-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0164-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0164-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0164-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0177-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0177-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0177-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0177-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0190-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0190-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0190-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0190-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2016/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0203-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0203-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0203-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0203-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000152",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/지침/2016/0153.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 153,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2016/0153.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0152-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0152-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0152-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0152-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2016/0153.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0165-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0165-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0165-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0165-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2016/0153.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0178-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0178-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0178-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0178-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2016/0153.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0191-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0191-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0191-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0191-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2016/0153.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0204-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0204-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0204-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0204-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000153",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/지침/2016/0154.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 154,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2016/0154.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0153-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0153-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0153-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0153-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2016/0154.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0166-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0166-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0166-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0166-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2016/0154.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0179-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0179-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0179-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0179-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2016/0154.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0192-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0192-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0192-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0192-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2016/0154.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000154",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 155,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0154-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0154-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0154-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0154-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0167-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0167-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0167-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0167-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2016/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000155",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 156,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2016/0156.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000156",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 157,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2016/0157.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000157",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 158,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2016/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0222-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0222-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0222-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0222-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000158",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/지침/2016/0159.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 159,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0197-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0197-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0197-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0197-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0210-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0210-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0210-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2016/0159.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0223-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0223-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0223-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0223-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000159",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/지침/2016/0160.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "지침",
+    "year": 2016,
+    "serial": 160,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0172-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0172-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0172-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0172-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0185-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0185-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0185-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0185-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0198-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0198-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0198-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0198-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0211-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0211-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0211-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0211-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2016/0160.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0224-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0224-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0224-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0224-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000160",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/서식/2016/0161.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 161,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0160-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0160-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0160-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0160-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0173-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0173-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0173-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0173-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0186-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0186-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0186-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0186-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0199-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0199-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0199-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0199-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0212-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0212-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0212-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0212-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2016/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0225-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0225-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0225-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000161",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 162,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0161-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0161-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0161-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0161-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0174-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0174-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0174-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0174-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0187-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0187-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0187-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0187-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0200-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0200-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0200-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0200-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2016/0162.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000162",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/서식/2016/0163.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 163,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0162-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0162-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0162-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0162-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0175-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0175-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0175-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0175-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2016/0163.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000163",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/서식/2016/0164.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 164,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2016/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000164",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/서식/2016/0165.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 165,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2016/0165.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000165",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/서식/2016/0166.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 166,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2016/0166.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0230-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0230-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0230-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0230-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000166",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 167,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0205-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0205-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0205-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0205-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0218-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0218-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0218-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0218-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2016/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0231-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0231-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0231-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0231-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000167",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 168,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0180-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0180-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0180-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0180-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0193-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0193-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0193-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0193-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0206-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0206-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0206-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0206-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0219-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0219-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0219-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0219-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2016/0168.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0232-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0232-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0232-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0232-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000168",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/서식/2016/0169.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 169,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0168-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0168-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0168-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0168-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0181-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0181-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0181-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0181-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0194-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0194-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0194-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0194-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0207-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0207-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0207-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0207-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0220-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0220-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0220-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0220-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2016/0169.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0233-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0233-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0233-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0233-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000169",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/서식/2016/0170.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 170,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0169-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-0169-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0182-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-0182-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 2,
+              "value": "주소-0182-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 3,
+              "value": "주소-0182-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2016/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000170",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 171,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2016/0171.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000171",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 172,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2016/0172.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000172",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 173,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2016/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000173",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 174,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0238-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0238-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0238-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0238-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2016/0174.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0251-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0251-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0251-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0251-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000174",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 175,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0213-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0213-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0213-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0213-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0226-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0226-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0226-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0226-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0239-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0239-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0239-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0239-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2016/0175.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0252-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0252-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0252-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0252-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000175",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 176,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0188-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0188-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0188-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0188-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0201-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0201-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0201-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0201-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0214-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0214-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0214-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0214-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0227-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0227-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0227-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0227-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0240-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0240-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0240-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0240-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2016/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0253-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0253-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0253-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0253-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000176",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 177,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0176-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0176-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0176-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0176-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0189-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0189-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0189-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0189-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0202-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0202-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0202-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0202-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0215-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0215-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0215-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0215-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0228-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0228-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0228-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0228-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0241-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0241-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0241-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0241-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2016/0177.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000177",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/서식/2016/0178.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 178,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0177-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0177-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0177-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0177-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0190-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0190-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0190-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0190-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0203-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0203-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0203-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0203-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0216-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0216-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0216-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0216-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2016/0178.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000178",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/서식/2016/0179.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 179,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0178-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0178-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0178-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0178-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0191-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0191-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0191-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0191-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2016/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000179",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/서식/2016/0180.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 180,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2016/0180.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000180",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/서식/2016/0181.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 181,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2016/0181.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000181",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/서식/2016/0182.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 182,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0246-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0246-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0246-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0246-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2016/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0259-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0259-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0259-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0259-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000182",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/서식/2016/0183.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 183,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 27,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0221-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0221-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0221-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0221-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0234-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0234-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0234-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0234-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0247-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0247-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0247-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0247-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2016/0183.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0260-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0260-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0260-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0260-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000183",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 184,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0196-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-0196-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 2,
+              "value": "주민등록번호-0196-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 3,
+              "value": "주민등록번호-0196-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0222-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0235-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 1,
+              "value": "계좌번호-0235-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0248-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 1,
+              "value": "담당부서-0248-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 2,
+              "value": "담당부서-0248-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 3,
+              "value": "담당부서-0248-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2016/0184.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000184",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/서식/2016/0185.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 185,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0184-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0197-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-0197-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0210-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-0210-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 2,
+              "value": "문서번호-0210-02"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0223-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-0223-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 2,
+              "value": "연락처-0223-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 3,
+              "value": "연락처-0223-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2016/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000185",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/서식/2016/0186.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 186,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0185-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0185-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 1,
+              "value": "사업자등록번호-0185-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 1,
+              "value": "법인명-0185-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0198-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0198-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-0198-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 1,
+              "value": "처리기한-0198-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0211-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2016/0186.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000186",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 187,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0186-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0186-01"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0199-00"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2016/0187.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000187",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 188,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2016/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시설위치"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000188",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 189,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2016/0189.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0279-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0279-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0279-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0279-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000189",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 190,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0254-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0254-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0254-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0254-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0267-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0267-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0267-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0267-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2016/0190.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0280-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0280-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0280-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0280-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000190",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/서식/2016/0191.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 191,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0229-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0229-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0229-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0229-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0242-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0242-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0242-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0242-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0255-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0255-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0255-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0255-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0268-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0268-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0268-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0268-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2016/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0281-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0281-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0281-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0281-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000191",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "서식",
+    "year": 2016,
+    "serial": 192,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0204-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0204-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0204-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0204-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0217-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0217-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0217-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0217-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0230-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0230-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0230-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0230-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0243-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0243-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0243-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0243-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0256-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0256-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0256-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0256-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0269-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0269-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0269-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0269-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2016/0192.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0282-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-0282-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0282-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0282-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000192",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/질의회신/2016/0193.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 193,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0192-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0192-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0192-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0192-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0205-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0205-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0205-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0205-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0218-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0218-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0218-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0218-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-0231-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0231-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0231-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0231-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-0244-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-0244-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0244-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0244-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0257-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-0257-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0257-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0257-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2016/0193.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0003.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0003.json
@@ -1,0 +1,13535 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000193",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 194,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0193-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0193-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0193-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0193-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-0206-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0206-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0206-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0206-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-0219-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-0219-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-0219-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-0219-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-0232-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-0232-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0232-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0232-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2016/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000194",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 195,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-0194-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-0194-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-0194-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-0194-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0207-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0207-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0207-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0207-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2016/0195.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "사업자등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000195",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/질의회신/2016/0196.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 196,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2016/0196.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000196",
+    "command": "fill-fields",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 197,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주소"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "계좌번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2016/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 27,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-0287-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-0287-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-0287-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-0287-03"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000197",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/질의회신/2016/0198.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 198,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2016/0198.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/교육부/질의회신/2016/0198.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/질의회신/2016/0198.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2016/0198.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/교육부/질의회신/2016/0198.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-210-2-0",
+              "newText": "new-210-2-0-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-210-3-0",
+              "newText": "new-210-3-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/질의회신/2016/0198.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000198",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/질의회신/2016/0199.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 199,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2016/0199.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/질의회신/2016/0199.csv",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-198-7-0",
+              "newText": "new-198-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-198-8-0",
+              "newText": "new-198-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-198-9-0",
+              "newText": "new-198-9-0-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2016/0199.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2016/0199.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/질의회신/2016/0199.csv",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-211-8-3",
+              "newText": "new-211-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-211-9-2",
+              "newText": "new-211-9-2-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-211-10-1",
+              "newText": "new-211-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-211-11-0",
+              "newText": "new-211-11-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2016/0199.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000199",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/질의회신/2016/0200.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 200,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2016/0200.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국토교통부/질의회신/2016/0200.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2016/0200.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2016/0200.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국토교통부/질의회신/2016/0200.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2016/0200.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000200",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/질의회신/2016/0201.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 201,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2016/0201.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/고용노동부/질의회신/2016/0201.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-200-3-0",
+              "newText": "new-200-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-200-4-3",
+              "newText": "new-200-4-3-1"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-200-5-1",
+              "newText": "new-200-5-1-2"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-200-6-4",
+              "newText": "new-200-6-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2016/0201.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2016/0201.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/질의회신/2016/0201.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-213-4-3",
+              "newText": "new-213-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-213-5-0",
+              "newText": "new-213-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-213-6-3",
+              "newText": "new-213-6-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2016/0201.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000201",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/질의회신/2016/0202.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 202,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2016/0202.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/질의회신/2016/0202.csv",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-201-12-3",
+              "newText": "new-201-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-201-13-0",
+              "newText": "new-201-13-0-1"
+            },
+            {
+              "row": 14,
+              "col": 3,
+              "oldText": "old-201-14-3",
+              "newText": "new-201-14-3-2"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-201-15-0",
+              "newText": "new-201-15-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/질의회신/2016/0202.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2016/0202.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/질의회신/2016/0202.csv",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-214-5-4",
+              "newText": "new-214-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-214-6-0",
+              "newText": "new-214-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-214-7-3",
+              "newText": "new-214-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-214-8-6",
+              "newText": "new-214-8-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/질의회신/2016/0202.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000202",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/질의회신/2016/0203.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 203,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2016/0203.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기획재정부/질의회신/2016/0203.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2016/0203.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2016/0203.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/기획재정부/질의회신/2016/0203.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2016/0203.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000203",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/질의회신/2016/0204.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 204,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2016/0204.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/공정거래위원회/질의회신/2016/0204.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-203-15-3",
+              "newText": "new-203-15-3-0"
+            },
+            {
+              "row": 16,
+              "col": 6,
+              "oldText": "old-203-16-6",
+              "newText": "new-203-16-6-1"
+            },
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-203-17-1",
+              "newText": "new-203-17-1-2"
+            },
+            {
+              "row": 18,
+              "col": 4,
+              "oldText": "old-203-18-4",
+              "newText": "new-203-18-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2016/0204.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2016/0204.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/공정거래위원회/질의회신/2016/0204.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-216-13-0",
+              "newText": "new-216-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-216-14-0",
+              "newText": "new-216-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-216-15-0",
+              "newText": "new-216-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-216-16-0",
+              "newText": "new-216-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2016/0204.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000204",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/질의회신/2016/0205.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 205,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2016/0205.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/금융위원회/질의회신/2016/0205.csv",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-204-5-0",
+              "newText": "new-204-5-0-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-204-1-0",
+              "newText": "new-204-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-204-2-0",
+              "newText": "new-204-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-204-3-0",
+              "newText": "new-204-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2016/0205.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2016/0205.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/금융위원회/질의회신/2016/0205.csv",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-217-2-1",
+              "newText": "new-217-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-217-3-0",
+              "newText": "new-217-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-217-4-3",
+              "newText": "new-217-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-217-5-2",
+              "newText": "new-217-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2016/0205.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000205",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/질의회신/2016/0206.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 206,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2016/0206.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/질의회신/2016/0206.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-205-2-1",
+              "newText": "new-205-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-205-3-0",
+              "newText": "new-205-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-205-4-3",
+              "newText": "new-205-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-205-5-2",
+              "newText": "new-205-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2016/0206.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2016/0206.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/방송통신위원회/질의회신/2016/0206.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2016/0206.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000206",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/질의회신/2016/0207.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 207,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2016/0207.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2016/0207.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-206-4-1",
+              "newText": "new-206-4-1-0"
+            },
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-206-5-4",
+              "newText": "new-206-5-4-1"
+            },
+            {
+              "row": 6,
+              "col": 2,
+              "oldText": "old-206-6-2",
+              "newText": "new-206-6-2-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-206-7-0",
+              "newText": "new-206-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2016/0207.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2016/0207.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2016/0207.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2016/0207.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000207",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/질의회신/2016/0208.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 208,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2016/0208.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/질의회신/2016/0208.csv",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-207-8-3",
+              "newText": "new-207-8-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-207-1-0",
+              "newText": "new-207-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-207-2-3",
+              "newText": "new-207-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-207-3-0",
+              "newText": "new-207-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2016/0208.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2016/0208.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/질의회신/2016/0208.csv",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2016/0208.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000208",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/질의회신/2016/0209.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 209,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2016/0209.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/질의회신/2016/0209.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-208-2-5",
+              "newText": "new-208-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-208-3-1",
+              "newText": "new-208-3-1-1"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-208-4-4",
+              "newText": "new-208-4-4-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-208-5-0",
+              "newText": "new-208-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2016/0209.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2016/0209.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/질의회신/2016/0209.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-221-2-5",
+              "newText": "new-221-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-221-3-0",
+              "newText": "new-221-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-221-4-3",
+              "newText": "new-221-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-221-5-6",
+              "newText": "new-221-5-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2016/0209.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000209",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/질의회신/2016/0210.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 210,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2016/0210.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/통계청/질의회신/2016/0210.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/질의회신/2016/0210.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2016/0210.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/통계청/질의회신/2016/0210.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/질의회신/2016/0210.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000210",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/질의회신/2016/0211.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 211,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2016/0211.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/기상청/질의회신/2016/0211.csv",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-210-2-0",
+              "newText": "new-210-2-0-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-210-3-0",
+              "newText": "new-210-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-210-4-0",
+              "newText": "new-210-4-0-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-210-5-0",
+              "newText": "new-210-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/질의회신/2016/0211.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2016/0211.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/기상청/질의회신/2016/0211.csv",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-223-7-3",
+              "newText": "new-223-7-3-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-223-1-2",
+              "newText": "new-223-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-223-2-1",
+              "newText": "new-223-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-223-3-0",
+              "newText": "new-223-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/질의회신/2016/0211.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000211",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/질의회신/2016/0212.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 212,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2016/0212.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/질의회신/2016/0212.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-211-8-3",
+              "newText": "new-211-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-211-9-2",
+              "newText": "new-211-9-2-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/질의회신/2016/0212.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2016/0212.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/질의회신/2016/0212.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-224-1-4",
+              "newText": "new-224-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-224-2-2",
+              "newText": "new-224-2-2-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-224-3-0",
+              "newText": "new-224-3-0-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/질의회신/2016/0212.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2016/0212.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/질의회신/2016/0212.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-237-7-3",
+              "newText": "new-237-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-237-8-0",
+              "newText": "new-237-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-237-9-3",
+              "newText": "new-237-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-237-10-0",
+              "newText": "new-237-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/질의회신/2016/0212.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000212",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/질의회신/2016/0213.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 213,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2016/0213.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/질의회신/2016/0213.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2016/0213.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2016/0213.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/질의회신/2016/0213.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2016/0213.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2016/0213.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/질의회신/2016/0213.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2016/0213.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000213",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/질의회신/2016/0214.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 214,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2016/0214.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/경찰청/질의회신/2016/0214.csv",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-213-4-3",
+              "newText": "new-213-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-213-5-0",
+              "newText": "new-213-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-213-6-3",
+              "newText": "new-213-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-213-7-0",
+              "newText": "new-213-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2016/0214.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2016/0214.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/경찰청/질의회신/2016/0214.csv",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-226-7-2",
+              "newText": "new-226-7-2-0"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-226-8-5",
+              "newText": "new-226-8-5-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2016/0214.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2016/0214.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/경찰청/질의회신/2016/0214.csv",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-239-6-7",
+              "newText": "new-239-6-7-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-239-1-2",
+              "newText": "new-239-1-2-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2016/0214.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000214",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/질의회신/2016/0215.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 215,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2016/0215.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/질의회신/2016/0215.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-214-5-4",
+              "newText": "new-214-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-214-6-0",
+              "newText": "new-214-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-214-7-3",
+              "newText": "new-214-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-214-8-6",
+              "newText": "new-214-8-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/질의회신/2016/0215.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2016/0215.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/질의회신/2016/0215.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-227-8-3",
+              "newText": "new-227-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-227-9-6",
+              "newText": "new-227-9-6-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-227-10-1",
+              "newText": "new-227-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 4,
+              "oldText": "old-227-11-4",
+              "newText": "new-227-11-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/질의회신/2016/0215.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2016/0215.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/질의회신/2016/0215.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-240-3-0",
+              "newText": "new-240-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-240-4-0",
+              "newText": "new-240-4-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/질의회신/2016/0215.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000215",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/질의회신/2016/0216.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 216,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2016/0216.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양경찰청/질의회신/2016/0216.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2016/0216.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2016/0216.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/해양경찰청/질의회신/2016/0216.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2016/0216.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2016/0216.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/질의회신/2016/0216.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-241-2-1",
+              "newText": "new-241-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-241-3-0",
+              "newText": "new-241-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-241-4-3",
+              "newText": "new-241-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-241-5-2",
+              "newText": "new-241-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2016/0216.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000216",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/질의회신/2016/0217.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 217,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2016/0217.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/병무청/질의회신/2016/0217.csv",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-216-13-0",
+              "newText": "new-216-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-216-14-0",
+              "newText": "new-216-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-216-15-0",
+              "newText": "new-216-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-216-16-0",
+              "newText": "new-216-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/질의회신/2016/0217.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2016/0217.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/병무청/질의회신/2016/0217.csv",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-229-9-1",
+              "newText": "new-229-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-229-10-0",
+              "newText": "new-229-10-0-1"
+            },
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-229-11-3",
+              "newText": "new-229-11-3-2"
+            },
+            {
+              "row": 12,
+              "col": 2,
+              "oldText": "old-229-12-2",
+              "newText": "new-229-12-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/질의회신/2016/0217.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2016/0217.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/병무청/질의회신/2016/0217.csv",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-242-9-2",
+              "newText": "new-242-9-2-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-242-1-0",
+              "newText": "new-242-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-242-2-3",
+              "newText": "new-242-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-242-3-1",
+              "newText": "new-242-3-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/질의회신/2016/0217.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000217",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/질의회신/2016/0218.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 218,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2016/0218.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/질의회신/2016/0218.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-217-2-1",
+              "newText": "new-217-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-217-3-0",
+              "newText": "new-217-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-217-4-3",
+              "newText": "new-217-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-217-5-2",
+              "newText": "new-217-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/질의회신/2016/0218.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2016/0218.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/질의회신/2016/0218.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-230-7-0",
+              "newText": "new-230-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-230-8-3",
+              "newText": "new-230-8-3-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-230-9-1",
+              "newText": "new-230-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-230-10-4",
+              "newText": "new-230-10-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/질의회신/2016/0218.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2016/0218.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/질의회신/2016/0218.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-243-4-3",
+              "newText": "new-243-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-243-5-0",
+              "newText": "new-243-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-243-6-3",
+              "newText": "new-243-6-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/질의회신/2016/0218.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000218",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/질의회신/2016/0219.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 219,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2016/0219.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/질의회신/2016/0219.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-218-10-3",
+              "newText": "new-218-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-218-11-1",
+              "newText": "new-218-11-1-1"
+            },
+            {
+              "row": 12,
+              "col": 4,
+              "oldText": "old-218-12-4",
+              "newText": "new-218-12-4-2"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-218-13-2",
+              "newText": "new-218-13-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2016/0219.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2016/0219.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/농촌진흥청/질의회신/2016/0219.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2016/0219.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2016/0219.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/질의회신/2016/0219.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 3,
+              "col": 6,
+              "oldText": "old-244-3-6",
+              "newText": "new-244-3-6-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-244-4-2",
+              "newText": "new-244-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-244-5-5",
+              "newText": "new-244-5-5-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-244-6-1",
+              "newText": "new-244-6-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2016/0219.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000219",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/질의회신/2016/0220.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 220,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2016/0220.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2016/0220.csv",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 20,
+              "col": 3,
+              "oldText": "old-219-20-3",
+              "newText": "new-219-20-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-219-1-0",
+              "newText": "new-219-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-219-2-3",
+              "newText": "new-219-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-219-3-0",
+              "newText": "new-219-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2016/0220.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2016/0220.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2016/0220.csv",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2016/0220.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2016/0220.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2016/0220.csv",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2016/0220.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000220",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/질의회신/2016/0221.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 221,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2016/0221.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2016/0221.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-220-11-3",
+              "newText": "new-220-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-220-12-6",
+              "newText": "new-220-12-6-1"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-220-13-2",
+              "newText": "new-220-13-2-2"
+            },
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-220-14-5",
+              "newText": "new-220-14-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2016/0221.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2016/0221.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2016/0221.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2016/0221.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2016/0221.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2016/0221.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-246-13-0",
+              "newText": "new-246-13-0-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-246-1-0",
+              "newText": "new-246-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-246-2-0",
+              "newText": "new-246-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-246-3-0",
+              "newText": "new-246-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2016/0221.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000221",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/질의회신/2016/0222.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 222,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2016/0222.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/질의회신/2016/0222.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-221-2-5",
+              "newText": "new-221-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-221-3-0",
+              "newText": "new-221-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-221-4-3",
+              "newText": "new-221-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-221-5-6",
+              "newText": "new-221-5-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/질의회신/2016/0222.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2016/0222.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/질의회신/2016/0222.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-234-1-0",
+              "newText": "new-234-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-234-2-0",
+              "newText": "new-234-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-234-3-0",
+              "newText": "new-234-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-234-4-0",
+              "newText": "new-234-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/질의회신/2016/0222.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2016/0222.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/질의회신/2016/0222.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-247-10-3",
+              "newText": "new-247-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-247-11-2",
+              "newText": "new-247-11-2-1"
+            },
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-247-12-1",
+              "newText": "new-247-12-1-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-247-13-0",
+              "newText": "new-247-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/질의회신/2016/0222.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000222",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/질의회신/2016/0223.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 223,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2016/0223.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/질의회신/2016/0223.csv",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/질의회신/2016/0223.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2016/0223.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/질의회신/2016/0223.csv",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/질의회신/2016/0223.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2016/0223.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/질의회신/2016/0223.csv",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/질의회신/2016/0223.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000223",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/질의회신/2016/0224.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "질의회신",
+    "year": 2016,
+    "serial": 224,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2016/0224.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양수산부/질의회신/2016/0224.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-223-7-3",
+              "newText": "new-223-7-3-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-223-1-2",
+              "newText": "new-223-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-223-2-1",
+              "newText": "new-223-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-223-3-0",
+              "newText": "new-223-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/질의회신/2016/0224.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2016/0224.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양수산부/질의회신/2016/0224.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-236-17-1",
+              "newText": "new-236-17-1-0"
+            },
+            {
+              "row": 18,
+              "col": 4,
+              "oldText": "old-236-18-4",
+              "newText": "new-236-18-4-1"
+            },
+            {
+              "row": 19,
+              "col": 2,
+              "oldText": "old-236-19-2",
+              "newText": "new-236-19-2-2"
+            },
+            {
+              "row": 20,
+              "col": 0,
+              "oldText": "old-236-20-0",
+              "newText": "new-236-20-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/질의회신/2016/0224.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2016/0224.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양수산부/질의회신/2016/0224.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-249-10-3",
+              "newText": "new-249-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-249-11-0",
+              "newText": "new-249-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-249-12-3",
+              "newText": "new-249-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-249-13-0",
+              "newText": "new-249-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/질의회신/2016/0224.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000224",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/업무계획/2016/0225.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 225,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2016/0225.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/업무계획/2016/0225.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-224-1-4",
+              "newText": "new-224-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-224-2-2",
+              "newText": "new-224-2-2-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-224-3-0",
+              "newText": "new-224-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-224-4-3",
+              "newText": "new-224-4-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/업무계획/2016/0225.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2016/0225.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/업무계획/2016/0225.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-237-7-3",
+              "newText": "new-237-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-237-8-0",
+              "newText": "new-237-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-237-9-3",
+              "newText": "new-237-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-237-10-0",
+              "newText": "new-237-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/업무계획/2016/0225.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2016/0225.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/업무계획/2016/0225.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-250-13-5",
+              "newText": "new-250-13-5-0"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-250-14-1",
+              "newText": "new-250-14-1-1"
+            },
+            {
+              "row": 15,
+              "col": 4,
+              "oldText": "old-250-15-4",
+              "newText": "new-250-15-4-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-250-16-0",
+              "newText": "new-250-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/업무계획/2016/0225.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000225",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/업무계획/2016/0226.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 226,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2016/0226.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/업무계획/2016/0226.csv",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/업무계획/2016/0226.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2016/0226.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/업무계획/2016/0226.csv",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/업무계획/2016/0226.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2016/0226.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/업무계획/2016/0226.csv",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/업무계획/2016/0226.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2016/0226.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/업무계획/2016/0226.csv",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/업무계획/2016/0226.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000226",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/업무계획/2016/0227.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 227,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2016/0227.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국세청/업무계획/2016/0227.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-226-7-2",
+              "newText": "new-226-7-2-0"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-226-8-5",
+              "newText": "new-226-8-5-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-226-9-1",
+              "newText": "new-226-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-226-10-4",
+              "newText": "new-226-10-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/업무계획/2016/0227.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2016/0227.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/업무계획/2016/0227.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-239-6-7",
+              "newText": "new-239-6-7-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/업무계획/2016/0227.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2016/0227.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국세청/업무계획/2016/0227.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-252-6-0",
+              "newText": "new-252-6-0-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/업무계획/2016/0227.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2016/0227.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국세청/업무계획/2016/0227.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-265-11-1",
+              "newText": "new-265-11-1-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/업무계획/2016/0227.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000227",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/업무계획/2016/0228.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 228,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2016/0228.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/업무계획/2016/0228.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-227-8-3",
+              "newText": "new-227-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-227-9-6",
+              "newText": "new-227-9-6-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-227-10-1",
+              "newText": "new-227-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 4,
+              "oldText": "old-227-11-4",
+              "newText": "new-227-11-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/업무계획/2016/0228.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2016/0228.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/업무계획/2016/0228.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-240-3-0",
+              "newText": "new-240-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-240-4-0",
+              "newText": "new-240-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-240-5-0",
+              "newText": "new-240-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-240-6-0",
+              "newText": "new-240-6-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/업무계획/2016/0228.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2016/0228.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/업무계획/2016/0228.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-253-14-1",
+              "newText": "new-253-14-1-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/업무계획/2016/0228.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2016/0228.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/업무계획/2016/0228.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/업무계획/2016/0228.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000228",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/업무계획/2016/0229.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 229,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2016/0229.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/업무계획/2016/0229.csv",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/업무계획/2016/0229.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2016/0229.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/업무계획/2016/0229.csv",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/업무계획/2016/0229.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2016/0229.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/업무계획/2016/0229.csv",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-254-3-4",
+              "newText": "new-254-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-254-4-2",
+              "newText": "new-254-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-254-5-0",
+              "newText": "new-254-5-0-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/업무계획/2016/0229.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2016/0229.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/특허청/업무계획/2016/0229.csv",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/업무계획/2016/0229.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000229",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/업무계획/2016/0230.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 230,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2016/0230.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/교육부/업무계획/2016/0230.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-229-9-1",
+              "newText": "new-229-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-229-10-0",
+              "newText": "new-229-10-0-1"
+            },
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-229-11-3",
+              "newText": "new-229-11-3-2"
+            },
+            {
+              "row": 12,
+              "col": 2,
+              "oldText": "old-229-12-2",
+              "newText": "new-229-12-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/업무계획/2016/0230.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2016/0230.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/교육부/업무계획/2016/0230.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-242-9-2",
+              "newText": "new-242-9-2-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-242-1-0",
+              "newText": "new-242-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-242-2-3",
+              "newText": "new-242-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-242-3-1",
+              "newText": "new-242-3-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/업무계획/2016/0230.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2016/0230.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/교육부/업무계획/2016/0230.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-255-1-3",
+              "newText": "new-255-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-255-2-0",
+              "newText": "new-255-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-255-3-3",
+              "newText": "new-255-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-255-4-0",
+              "newText": "new-255-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/업무계획/2016/0230.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2016/0230.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/교육부/업무계획/2016/0230.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/업무계획/2016/0230.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000230",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/업무계획/2016/0231.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 231,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2016/0231.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/업무계획/2016/0231.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-230-7-0",
+              "newText": "new-230-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-230-8-3",
+              "newText": "new-230-8-3-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-230-9-1",
+              "newText": "new-230-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-230-10-4",
+              "newText": "new-230-10-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/업무계획/2016/0231.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2016/0231.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/업무계획/2016/0231.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-243-4-3",
+              "newText": "new-243-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-243-5-0",
+              "newText": "new-243-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-243-6-3",
+              "newText": "new-243-6-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/업무계획/2016/0231.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2016/0231.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/업무계획/2016/0231.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-256-5-4",
+              "newText": "new-256-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-256-6-0",
+              "newText": "new-256-6-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/업무계획/2016/0231.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2016/0231.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/업무계획/2016/0231.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/업무계획/2016/0231.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000231",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/업무계획/2016/0232.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 232,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2016/0232.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/업무계획/2016/0232.csv",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-231-7-3",
+              "newText": "new-231-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-231-8-0",
+              "newText": "new-231-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-231-9-3",
+              "newText": "new-231-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-231-10-0",
+              "newText": "new-231-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/업무계획/2016/0232.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2016/0232.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국토교통부/업무계획/2016/0232.csv",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/업무계획/2016/0232.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2016/0232.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/업무계획/2016/0232.csv",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-257-6-1",
+              "newText": "new-257-6-1-0"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-257-7-4",
+              "newText": "new-257-7-4-1"
+            },
+            {
+              "row": 1,
+              "col": 7,
+              "oldText": "old-257-1-7",
+              "newText": "new-257-1-7-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-257-2-2",
+              "newText": "new-257-2-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/업무계획/2016/0232.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2016/0232.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/업무계획/2016/0232.csv",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-270-11-0",
+              "newText": "new-270-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-270-12-0",
+              "newText": "new-270-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-270-13-0",
+              "newText": "new-270-13-0-2"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-270-14-0",
+              "newText": "new-270-14-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/업무계획/2016/0232.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000232",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/업무계획/2016/0233.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 233,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2016/0233.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/고용노동부/업무계획/2016/0233.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-232-9-1",
+              "newText": "new-232-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-232-10-4",
+              "newText": "new-232-10-4-1"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-232-11-0",
+              "newText": "new-232-11-0-2"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-232-12-3",
+              "newText": "new-232-12-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/업무계획/2016/0233.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2016/0233.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/고용노동부/업무계획/2016/0233.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/업무계획/2016/0233.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2016/0233.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/업무계획/2016/0233.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/업무계획/2016/0233.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2016/0233.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/업무계획/2016/0233.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/업무계획/2016/0233.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000233",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/업무계획/2016/0234.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 234,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2016/0234.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/업무계획/2016/0234.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-233-13-1",
+              "newText": "new-233-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 4,
+              "oldText": "old-233-14-4",
+              "newText": "new-233-14-4-1"
+            },
+            {
+              "row": 15,
+              "col": 7,
+              "oldText": "old-233-15-7",
+              "newText": "new-233-15-7-2"
+            },
+            {
+              "row": 16,
+              "col": 2,
+              "oldText": "old-233-16-2",
+              "newText": "new-233-16-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/업무계획/2016/0234.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2016/0234.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/업무계획/2016/0234.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/업무계획/2016/0234.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2016/0234.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/외교부/업무계획/2016/0234.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-259-8-3",
+              "newText": "new-259-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-259-9-2",
+              "newText": "new-259-9-2-1"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-259-1-1",
+              "newText": "new-259-1-1-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-259-2-0",
+              "newText": "new-259-2-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/업무계획/2016/0234.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2016/0234.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/외교부/업무계획/2016/0234.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-272-3-2",
+              "newText": "new-272-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-272-4-0",
+              "newText": "new-272-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-272-5-3",
+              "newText": "new-272-5-3-2"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-272-1-1",
+              "newText": "new-272-1-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/업무계획/2016/0234.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000234",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/업무계획/2016/0235.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 235,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2016/0235.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/업무계획/2016/0235.csv",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-234-1-0",
+              "newText": "new-234-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-234-2-0",
+              "newText": "new-234-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-234-3-0",
+              "newText": "new-234-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-234-4-0",
+              "newText": "new-234-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/업무계획/2016/0235.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2016/0235.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/업무계획/2016/0235.csv",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-247-10-3",
+              "newText": "new-247-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-247-11-2",
+              "newText": "new-247-11-2-1"
+            },
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-247-12-1",
+              "newText": "new-247-12-1-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-247-13-0",
+              "newText": "new-247-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/업무계획/2016/0235.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2016/0235.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/업무계획/2016/0235.csv",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-260-1-0",
+              "newText": "new-260-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-260-2-3",
+              "newText": "new-260-2-3-1"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-260-3-1",
+              "newText": "new-260-3-1-2"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-260-4-4",
+              "newText": "new-260-4-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/업무계획/2016/0235.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2016/0235.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/업무계획/2016/0235.csv",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-273-4-3",
+              "newText": "new-273-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-273-5-0",
+              "newText": "new-273-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-273-6-3",
+              "newText": "new-273-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-273-1-0",
+              "newText": "new-273-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/업무계획/2016/0235.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000235",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/업무계획/2016/0236.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 236,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2016/0236.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/업무계획/2016/0236.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/업무계획/2016/0236.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2016/0236.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/업무계획/2016/0236.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/업무계획/2016/0236.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2016/0236.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/업무계획/2016/0236.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/업무계획/2016/0236.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2016/0236.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/업무계획/2016/0236.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/업무계획/2016/0236.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000236",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/업무계획/2016/0237.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 237,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2016/0237.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/금융위원회/업무계획/2016/0237.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-236-17-1",
+              "newText": "new-236-17-1-0"
+            },
+            {
+              "row": 18,
+              "col": 4,
+              "oldText": "old-236-18-4",
+              "newText": "new-236-18-4-1"
+            },
+            {
+              "row": 19,
+              "col": 2,
+              "oldText": "old-236-19-2",
+              "newText": "new-236-19-2-2"
+            },
+            {
+              "row": 20,
+              "col": 0,
+              "oldText": "old-236-20-0",
+              "newText": "new-236-20-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/업무계획/2016/0237.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2016/0237.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/금융위원회/업무계획/2016/0237.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-249-10-3",
+              "newText": "new-249-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-249-11-0",
+              "newText": "new-249-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-249-12-3",
+              "newText": "new-249-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-249-13-0",
+              "newText": "new-249-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/업무계획/2016/0237.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2016/0237.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/금융위원회/업무계획/2016/0237.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-262-11-3",
+              "newText": "new-262-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-262-12-6",
+              "newText": "new-262-12-6-1"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-262-1-2",
+              "newText": "new-262-1-2-2"
+            },
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-262-2-5",
+              "newText": "new-262-2-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/업무계획/2016/0237.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2016/0237.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/금융위원회/업무계획/2016/0237.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-275-4-3",
+              "newText": "new-275-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-275-5-6",
+              "newText": "new-275-5-6-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-275-6-1",
+              "newText": "new-275-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-275-7-4",
+              "newText": "new-275-7-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/업무계획/2016/0237.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000237",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/업무계획/2016/0238.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 238,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2016/0238.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/업무계획/2016/0238.csv",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-237-7-3",
+              "newText": "new-237-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-237-8-0",
+              "newText": "new-237-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-237-9-3",
+              "newText": "new-237-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-237-10-0",
+              "newText": "new-237-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/업무계획/2016/0238.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2016/0238.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/업무계획/2016/0238.csv",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-250-13-5",
+              "newText": "new-250-13-5-0"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-250-14-1",
+              "newText": "new-250-14-1-1"
+            },
+            {
+              "row": 15,
+              "col": 4,
+              "oldText": "old-250-15-4",
+              "newText": "new-250-15-4-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-250-16-0",
+              "newText": "new-250-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/업무계획/2016/0238.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2016/0238.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/업무계획/2016/0238.csv",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-263-4-7",
+              "newText": "new-263-4-7-0"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-263-5-2",
+              "newText": "new-263-5-2-1"
+            },
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-263-6-5",
+              "newText": "new-263-6-5-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-263-7-0",
+              "newText": "new-263-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/업무계획/2016/0238.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2016/0238.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/업무계획/2016/0238.csv",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-276-7-0",
+              "newText": "new-276-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-276-8-0",
+              "newText": "new-276-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-276-9-0",
+              "newText": "new-276-9-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-276-1-0",
+              "newText": "new-276-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/업무계획/2016/0238.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000238",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/업무계획/2016/0239.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 239,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2016/0239.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/업무계획/2016/0239.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2016/0239.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2016/0239.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/업무계획/2016/0239.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2016/0239.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2016/0239.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/업무계획/2016/0239.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2016/0239.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2016/0239.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/업무계획/2016/0239.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2016/0239.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000239",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 240,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국민권익위원회/업무계획/2016/0240.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-239-6-7",
+              "newText": "new-239-6-7-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-239-1-2",
+              "newText": "new-239-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-239-2-5",
+              "newText": "new-239-2-5-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-239-3-0",
+              "newText": "new-239-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/업무계획/2016/0240.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/업무계획/2016/0240.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/업무계획/2016/0240.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국민권익위원회/업무계획/2016/0240.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/업무계획/2016/0240.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/업무계획/2016/0240.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/업무계획/2016/0240.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2016/0240.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/업무계획/2016/0240.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-291-5-3",
+              "newText": "new-291-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-291-6-0",
+              "newText": "new-291-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-291-7-3",
+              "newText": "new-291-7-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/업무계획/2016/0240.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000240",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 241,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/업무계획/2016/0241.csv",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-240-3-0",
+              "newText": "new-240-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-240-4-0",
+              "newText": "new-240-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-240-5-0",
+              "newText": "new-240-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-240-6-0",
+              "newText": "new-240-6-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/업무계획/2016/0241.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/업무계획/2016/0241.csv",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-253-14-1",
+              "newText": "new-253-14-1-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-253-15-0",
+              "newText": "new-253-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-253-16-3",
+              "newText": "new-253-16-3-2"
+            },
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-253-17-2",
+              "newText": "new-253-17-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/업무계획/2016/0241.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/업무계획/2016/0241.csv",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/업무계획/2016/0241.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/업무계획/2016/0241.csv",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/업무계획/2016/0241.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2016/0241.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/업무계획/2016/0241.csv",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/업무계획/2016/0241.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000241",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 242,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/통계청/업무계획/2016/0242.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/업무계획/2016/0242.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/통계청/업무계획/2016/0242.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/업무계획/2016/0242.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/업무계획/2016/0242.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-267-13-3",
+              "newText": "new-267-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-267-14-0",
+              "newText": "new-267-14-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/업무계획/2016/0242.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/통계청/업무계획/2016/0242.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/업무계획/2016/0242.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2016/0242.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/업무계획/2016/0242.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-293-6-5",
+              "newText": "new-293-6-5-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-293-7-0",
+              "newText": "new-293-7-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/업무계획/2016/0242.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000242",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 243,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/기상청/업무계획/2016/0243.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-242-9-2",
+              "newText": "new-242-9-2-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-242-1-0",
+              "newText": "new-242-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-242-2-3",
+              "newText": "new-242-2-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/업무계획/2016/0243.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/기상청/업무계획/2016/0243.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-255-1-3",
+              "newText": "new-255-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-255-2-0",
+              "newText": "new-255-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-255-3-3",
+              "newText": "new-255-3-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/업무계획/2016/0243.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/기상청/업무계획/2016/0243.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-268-17-2",
+              "newText": "new-268-17-2-0"
+            },
+            {
+              "row": 18,
+              "col": 5,
+              "oldText": "old-268-18-5",
+              "newText": "new-268-18-5-1"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-268-1-1",
+              "newText": "new-268-1-1-2"
+            },
+            {
+              "row": 2,
+              "col": 4,
+              "oldText": "old-268-2-4",
+              "newText": "new-268-2-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/업무계획/2016/0243.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/기상청/업무계획/2016/0243.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/업무계획/2016/0243.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2016/0243.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/업무계획/2016/0243.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/업무계획/2016/0243.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000243",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/업무계획/2016/0244.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 244,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2016/0244.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/업무계획/2016/0244.csv",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-243-4-3",
+              "newText": "new-243-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-243-5-0",
+              "newText": "new-243-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-243-6-3",
+              "newText": "new-243-6-3-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/업무계획/2016/0244.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2016/0244.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/업무계획/2016/0244.csv",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-256-5-4",
+              "newText": "new-256-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-256-6-0",
+              "newText": "new-256-6-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/업무계획/2016/0244.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2016/0244.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/업무계획/2016/0244.csv",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-269-4-5",
+              "newText": "new-269-4-5-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/업무계획/2016/0244.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2016/0244.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/업무계획/2016/0244.csv",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/업무계획/2016/0244.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2016/0244.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/관세청/업무계획/2016/0244.csv",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-295-10-3",
+              "newText": "new-295-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-295-11-2",
+              "newText": "new-295-11-2-1"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-295-1-1",
+              "newText": "new-295-1-1-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-295-2-0",
+              "newText": "new-295-2-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/업무계획/2016/0244.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000244",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 245,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/업무계획/2016/0245.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 3,
+              "col": 6,
+              "oldText": "old-244-3-6",
+              "newText": "new-244-3-6-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-244-4-2",
+              "newText": "new-244-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-244-5-5",
+              "newText": "new-244-5-5-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-244-6-1",
+              "newText": "new-244-6-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/업무계획/2016/0245.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/검찰청/업무계획/2016/0245.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/업무계획/2016/0245.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/업무계획/2016/0245.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-270-11-0",
+              "newText": "new-270-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-270-12-0",
+              "newText": "new-270-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-270-13-0",
+              "newText": "new-270-13-0-2"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-270-14-0",
+              "newText": "new-270-14-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/업무계획/2016/0245.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/업무계획/2016/0245.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-283-12-3",
+              "newText": "new-283-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-283-13-2",
+              "newText": "new-283-13-2-1"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-283-14-1",
+              "newText": "new-283-14-1-2"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-283-15-0",
+              "newText": "new-283-15-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/업무계획/2016/0245.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2016/0245.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/업무계획/2016/0245.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-296-9-1",
+              "newText": "new-296-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-296-10-4",
+              "newText": "new-296-10-4-1"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-296-11-2",
+              "newText": "new-296-11-2-2"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-296-12-0",
+              "newText": "new-296-12-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/업무계획/2016/0245.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000245",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 246,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/경찰청/업무계획/2016/0246.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-245-6-5",
+              "newText": "new-245-6-5-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-245-7-0",
+              "newText": "new-245-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-245-8-3",
+              "newText": "new-245-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-245-9-6",
+              "newText": "new-245-9-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/업무계획/2016/0246.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/경찰청/업무계획/2016/0246.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/업무계획/2016/0246.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/업무계획/2016/0246.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/업무계획/2016/0246.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/업무계획/2016/0246.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/업무계획/2016/0246.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2016/0246.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/업무계획/2016/0246.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/업무계획/2016/0246.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000246",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/업무계획/2016/0247.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 247,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2016/0247.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/업무계획/2016/0247.csv",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-246-13-0",
+              "newText": "new-246-13-0-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-246-1-0",
+              "newText": "new-246-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-246-2-0",
+              "newText": "new-246-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-246-3-0",
+              "newText": "new-246-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/업무계획/2016/0247.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2016/0247.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/업무계획/2016/0247.csv",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/업무계획/2016/0247.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2016/0247.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/소방청/업무계획/2016/0247.csv",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-272-3-2",
+              "newText": "new-272-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-272-4-0",
+              "newText": "new-272-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-272-5-3",
+              "newText": "new-272-5-3-2"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-272-1-1",
+              "newText": "new-272-1-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/업무계획/2016/0247.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2016/0247.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/소방청/업무계획/2016/0247.csv",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-285-16-3",
+              "newText": "new-285-16-3-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-285-17-0",
+              "newText": "new-285-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 3,
+              "oldText": "old-285-18-3",
+              "newText": "new-285-18-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-285-1-0",
+              "newText": "new-285-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/업무계획/2016/0247.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2016/0247.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/소방청/업무계획/2016/0247.csv",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-298-5-4",
+              "newText": "new-298-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-298-6-0",
+              "newText": "new-298-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-298-7-3",
+              "newText": "new-298-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-298-8-6",
+              "newText": "new-298-8-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/업무계획/2016/0247.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000247",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 248,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/업무계획/2016/0248.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-247-10-3",
+              "newText": "new-247-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-247-11-2",
+              "newText": "new-247-11-2-1"
+            },
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-247-12-1",
+              "newText": "new-247-12-1-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-247-13-0",
+              "newText": "new-247-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/업무계획/2016/0248.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/업무계획/2016/0248.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-260-1-0",
+              "newText": "new-260-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-260-2-3",
+              "newText": "new-260-2-3-1"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-260-3-1",
+              "newText": "new-260-3-1-2"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-260-4-4",
+              "newText": "new-260-4-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/업무계획/2016/0248.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/업무계획/2016/0248.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-273-4-3",
+              "newText": "new-273-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-273-5-0",
+              "newText": "new-273-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-273-6-3",
+              "newText": "new-273-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-273-1-0",
+              "newText": "new-273-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/업무계획/2016/0248.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/업무계획/2016/0248.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-286-2-6",
+              "newText": "new-286-2-6-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-286-3-2",
+              "newText": "new-286-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-286-4-5",
+              "newText": "new-286-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-286-5-1",
+              "newText": "new-286-5-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/업무계획/2016/0248.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2016/0248.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/업무계획/2016/0248.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-299-15-3",
+              "newText": "new-299-15-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-299-1-6",
+              "newText": "new-299-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-299-2-1",
+              "newText": "new-299-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-299-3-4",
+              "newText": "new-299-3-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/업무계획/2016/0248.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000248",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 249,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/업무계획/2016/0249.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/업무계획/2016/0249.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/업무계획/2016/0249.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/업무계획/2016/0249.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/업무계획/2016/0249.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/업무계획/2016/0249.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/업무계획/2016/0249.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/업무계획/2016/0249.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2016/0249.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/업무계획/2016/0249.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/업무계획/2016/0249.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000249",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/업무계획/2016/0250.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 250,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2016/0250.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/산림청/업무계획/2016/0250.csv",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-249-10-3",
+              "newText": "new-249-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-249-11-0",
+              "newText": "new-249-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-249-12-3",
+              "newText": "new-249-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-249-13-0",
+              "newText": "new-249-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/업무계획/2016/0250.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2016/0250.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/산림청/업무계획/2016/0250.csv",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-262-11-3",
+              "newText": "new-262-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-262-12-6",
+              "newText": "new-262-12-6-1"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-262-1-2",
+              "newText": "new-262-1-2-2"
+            },
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-262-2-5",
+              "newText": "new-262-2-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/업무계획/2016/0250.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2016/0250.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/산림청/업무계획/2016/0250.csv",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-275-4-3",
+              "newText": "new-275-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-275-5-6",
+              "newText": "new-275-5-6-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-275-6-1",
+              "newText": "new-275-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-275-7-4",
+              "newText": "new-275-7-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/업무계획/2016/0250.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2016/0250.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/업무계획/2016/0250.csv",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-288-16-0",
+              "newText": "new-288-16-0-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-288-17-0",
+              "newText": "new-288-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-288-18-0",
+              "newText": "new-288-18-0-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-288-19-0",
+              "newText": "new-288-19-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/업무계획/2016/0250.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2016/0250.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/산림청/업무계획/2016/0250.csv",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-301-13-1",
+              "newText": "new-301-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-301-14-0",
+              "newText": "new-301-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-301-15-3",
+              "newText": "new-301-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 2,
+              "oldText": "old-301-16-2",
+              "newText": "new-301-16-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/업무계획/2016/0250.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000250",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 251,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/업무계획/2016/0251.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-250-13-5",
+              "newText": "new-250-13-5-0"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-250-14-1",
+              "newText": "new-250-14-1-1"
+            },
+            {
+              "row": 15,
+              "col": 4,
+              "oldText": "old-250-15-4",
+              "newText": "new-250-15-4-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-250-16-0",
+              "newText": "new-250-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/업무계획/2016/0251.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/업무계획/2016/0251.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-263-4-7",
+              "newText": "new-263-4-7-0"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-263-5-2",
+              "newText": "new-263-5-2-1"
+            },
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-263-6-5",
+              "newText": "new-263-6-5-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-263-7-0",
+              "newText": "new-263-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/업무계획/2016/0251.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/업무계획/2016/0251.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-276-7-0",
+              "newText": "new-276-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-276-8-0",
+              "newText": "new-276-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-276-9-0",
+              "newText": "new-276-9-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-276-1-0",
+              "newText": "new-276-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/업무계획/2016/0251.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/업무계획/2016/0251.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-289-5-1",
+              "newText": "new-289-5-1-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-289-1-0",
+              "newText": "new-289-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-289-2-3",
+              "newText": "new-289-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-289-3-2",
+              "newText": "new-289-3-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/업무계획/2016/0251.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2016/0251.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/업무계획/2016/0251.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-302-15-2",
+              "newText": "new-302-15-2-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-302-16-0",
+              "newText": "new-302-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-302-17-3",
+              "newText": "new-302-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-302-18-1",
+              "newText": "new-302-18-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/업무계획/2016/0251.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000251",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 252,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/업무계획/2016/0252.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/업무계획/2016/0252.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/업무계획/2016/0252.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/업무계획/2016/0252.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/업무계획/2016/0252.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/업무계획/2016/0252.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/업무계획/2016/0252.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/업무계획/2016/0252.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2016/0252.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/업무계획/2016/0252.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-303-19-3",
+              "newText": "new-303-19-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-303-1-0",
+              "newText": "new-303-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-303-2-3",
+              "newText": "new-303-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-303-3-0",
+              "newText": "new-303-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/업무계획/2016/0252.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000252",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 253,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/과학기술정보통신부/업무계획/2016/0253.csv",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-252-6-0",
+              "newText": "new-252-6-0-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-252-7-0",
+              "newText": "new-252-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-252-8-0",
+              "newText": "new-252-8-0-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-252-9-0",
+              "newText": "new-252-9-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2016/0253.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/과학기술정보통신부/업무계획/2016/0253.csv",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-265-11-1",
+              "newText": "new-265-11-1-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-265-12-0",
+              "newText": "new-265-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-265-13-3",
+              "newText": "new-265-13-3-2"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-265-14-2",
+              "newText": "new-265-14-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2016/0253.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/과학기술정보통신부/업무계획/2016/0253.csv",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-278-4-3",
+              "newText": "new-278-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-278-5-1",
+              "newText": "new-278-5-1-1"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-278-6-4",
+              "newText": "new-278-6-4-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-278-7-2",
+              "newText": "new-278-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2016/0253.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/과학기술정보통신부/업무계획/2016/0253.csv",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-291-5-3",
+              "newText": "new-291-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-291-6-0",
+              "newText": "new-291-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-291-7-3",
+              "newText": "new-291-7-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-291-1-0",
+              "newText": "new-291-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2016/0253.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2016/0253.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/과학기술정보통신부/업무계획/2016/0253.csv",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-304-5-3",
+              "newText": "new-304-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-304-6-6",
+              "newText": "new-304-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-304-7-2",
+              "newText": "new-304-7-2-2"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-304-8-5",
+              "newText": "new-304-8-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2016/0253.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000253",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 254,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-253-14-1",
+              "newText": "new-253-14-1-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-253-15-0",
+              "newText": "new-253-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-253-16-3",
+              "newText": "new-253-16-3-2"
+            },
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-253-17-2",
+              "newText": "new-253-17-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-266-11-1",
+              "newText": "new-266-11-1-0"
+            },
+            {
+              "row": 12,
+              "col": 4,
+              "oldText": "old-266-12-4",
+              "newText": "new-266-12-4-1"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-266-13-2",
+              "newText": "new-266-13-2-2"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-266-14-0",
+              "newText": "new-266-14-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2016/0254.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/업무계획/2016/0254.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/업무계획/2016/0254.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000254",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 255,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-280-8-0",
+              "newText": "new-280-8-0-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-306-2-0",
+              "newText": "new-306-2-0-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2016/0255.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/업무계획/2016/0255.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 3,
+              "oldText": "old-319-14-3",
+              "newText": "new-319-14-3-0"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-319-15-2",
+              "newText": "new-319-15-2-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/업무계획/2016/0255.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000255",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "업무계획",
+    "year": 2016,
+    "serial": 256,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-255-1-3",
+              "newText": "new-255-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-255-2-0",
+              "newText": "new-255-2-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-268-17-2",
+              "newText": "new-268-17-2-0"
+            },
+            {
+              "row": 18,
+              "col": 5,
+              "oldText": "old-268-18-5",
+              "newText": "new-268-18-5-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-281-2-1",
+              "newText": "new-281-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-281-3-4",
+              "newText": "new-281-3-4-1"
+            },
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-281-4-7",
+              "newText": "new-281-4-7-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-281-5-2",
+              "newText": "new-281-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2016/0256.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/업무계획/2016/0256.csv",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/업무계획/2016/0256.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000256",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/예산서/2016/0257.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 257,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-256-5-4",
+              "newText": "new-256-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-256-6-0",
+              "newText": "new-256-6-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-269-4-5",
+              "newText": "new-269-4-5-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-308-1-3",
+              "newText": "new-308-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-308-2-1",
+              "newText": "new-308-2-1-1"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-308-3-4",
+              "newText": "new-308-3-4-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2016/0257.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/예산서/2016/0257.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-321-2-3",
+              "newText": "new-321-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-321-3-0",
+              "newText": "new-321-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-321-4-3",
+              "newText": "new-321-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-321-5-0",
+              "newText": "new-321-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/예산서/2016/0257.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0004.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0004.json
@@ -1,0 +1,17444 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000257",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 258,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-257-6-1",
+              "newText": "new-257-6-1-0"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-257-7-4",
+              "newText": "new-257-7-4-1"
+            },
+            {
+              "row": 1,
+              "col": 7,
+              "oldText": "old-257-1-7",
+              "newText": "new-257-1-7-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-257-2-2",
+              "newText": "new-257-2-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-283-12-3",
+              "newText": "new-283-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-283-13-2",
+              "newText": "new-283-13-2-1"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-283-14-1",
+              "newText": "new-283-14-1-2"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-283-15-0",
+              "newText": "new-283-15-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-296-9-1",
+              "newText": "new-296-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-296-10-4",
+              "newText": "new-296-10-4-1"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-296-11-2",
+              "newText": "new-296-11-2-2"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-296-12-0",
+              "newText": "new-296-12-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-309-6-3",
+              "newText": "new-309-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-309-7-0",
+              "newText": "new-309-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-309-8-3",
+              "newText": "new-309-8-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-309-1-0",
+              "newText": "new-309-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2016/0258.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/예산서/2016/0258.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-322-8-0",
+              "newText": "new-322-8-0-0"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-322-9-3",
+              "newText": "new-322-9-3-1"
+            },
+            {
+              "row": 10,
+              "col": 6,
+              "oldText": "old-322-10-6",
+              "newText": "new-322-10-6-2"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-322-11-2",
+              "newText": "new-322-11-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/예산서/2016/0258.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000258",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/예산서/2016/0259.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 259,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-258-3-0",
+              "newText": "new-258-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-258-4-0",
+              "newText": "new-258-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-258-5-0",
+              "newText": "new-258-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-258-6-0",
+              "newText": "new-258-6-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2016/0259.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/예산서/2016/0259.csv",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/예산서/2016/0259.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000259",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/예산서/2016/0260.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 260,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-259-8-3",
+              "newText": "new-259-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-259-9-2",
+              "newText": "new-259-9-2-1"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-259-1-1",
+              "newText": "new-259-1-1-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-285-16-3",
+              "newText": "new-285-16-3-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-285-17-0",
+              "newText": "new-285-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 3,
+              "oldText": "old-285-18-3",
+              "newText": "new-285-18-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-285-1-0",
+              "newText": "new-285-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-298-5-4",
+              "newText": "new-298-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-298-6-0",
+              "newText": "new-298-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-298-7-3",
+              "newText": "new-298-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-298-8-6",
+              "newText": "new-298-8-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-311-2-7",
+              "newText": "new-311-2-7-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-311-3-2",
+              "newText": "new-311-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-311-4-5",
+              "newText": "new-311-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-311-5-0",
+              "newText": "new-311-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2016/0260.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/예산서/2016/0260.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-324-1-0",
+              "newText": "new-324-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-324-2-0",
+              "newText": "new-324-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-324-3-0",
+              "newText": "new-324-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-324-4-0",
+              "newText": "new-324-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/예산서/2016/0260.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000260",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/예산서/2016/0261.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 261,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-260-1-0",
+              "newText": "new-260-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-260-2-3",
+              "newText": "new-260-2-3-1"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-260-3-1",
+              "newText": "new-260-3-1-2"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-260-4-4",
+              "newText": "new-260-4-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-273-4-3",
+              "newText": "new-273-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-273-5-0",
+              "newText": "new-273-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-273-6-3",
+              "newText": "new-273-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-273-1-0",
+              "newText": "new-273-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-286-2-6",
+              "newText": "new-286-2-6-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-286-3-2",
+              "newText": "new-286-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-286-4-5",
+              "newText": "new-286-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-286-5-1",
+              "newText": "new-286-5-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-299-15-3",
+              "newText": "new-299-15-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-299-1-6",
+              "newText": "new-299-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-299-2-1",
+              "newText": "new-299-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-299-3-4",
+              "newText": "new-299-3-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-312-5-0",
+              "newText": "new-312-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-312-6-0",
+              "newText": "new-312-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-312-7-0",
+              "newText": "new-312-7-0-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-312-8-0",
+              "newText": "new-312-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2016/0261.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/예산서/2016/0261.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-325-4-1",
+              "newText": "new-325-4-1-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-325-5-0",
+              "newText": "new-325-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-325-6-3",
+              "newText": "new-325-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-325-7-2",
+              "newText": "new-325-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/예산서/2016/0261.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000261",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/예산서/2016/0262.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 262,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2016/0262.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/예산서/2016/0262.csv",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/예산서/2016/0262.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000262",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 263,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-262-11-3",
+              "newText": "new-262-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-262-12-6",
+              "newText": "new-262-12-6-1"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-262-1-2",
+              "newText": "new-262-1-2-2"
+            },
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-262-2-5",
+              "newText": "new-262-2-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-275-4-3",
+              "newText": "new-275-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-275-5-6",
+              "newText": "new-275-5-6-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-275-6-1",
+              "newText": "new-275-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-275-7-4",
+              "newText": "new-275-7-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-288-16-0",
+              "newText": "new-288-16-0-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-288-17-0",
+              "newText": "new-288-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-288-18-0",
+              "newText": "new-288-18-0-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-288-19-0",
+              "newText": "new-288-19-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-301-13-1",
+              "newText": "new-301-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-301-14-0",
+              "newText": "new-301-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-301-15-3",
+              "newText": "new-301-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 2,
+              "oldText": "old-301-16-2",
+              "newText": "new-301-16-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-314-3-4",
+              "newText": "new-314-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-314-4-2",
+              "newText": "new-314-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-314-5-0",
+              "newText": "new-314-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-314-6-3",
+              "newText": "new-314-6-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2016/0263.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/예산서/2016/0263.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-327-4-3",
+              "newText": "new-327-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-327-5-0",
+              "newText": "new-327-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-327-6-3",
+              "newText": "new-327-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-327-7-0",
+              "newText": "new-327-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/예산서/2016/0263.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000263",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 264,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-263-4-7",
+              "newText": "new-263-4-7-0"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-263-5-2",
+              "newText": "new-263-5-2-1"
+            },
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-263-6-5",
+              "newText": "new-263-6-5-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-263-7-0",
+              "newText": "new-263-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-276-7-0",
+              "newText": "new-276-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-276-8-0",
+              "newText": "new-276-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-276-9-0",
+              "newText": "new-276-9-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-276-1-0",
+              "newText": "new-276-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-289-5-1",
+              "newText": "new-289-5-1-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-289-1-0",
+              "newText": "new-289-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-289-2-3",
+              "newText": "new-289-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-289-3-2",
+              "newText": "new-289-3-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-302-15-2",
+              "newText": "new-302-15-2-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-302-16-0",
+              "newText": "new-302-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-302-17-3",
+              "newText": "new-302-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-302-18-1",
+              "newText": "new-302-18-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-315-8-3",
+              "newText": "new-315-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-315-9-0",
+              "newText": "new-315-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-315-10-3",
+              "newText": "new-315-10-3-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-315-11-0",
+              "newText": "new-315-11-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2016/0264.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/예산서/2016/0264.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-328-9-6",
+              "newText": "new-328-9-6-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-328-10-2",
+              "newText": "new-328-10-2-1"
+            },
+            {
+              "row": 1,
+              "col": 5,
+              "oldText": "old-328-1-5",
+              "newText": "new-328-1-5-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-328-2-1",
+              "newText": "new-328-2-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국토교통부/예산서/2016/0264.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000264",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 265,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-316-2-1",
+              "newText": "new-316-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-316-3-4",
+              "newText": "new-316-3-4-1"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-316-4-0",
+              "newText": "new-316-4-0-2"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-316-5-3",
+              "newText": "new-316-5-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2016/0265.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/고용노동부/예산서/2016/0265.csv",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/고용노동부/예산서/2016/0265.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000265",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/예산서/2016/0266.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 266,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-265-11-1",
+              "newText": "new-265-11-1-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-265-12-0",
+              "newText": "new-265-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-265-13-3",
+              "newText": "new-265-13-3-2"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-265-14-2",
+              "newText": "new-265-14-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-278-4-3",
+              "newText": "new-278-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-278-5-1",
+              "newText": "new-278-5-1-1"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-278-6-4",
+              "newText": "new-278-6-4-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-278-7-2",
+              "newText": "new-278-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-291-5-3",
+              "newText": "new-291-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-291-6-0",
+              "newText": "new-291-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-291-7-3",
+              "newText": "new-291-7-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-291-1-0",
+              "newText": "new-291-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-304-5-3",
+              "newText": "new-304-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-304-6-6",
+              "newText": "new-304-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-304-7-2",
+              "newText": "new-304-7-2-2"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-304-8-5",
+              "newText": "new-304-8-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-317-14-5",
+              "newText": "new-317-14-5-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-317-15-0",
+              "newText": "new-317-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-317-16-3",
+              "newText": "new-317-16-3-2"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-317-1-6",
+              "newText": "new-317-1-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2016/0266.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/외교부/예산서/2016/0266.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/외교부/예산서/2016/0266.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000266",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 267,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-266-11-1",
+              "newText": "new-266-11-1-0"
+            },
+            {
+              "row": 12,
+              "col": 4,
+              "oldText": "old-266-12-4",
+              "newText": "new-266-12-4-1"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-266-13-2",
+              "newText": "new-266-13-2-2"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-266-14-0",
+              "newText": "new-266-14-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-279-4-3",
+              "newText": "new-279-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-279-5-0",
+              "newText": "new-279-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-279-6-3",
+              "newText": "new-279-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-279-7-0",
+              "newText": "new-279-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-292-5-5",
+              "newText": "new-292-5-5-0"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-292-6-1",
+              "newText": "new-292-6-1-1"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-292-7-4",
+              "newText": "new-292-7-4-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-292-8-0",
+              "newText": "new-292-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-305-12-1",
+              "newText": "new-305-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-305-13-4",
+              "newText": "new-305-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-305-14-7",
+              "newText": "new-305-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-305-15-2",
+              "newText": "new-305-15-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-318-13-0",
+              "newText": "new-318-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-318-14-0",
+              "newText": "new-318-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-318-15-0",
+              "newText": "new-318-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-318-16-0",
+              "newText": "new-318-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2016/0267.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/예산서/2016/0267.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기획재정부/예산서/2016/0267.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000267",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 268,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-332-11-2",
+              "newText": "new-332-11-2-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2016/0268.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/예산서/2016/0268.csv",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-345-6-3",
+              "newText": "new-345-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-345-7-0",
+              "newText": "new-345-7-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/예산서/2016/0268.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000268",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 269,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-268-17-2",
+              "newText": "new-268-17-2-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-281-2-1",
+              "newText": "new-281-2-1-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-294-5-0",
+              "newText": "new-294-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-294-6-0",
+              "newText": "new-294-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-294-7-0",
+              "newText": "new-294-7-0-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-294-8-0",
+              "newText": "new-294-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2016/0269.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/예산서/2016/0269.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/금융위원회/예산서/2016/0269.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000269",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 270,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-269-4-5",
+              "newText": "new-269-4-5-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-321-2-3",
+              "newText": "new-321-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-321-3-0",
+              "newText": "new-321-3-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-334-15-5",
+              "newText": "new-334-15-5-0"
+            },
+            {
+              "row": 16,
+              "col": 1,
+              "oldText": "old-334-16-1",
+              "newText": "new-334-16-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-334-1-4",
+              "newText": "new-334-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-334-2-0",
+              "newText": "new-334-2-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2016/0270.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/방송통신위원회/예산서/2016/0270.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-347-12-3",
+              "newText": "new-347-12-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-347-1-6",
+              "newText": "new-347-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-347-2-1",
+              "newText": "new-347-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-347-3-4",
+              "newText": "new-347-3-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/예산서/2016/0270.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000270",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 271,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-270-11-0",
+              "newText": "new-270-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-270-12-0",
+              "newText": "new-270-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-270-13-0",
+              "newText": "new-270-13-0-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-296-9-1",
+              "newText": "new-296-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-296-10-4",
+              "newText": "new-296-10-4-1"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-296-11-2",
+              "newText": "new-296-11-2-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-309-6-3",
+              "newText": "new-309-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-309-7-0",
+              "newText": "new-309-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-309-8-3",
+              "newText": "new-309-8-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-309-1-0",
+              "newText": "new-309-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-322-8-0",
+              "newText": "new-322-8-0-0"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-322-9-3",
+              "newText": "new-322-9-3-1"
+            },
+            {
+              "row": 10,
+              "col": 6,
+              "oldText": "old-322-10-6",
+              "newText": "new-322-10-6-2"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-322-11-2",
+              "newText": "new-322-11-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 13,
+              "col": 7,
+              "oldText": "old-335-13-7",
+              "newText": "new-335-13-7-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-335-14-2",
+              "newText": "new-335-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-335-15-5",
+              "newText": "new-335-15-5-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-335-16-0",
+              "newText": "new-335-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2016/0271.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/예산서/2016/0271.csv",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-348-11-0",
+              "newText": "new-348-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-348-12-0",
+              "newText": "new-348-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-348-13-0",
+              "newText": "new-348-13-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-348-1-0",
+              "newText": "new-348-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예산서/2016/0271.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000271",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 272,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 20,
+              "col": 3,
+              "oldText": "old-271-20-3",
+              "newText": "new-271-20-3-0"
+            },
+            {
+              "row": 21,
+              "col": 2,
+              "oldText": "old-271-21-2",
+              "newText": "new-271-21-2-1"
+            },
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-271-1-1",
+              "newText": "new-271-1-1-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-271-2-0",
+              "newText": "new-271-2-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2016/0272.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국민권익위원회/예산서/2016/0272.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/예산서/2016/0272.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000272",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 273,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-272-3-2",
+              "newText": "new-272-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-272-4-0",
+              "newText": "new-272-4-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-298-5-4",
+              "newText": "new-298-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-298-6-0",
+              "newText": "new-298-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-298-7-3",
+              "newText": "new-298-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-298-8-6",
+              "newText": "new-298-8-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-311-2-7",
+              "newText": "new-311-2-7-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-311-3-2",
+              "newText": "new-311-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-311-4-5",
+              "newText": "new-311-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-311-5-0",
+              "newText": "new-311-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-324-1-0",
+              "newText": "new-324-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-324-2-0",
+              "newText": "new-324-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-324-3-0",
+              "newText": "new-324-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-324-4-0",
+              "newText": "new-324-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-337-15-1",
+              "newText": "new-337-15-1-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-337-16-0",
+              "newText": "new-337-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-337-17-3",
+              "newText": "new-337-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 2,
+              "oldText": "old-337-18-2",
+              "newText": "new-337-18-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2016/0273.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국가인권위원회/예산서/2016/0273.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-350-6-0",
+              "newText": "new-350-6-0-0"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-350-7-3",
+              "newText": "new-350-7-3-1"
+            },
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-350-8-1",
+              "newText": "new-350-8-1-2"
+            },
+            {
+              "row": 9,
+              "col": 4,
+              "oldText": "old-350-9-4",
+              "newText": "new-350-9-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/예산서/2016/0273.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000273",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/예산서/2016/0274.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 274,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-273-4-3",
+              "newText": "new-273-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-273-5-0",
+              "newText": "new-273-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-273-6-3",
+              "newText": "new-273-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-273-1-0",
+              "newText": "new-273-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-286-2-6",
+              "newText": "new-286-2-6-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-286-3-2",
+              "newText": "new-286-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-286-4-5",
+              "newText": "new-286-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-286-5-1",
+              "newText": "new-286-5-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-299-15-3",
+              "newText": "new-299-15-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-299-1-6",
+              "newText": "new-299-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-299-2-1",
+              "newText": "new-299-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-299-3-4",
+              "newText": "new-299-3-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-312-5-0",
+              "newText": "new-312-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-312-6-0",
+              "newText": "new-312-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-312-7-0",
+              "newText": "new-312-7-0-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-312-8-0",
+              "newText": "new-312-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-325-4-1",
+              "newText": "new-325-4-1-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-325-5-0",
+              "newText": "new-325-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-325-6-3",
+              "newText": "new-325-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-325-7-2",
+              "newText": "new-325-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-338-19-3",
+              "newText": "new-338-19-3-0"
+            },
+            {
+              "row": 20,
+              "col": 1,
+              "oldText": "old-338-20-1",
+              "newText": "new-338-20-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-338-1-4",
+              "newText": "new-338-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-338-2-2",
+              "newText": "new-338-2-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2016/0274.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/예산서/2016/0274.csv",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-351-16-3",
+              "newText": "new-351-16-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-351-1-0",
+              "newText": "new-351-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-351-2-3",
+              "newText": "new-351-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-351-3-0",
+              "newText": "new-351-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/통계청/예산서/2016/0274.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000274",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/예산서/2016/0275.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 275,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2016/0275.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/예산서/2016/0275.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-352-13-2",
+              "newText": "new-352-13-2-0"
+            },
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-352-14-5",
+              "newText": "new-352-14-5-1"
+            },
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-352-15-1",
+              "newText": "new-352-15-1-2"
+            },
+            {
+              "row": 16,
+              "col": 4,
+              "oldText": "old-352-16-4",
+              "newText": "new-352-16-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/기상청/예산서/2016/0275.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000275",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/예산서/2016/0276.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 276,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-275-4-3",
+              "newText": "new-275-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-275-5-6",
+              "newText": "new-275-5-6-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-275-6-1",
+              "newText": "new-275-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-275-7-4",
+              "newText": "new-275-7-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-288-16-0",
+              "newText": "new-288-16-0-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-288-17-0",
+              "newText": "new-288-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-288-18-0",
+              "newText": "new-288-18-0-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-288-19-0",
+              "newText": "new-288-19-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-301-13-1",
+              "newText": "new-301-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-301-14-0",
+              "newText": "new-301-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-301-15-3",
+              "newText": "new-301-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 2,
+              "oldText": "old-301-16-2",
+              "newText": "new-301-16-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-314-3-4",
+              "newText": "new-314-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-314-4-2",
+              "newText": "new-314-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-314-5-0",
+              "newText": "new-314-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-314-6-3",
+              "newText": "new-314-6-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-327-4-3",
+              "newText": "new-327-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-327-5-0",
+              "newText": "new-327-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-327-6-3",
+              "newText": "new-327-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-327-7-0",
+              "newText": "new-327-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-340-1-4",
+              "newText": "new-340-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-340-2-0",
+              "newText": "new-340-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-340-3-3",
+              "newText": "new-340-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 6,
+              "oldText": "old-340-4-6",
+              "newText": "new-340-4-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2016/0276.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/관세청/예산서/2016/0276.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-353-12-1",
+              "newText": "new-353-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-353-13-4",
+              "newText": "new-353-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-353-14-7",
+              "newText": "new-353-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-353-15-2",
+              "newText": "new-353-15-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/관세청/예산서/2016/0276.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000276",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/예산서/2016/0277.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 277,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-276-7-0",
+              "newText": "new-276-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-276-8-0",
+              "newText": "new-276-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-276-9-0",
+              "newText": "new-276-9-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-276-1-0",
+              "newText": "new-276-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-289-5-1",
+              "newText": "new-289-5-1-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-289-1-0",
+              "newText": "new-289-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-289-2-3",
+              "newText": "new-289-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-289-3-2",
+              "newText": "new-289-3-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-302-15-2",
+              "newText": "new-302-15-2-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-302-16-0",
+              "newText": "new-302-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-302-17-3",
+              "newText": "new-302-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-302-18-1",
+              "newText": "new-302-18-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-315-8-3",
+              "newText": "new-315-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-315-9-0",
+              "newText": "new-315-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-315-10-3",
+              "newText": "new-315-10-3-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-315-11-0",
+              "newText": "new-315-11-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-328-9-6",
+              "newText": "new-328-9-6-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-328-10-2",
+              "newText": "new-328-10-2-1"
+            },
+            {
+              "row": 1,
+              "col": 5,
+              "oldText": "old-328-1-5",
+              "newText": "new-328-1-5-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-328-2-1",
+              "newText": "new-328-2-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-341-6-5",
+              "newText": "new-341-6-5-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-341-1-0",
+              "newText": "new-341-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-341-2-3",
+              "newText": "new-341-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 6,
+              "oldText": "old-341-3-6",
+              "newText": "new-341-3-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2016/0277.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/검찰청/예산서/2016/0277.csv",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-354-13-0",
+              "newText": "new-354-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-354-14-0",
+              "newText": "new-354-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-354-15-0",
+              "newText": "new-354-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-354-16-0",
+              "newText": "new-354-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/검찰청/예산서/2016/0277.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000277",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 278,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-329-11-1",
+              "newText": "new-329-11-1-0"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-329-1-4",
+              "newText": "new-329-1-4-1"
+            },
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-329-2-7",
+              "newText": "new-329-2-7-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-329-3-2",
+              "newText": "new-329-3-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2016/0278.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/경찰청/예산서/2016/0278.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-355-16-3",
+              "newText": "new-355-16-3-0"
+            },
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-355-17-2",
+              "newText": "new-355-17-2-1"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-355-18-1",
+              "newText": "new-355-18-1-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-355-19-0",
+              "newText": "new-355-19-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/경찰청/예산서/2016/0278.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000278",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/예산서/2016/0279.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 279,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-278-4-3",
+              "newText": "new-278-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-278-5-1",
+              "newText": "new-278-5-1-1"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-278-6-4",
+              "newText": "new-278-6-4-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-278-7-2",
+              "newText": "new-278-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-291-5-3",
+              "newText": "new-291-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-291-6-0",
+              "newText": "new-291-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-291-7-3",
+              "newText": "new-291-7-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-291-1-0",
+              "newText": "new-291-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-304-5-3",
+              "newText": "new-304-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-304-6-6",
+              "newText": "new-304-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-304-7-2",
+              "newText": "new-304-7-2-2"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-304-8-5",
+              "newText": "new-304-8-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-317-14-5",
+              "newText": "new-317-14-5-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-317-15-0",
+              "newText": "new-317-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-317-16-3",
+              "newText": "new-317-16-3-2"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-317-1-6",
+              "newText": "new-317-1-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-330-7-0",
+              "newText": "new-330-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-330-8-0",
+              "newText": "new-330-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-330-9-0",
+              "newText": "new-330-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-330-10-0",
+              "newText": "new-330-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2016/0279.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/예산서/2016/0279.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/소방청/예산서/2016/0279.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000279",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 280,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-279-4-3",
+              "newText": "new-279-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-279-5-0",
+              "newText": "new-279-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-279-6-3",
+              "newText": "new-279-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-279-7-0",
+              "newText": "new-279-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-292-5-5",
+              "newText": "new-292-5-5-0"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-292-6-1",
+              "newText": "new-292-6-1-1"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-292-7-4",
+              "newText": "new-292-7-4-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-292-8-0",
+              "newText": "new-292-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-305-12-1",
+              "newText": "new-305-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-305-13-4",
+              "newText": "new-305-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-305-14-7",
+              "newText": "new-305-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-305-15-2",
+              "newText": "new-305-15-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-318-13-0",
+              "newText": "new-318-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-318-14-0",
+              "newText": "new-318-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-318-15-0",
+              "newText": "new-318-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-318-16-0",
+              "newText": "new-318-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-331-7-3",
+              "newText": "new-331-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-331-8-2",
+              "newText": "new-331-8-2-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-331-9-1",
+              "newText": "new-331-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-331-10-0",
+              "newText": "new-331-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2016/0280.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양경찰청/예산서/2016/0280.csv",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-357-3-3",
+              "newText": "new-357-3-3-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-357-4-0",
+              "newText": "new-357-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-357-5-3",
+              "newText": "new-357-5-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-357-1-0",
+              "newText": "new-357-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/예산서/2016/0280.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000280",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/예산서/2016/0281.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 281,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-306-2-0",
+              "newText": "new-306-2-0-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-306-3-0",
+              "newText": "new-306-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-306-4-0",
+              "newText": "new-306-4-0-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-306-5-0",
+              "newText": "new-306-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-332-11-2",
+              "newText": "new-332-11-2-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-332-12-0",
+              "newText": "new-332-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-332-13-3",
+              "newText": "new-332-13-3-2"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-332-14-1",
+              "newText": "new-332-14-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-345-6-3",
+              "newText": "new-345-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-345-7-0",
+              "newText": "new-345-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-345-8-3",
+              "newText": "new-345-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-345-9-0",
+              "newText": "new-345-9-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2016/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/예산서/2016/0281.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-358-5-1",
+              "newText": "new-358-5-1-0"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-358-6-4",
+              "newText": "new-358-6-4-1"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-358-1-0",
+              "newText": "new-358-1-0-2"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-358-2-3",
+              "newText": "new-358-2-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/병무청/예산서/2016/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000281",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/예산서/2016/0282.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 282,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-307-2-3",
+              "newText": "new-307-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-307-3-2",
+              "newText": "new-307-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-307-4-1",
+              "newText": "new-307-4-1-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2016/0282.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/산림청/예산서/2016/0282.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/산림청/예산서/2016/0282.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000282",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 283,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-334-15-5",
+              "newText": "new-334-15-5-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-347-12-3",
+              "newText": "new-347-12-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-347-1-6",
+              "newText": "new-347-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-347-2-1",
+              "newText": "new-347-2-1-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-360-1-0",
+              "newText": "new-360-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-360-2-0",
+              "newText": "new-360-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-360-3-0",
+              "newText": "new-360-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-360-4-0",
+              "newText": "new-360-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2016/0283.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/예산서/2016/0283.csv",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-373-17-1",
+              "newText": "new-373-17-1-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/예산서/2016/0283.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000283",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 284,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-283-12-3",
+              "newText": "new-283-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-283-13-2",
+              "newText": "new-283-13-2-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-309-6-3",
+              "newText": "new-309-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-309-7-0",
+              "newText": "new-309-7-0-1"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-322-8-0",
+              "newText": "new-322-8-0-0"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-322-9-3",
+              "newText": "new-322-9-3-1"
+            },
+            {
+              "row": 10,
+              "col": 6,
+              "oldText": "old-322-10-6",
+              "newText": "new-322-10-6-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 13,
+              "col": 7,
+              "oldText": "old-335-13-7",
+              "newText": "new-335-13-7-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-335-14-2",
+              "newText": "new-335-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-335-15-5",
+              "newText": "new-335-15-5-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-335-16-0",
+              "newText": "new-335-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-348-11-0",
+              "newText": "new-348-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-348-12-0",
+              "newText": "new-348-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-348-13-0",
+              "newText": "new-348-13-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-348-1-0",
+              "newText": "new-348-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-361-2-1",
+              "newText": "new-361-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-361-3-0",
+              "newText": "new-361-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-361-4-3",
+              "newText": "new-361-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-361-5-2",
+              "newText": "new-361-5-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2016/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/예산서/2016/0284.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-374-5-4",
+              "newText": "new-374-5-4-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-374-1-2",
+              "newText": "new-374-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-374-2-0",
+              "newText": "new-374-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-374-3-3",
+              "newText": "new-374-3-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/예산서/2016/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000284",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 285,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-284-13-4",
+              "newText": "new-284-13-4-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-284-14-2",
+              "newText": "new-284-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-284-15-0",
+              "newText": "new-284-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-284-16-3",
+              "newText": "new-284-16-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2016/0285.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/예산서/2016/0285.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예산서/2016/0285.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000285",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 286,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-285-16-3",
+              "newText": "new-285-16-3-0"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-311-2-7",
+              "newText": "new-311-2-7-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-311-3-2",
+              "newText": "new-311-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-311-4-5",
+              "newText": "new-311-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-311-5-0",
+              "newText": "new-311-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-324-1-0",
+              "newText": "new-324-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-324-2-0",
+              "newText": "new-324-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-324-3-0",
+              "newText": "new-324-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-324-4-0",
+              "newText": "new-324-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-337-15-1",
+              "newText": "new-337-15-1-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-337-16-0",
+              "newText": "new-337-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-337-17-3",
+              "newText": "new-337-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 2,
+              "oldText": "old-337-18-2",
+              "newText": "new-337-18-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-350-6-0",
+              "newText": "new-350-6-0-0"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-350-7-3",
+              "newText": "new-350-7-3-1"
+            },
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-350-8-1",
+              "newText": "new-350-8-1-2"
+            },
+            {
+              "row": 9,
+              "col": 4,
+              "oldText": "old-350-9-4",
+              "newText": "new-350-9-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-363-1-3",
+              "newText": "new-363-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-363-2-0",
+              "newText": "new-363-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-363-3-3",
+              "newText": "new-363-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-363-4-0",
+              "newText": "new-363-4-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2016/0286.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/문화체육관광부/예산서/2016/0286.csv",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-376-6-5",
+              "newText": "new-376-6-5-0"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-376-7-1",
+              "newText": "new-376-7-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-376-1-4",
+              "newText": "new-376-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-376-2-0",
+              "newText": "new-376-2-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/예산서/2016/0286.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000286",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/예산서/2016/0287.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 287,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-286-2-6",
+              "newText": "new-286-2-6-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-286-3-2",
+              "newText": "new-286-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-286-4-5",
+              "newText": "new-286-4-5-2"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-286-5-1",
+              "newText": "new-286-5-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-299-15-3",
+              "newText": "new-299-15-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-299-1-6",
+              "newText": "new-299-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-299-2-1",
+              "newText": "new-299-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-299-3-4",
+              "newText": "new-299-3-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-312-5-0",
+              "newText": "new-312-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-312-6-0",
+              "newText": "new-312-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-312-7-0",
+              "newText": "new-312-7-0-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-312-8-0",
+              "newText": "new-312-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-325-4-1",
+              "newText": "new-325-4-1-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-325-5-0",
+              "newText": "new-325-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-325-6-3",
+              "newText": "new-325-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-325-7-2",
+              "newText": "new-325-7-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-338-19-3",
+              "newText": "new-338-19-3-0"
+            },
+            {
+              "row": 20,
+              "col": 1,
+              "oldText": "old-338-20-1",
+              "newText": "new-338-20-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-338-1-4",
+              "newText": "new-338-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-338-2-2",
+              "newText": "new-338-2-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-351-16-3",
+              "newText": "new-351-16-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-351-1-0",
+              "newText": "new-351-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-351-2-3",
+              "newText": "new-351-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-351-3-0",
+              "newText": "new-351-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-364-5-0",
+              "newText": "new-364-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-364-6-3",
+              "newText": "new-364-6-3-1"
+            },
+            {
+              "row": 7,
+              "col": 6,
+              "oldText": "old-364-7-6",
+              "newText": "new-364-7-6-2"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-364-8-2",
+              "newText": "new-364-8-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2016/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/예산서/2016/0287.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-377-2-1",
+              "newText": "new-377-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-377-3-4",
+              "newText": "new-377-3-4-1"
+            },
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-377-4-7",
+              "newText": "new-377-4-7-2"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/환경부/예산서/2016/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000287",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예산서",
+    "year": 2016,
+    "serial": 288,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-365-2-5",
+              "newText": "new-365-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-365-3-0",
+              "newText": "new-365-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-365-4-3",
+              "newText": "new-365-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-365-5-6",
+              "newText": "new-365-5-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2016/0288.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/해양수산부/예산서/2016/0288.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/해양수산부/예산서/2016/0288.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000288",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/회의록/2016/0289.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 289,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-288-16-0",
+              "newText": "new-288-16-0-0"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-288-17-0",
+              "newText": "new-288-17-0-1"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-288-18-0",
+              "newText": "new-288-18-0-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-288-19-0",
+              "newText": "new-288-19-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-301-13-1",
+              "newText": "new-301-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-301-14-0",
+              "newText": "new-301-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-301-15-3",
+              "newText": "new-301-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 2,
+              "oldText": "old-301-16-2",
+              "newText": "new-301-16-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-314-3-4",
+              "newText": "new-314-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-314-4-2",
+              "newText": "new-314-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-314-5-0",
+              "newText": "new-314-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-314-6-3",
+              "newText": "new-314-6-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-327-4-3",
+              "newText": "new-327-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-327-5-0",
+              "newText": "new-327-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-327-6-3",
+              "newText": "new-327-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-327-7-0",
+              "newText": "new-327-7-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-340-1-4",
+              "newText": "new-340-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-340-2-0",
+              "newText": "new-340-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-340-3-3",
+              "newText": "new-340-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 6,
+              "oldText": "old-340-4-6",
+              "newText": "new-340-4-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-353-12-1",
+              "newText": "new-353-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-353-13-4",
+              "newText": "new-353-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-353-14-7",
+              "newText": "new-353-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-353-15-2",
+              "newText": "new-353-15-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-366-3-0",
+              "newText": "new-366-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-366-4-0",
+              "newText": "new-366-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-366-5-0",
+              "newText": "new-366-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-366-6-0",
+              "newText": "new-366-6-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2016/0289.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/법제처/회의록/2016/0289.csv",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/법제처/회의록/2016/0289.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000289",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 290,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-289-5-1",
+              "newText": "new-289-5-1-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-289-1-0",
+              "newText": "new-289-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-289-2-3",
+              "newText": "new-289-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-289-3-2",
+              "newText": "new-289-3-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-302-15-2",
+              "newText": "new-302-15-2-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-302-16-0",
+              "newText": "new-302-16-0-1"
+            },
+            {
+              "row": 17,
+              "col": 3,
+              "oldText": "old-302-17-3",
+              "newText": "new-302-17-3-2"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-302-18-1",
+              "newText": "new-302-18-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-315-8-3",
+              "newText": "new-315-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-315-9-0",
+              "newText": "new-315-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-315-10-3",
+              "newText": "new-315-10-3-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-315-11-0",
+              "newText": "new-315-11-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-328-9-6",
+              "newText": "new-328-9-6-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-328-10-2",
+              "newText": "new-328-10-2-1"
+            },
+            {
+              "row": 1,
+              "col": 5,
+              "oldText": "old-328-1-5",
+              "newText": "new-328-1-5-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-328-2-1",
+              "newText": "new-328-2-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-341-6-5",
+              "newText": "new-341-6-5-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-341-1-0",
+              "newText": "new-341-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-341-2-3",
+              "newText": "new-341-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 6,
+              "oldText": "old-341-3-6",
+              "newText": "new-341-3-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-354-13-0",
+              "newText": "new-354-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-354-14-0",
+              "newText": "new-354-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-354-15-0",
+              "newText": "new-354-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-354-16-0",
+              "newText": "new-354-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-367-8-3",
+              "newText": "new-367-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-367-9-2",
+              "newText": "new-367-9-2-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-367-10-1",
+              "newText": "new-367-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-367-11-0",
+              "newText": "new-367-11-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2016/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/회의록/2016/0290.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/행정안전부/회의록/2016/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000290",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/회의록/2016/0291.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 291,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-342-7-0",
+              "newText": "new-342-7-0-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-342-1-0",
+              "newText": "new-342-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-342-2-0",
+              "newText": "new-342-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-342-3-0",
+              "newText": "new-342-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-368-1-3",
+              "newText": "new-368-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-368-2-1",
+              "newText": "new-368-2-1-1"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-368-3-4",
+              "newText": "new-368-3-4-2"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-368-4-2",
+              "newText": "new-368-4-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2016/0291.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/회의록/2016/0291.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-381-10-3",
+              "newText": "new-381-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-381-11-0",
+              "newText": "new-381-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-381-12-3",
+              "newText": "new-381-12-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-381-1-0",
+              "newText": "new-381-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/국세청/회의록/2016/0291.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000291",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/회의록/2016/0292.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 292,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-291-5-3",
+              "newText": "new-291-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-291-6-0",
+              "newText": "new-291-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-291-7-3",
+              "newText": "new-291-7-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-291-1-0",
+              "newText": "new-291-1-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-304-5-3",
+              "newText": "new-304-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-304-6-6",
+              "newText": "new-304-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-304-7-2",
+              "newText": "new-304-7-2-2"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-304-8-5",
+              "newText": "new-304-8-5-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-317-14-5",
+              "newText": "new-317-14-5-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-317-15-0",
+              "newText": "new-317-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-317-16-3",
+              "newText": "new-317-16-3-2"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-317-1-6",
+              "newText": "new-317-1-6-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-330-7-0",
+              "newText": "new-330-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-330-8-0",
+              "newText": "new-330-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-330-9-0",
+              "newText": "new-330-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-330-10-0",
+              "newText": "new-330-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-343-8-3",
+              "newText": "new-343-8-3-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-343-1-2",
+              "newText": "new-343-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-343-2-1",
+              "newText": "new-343-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-343-3-0",
+              "newText": "new-343-3-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2016/0292.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/회의록/2016/0292.csv",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/대법원/회의록/2016/0292.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000292",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/회의록/2016/0293.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 293,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-292-5-5",
+              "newText": "new-292-5-5-0"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-292-6-1",
+              "newText": "new-292-6-1-1"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-292-7-4",
+              "newText": "new-292-7-4-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-292-8-0",
+              "newText": "new-292-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-305-12-1",
+              "newText": "new-305-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-305-13-4",
+              "newText": "new-305-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-305-14-7",
+              "newText": "new-305-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-305-15-2",
+              "newText": "new-305-15-2-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-318-13-0",
+              "newText": "new-318-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-318-14-0",
+              "newText": "new-318-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-318-15-0",
+              "newText": "new-318-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-318-16-0",
+              "newText": "new-318-16-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-331-7-3",
+              "newText": "new-331-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-331-8-2",
+              "newText": "new-331-8-2-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-331-9-1",
+              "newText": "new-331-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-331-10-0",
+              "newText": "new-331-10-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-344-3-4",
+              "newText": "new-344-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-344-4-2",
+              "newText": "new-344-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-344-5-0",
+              "newText": "new-344-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-344-6-3",
+              "newText": "new-344-6-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 6,
+              "oldText": "old-370-11-6",
+              "newText": "new-370-11-6-0"
+            },
+            {
+              "row": 12,
+              "col": 2,
+              "oldText": "old-370-12-2",
+              "newText": "new-370-12-2-1"
+            },
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-370-13-5",
+              "newText": "new-370-13-5-2"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-370-14-1",
+              "newText": "new-370-14-1-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2016/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/특허청/회의록/2016/0293.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-383-6-7",
+              "newText": "new-383-6-7-0"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-383-7-2",
+              "newText": "new-383-7-2-1"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-383-8-5",
+              "newText": "new-383-8-5-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-383-9-0",
+              "newText": "new-383-9-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/특허청/회의록/2016/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000293",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/회의록/2016/0294.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 294,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 3,
+              "oldText": "old-319-14-3",
+              "newText": "new-319-14-3-0"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-319-15-2",
+              "newText": "new-319-15-2-1"
+            },
+            {
+              "row": 16,
+              "col": 1,
+              "oldText": "old-319-16-1",
+              "newText": "new-319-16-1-2"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-319-17-0",
+              "newText": "new-319-17-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-345-6-3",
+              "newText": "new-345-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-345-7-0",
+              "newText": "new-345-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-345-8-3",
+              "newText": "new-345-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-345-9-0",
+              "newText": "new-345-9-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-358-5-1",
+              "newText": "new-358-5-1-0"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-358-6-4",
+              "newText": "new-358-6-4-1"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-358-1-0",
+              "newText": "new-358-1-0-2"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-358-2-3",
+              "newText": "new-358-2-3-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-371-11-3",
+              "newText": "new-371-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-371-12-6",
+              "newText": "new-371-12-6-1"
+            },
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-371-13-1",
+              "newText": "new-371-13-1-2"
+            },
+            {
+              "row": 14,
+              "col": 4,
+              "oldText": "old-371-14-4",
+              "newText": "new-371-14-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2016/0294.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/회의록/2016/0294.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-384-10-0",
+              "newText": "new-384-10-0-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-384-11-0",
+              "newText": "new-384-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-384-12-0",
+              "newText": "new-384-12-0-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-384-13-0",
+              "newText": "new-384-13-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/교육부/회의록/2016/0294.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000294",
+    "command": "csv-to-table",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 295,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-294-5-0",
+              "newText": "new-294-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-294-6-0",
+              "newText": "new-294-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-294-7-0",
+              "newText": "new-294-7-0-2"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-294-8-0",
+              "newText": "new-294-8-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-307-2-3",
+              "newText": "new-307-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-307-3-2",
+              "newText": "new-307-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-307-4-1",
+              "newText": "new-307-4-1-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-307-5-0",
+              "newText": "new-307-5-0-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-320-17-0",
+              "newText": "new-320-17-0-0"
+            },
+            {
+              "row": 18,
+              "col": 3,
+              "oldText": "old-320-18-3",
+              "newText": "new-320-18-3-1"
+            },
+            {
+              "row": 19,
+              "col": 1,
+              "oldText": "old-320-19-1",
+              "newText": "new-320-19-1-2"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-320-1-4",
+              "newText": "new-320-1-4-3"
+            }
+          ],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2016/0295.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/회의록/2016/0295.csv",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": [
+            0
+          ],
+          "output": "out/v-bon/보건복지부/회의록/2016/0295.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000295",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/회의록/2016/0296.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 296,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2016/0296.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국토교통부/회의록/2016/0296.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2016/0296.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/회의록/2016/0296.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-308-1-3",
+              "newText": "new-308-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-308-2-1",
+              "newText": "new-308-2-1-1"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-308-3-4",
+              "newText": "new-308-3-4-2"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-308-4-2",
+              "newText": "new-308-4-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000296",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/회의록/2016/0297.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 297,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2016/0297.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/회의록/2016/0297.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-296-9-1",
+              "newText": "new-296-9-1-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2016/0297.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/회의록/2016/0297.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-309-6-3",
+              "newText": "new-309-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-309-7-0",
+              "newText": "new-309-7-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000297",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/회의록/2016/0298.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 298,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2016/0298.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/회의록/2016/0298.csv",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-297-12-3",
+              "newText": "new-297-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-297-13-0",
+              "newText": "new-297-13-0-1"
+            },
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-297-1-3",
+              "newText": "new-297-1-3-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-297-2-0",
+              "newText": "new-297-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2016/0298.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/회의록/2016/0298.csv",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-310-5-2",
+              "newText": "new-310-5-2-0"
+            },
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-310-6-5",
+              "newText": "new-310-6-5-1"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-310-7-1",
+              "newText": "new-310-7-1-2"
+            },
+            {
+              "row": 8,
+              "col": 4,
+              "oldText": "old-310-8-4",
+              "newText": "new-310-8-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000298",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/회의록/2016/0299.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 299,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2016/0299.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/회의록/2016/0299.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-298-5-4",
+              "newText": "new-298-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-298-6-0",
+              "newText": "new-298-6-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2016/0299.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/회의록/2016/0299.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-311-2-7",
+              "newText": "new-311-2-7-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000299",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/회의록/2016/0300.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 300,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2016/0300.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/회의록/2016/0300.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2016/0300.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/공정거래위원회/회의록/2016/0300.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000300",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/회의록/2016/0301.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 301,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2016/0301.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/회의록/2016/0301.csv",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2016/0301.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/회의록/2016/0301.csv",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000301",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/회의록/2016/0302.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 302,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2016/0302.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/회의록/2016/0302.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2016/0302.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/회의록/2016/0302.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000302",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/회의록/2016/0303.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 303,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2016/0303.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/회의록/2016/0303.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2016/0303.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/회의록/2016/0303.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000303",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/회의록/2016/0304.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 304,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2016/0304.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/회의록/2016/0304.csv",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2016/0304.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/회의록/2016/0304.csv",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-316-2-1",
+              "newText": "new-316-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-316-3-4",
+              "newText": "new-316-3-4-1"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-316-4-0",
+              "newText": "new-316-4-0-2"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-316-5-3",
+              "newText": "new-316-5-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000304",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/회의록/2016/0305.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 305,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2016/0305.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/회의록/2016/0305.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-304-5-3",
+              "newText": "new-304-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-304-6-6",
+              "newText": "new-304-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-304-7-2",
+              "newText": "new-304-7-2-2"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-304-8-5",
+              "newText": "new-304-8-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2016/0305.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/회의록/2016/0305.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-317-14-5",
+              "newText": "new-317-14-5-0"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-317-15-0",
+              "newText": "new-317-15-0-1"
+            },
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-317-16-3",
+              "newText": "new-317-16-3-2"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-317-1-6",
+              "newText": "new-317-1-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000305",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/회의록/2016/0306.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 306,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2016/0306.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/회의록/2016/0306.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-305-12-1",
+              "newText": "new-305-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-305-13-4",
+              "newText": "new-305-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-305-14-7",
+              "newText": "new-305-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-305-15-2",
+              "newText": "new-305-15-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2016/0306.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/회의록/2016/0306.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-318-13-0",
+              "newText": "new-318-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-318-14-0",
+              "newText": "new-318-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-318-15-0",
+              "newText": "new-318-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-318-16-0",
+              "newText": "new-318-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000306",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/회의록/2016/0307.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 307,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2016/0307.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/회의록/2016/0307.csv",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-306-2-0",
+              "newText": "new-306-2-0-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-306-3-0",
+              "newText": "new-306-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-306-4-0",
+              "newText": "new-306-4-0-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-306-5-0",
+              "newText": "new-306-5-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2016/0307.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/회의록/2016/0307.csv",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 3,
+              "oldText": "old-319-14-3",
+              "newText": "new-319-14-3-0"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-319-15-2",
+              "newText": "new-319-15-2-1"
+            },
+            {
+              "row": 16,
+              "col": 1,
+              "oldText": "old-319-16-1",
+              "newText": "new-319-16-1-2"
+            },
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-319-17-0",
+              "newText": "new-319-17-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000307",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/회의록/2016/0308.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 308,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2016/0308.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/회의록/2016/0308.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2016/0308.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/관세청/회의록/2016/0308.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000308",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/회의록/2016/0309.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 309,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2016/0309.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/회의록/2016/0309.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2016/0309.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/회의록/2016/0309.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000309",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/회의록/2016/0310.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 310,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2016/0310.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/회의록/2016/0310.csv",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2016/0310.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/회의록/2016/0310.csv",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2016/0310.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/회의록/2016/0310.csv",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000310",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/회의록/2016/0311.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 311,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2016/0311.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/회의록/2016/0311.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2016/0311.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/회의록/2016/0311.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2016/0311.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/소방청/회의록/2016/0311.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000311",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/회의록/2016/0312.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 312,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2016/0312.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양경찰청/회의록/2016/0312.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2016/0312.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/회의록/2016/0312.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-324-1-0",
+              "newText": "new-324-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-324-2-0",
+              "newText": "new-324-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-324-3-0",
+              "newText": "new-324-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-324-4-0",
+              "newText": "new-324-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2016/0312.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/회의록/2016/0312.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-337-15-1",
+              "newText": "new-337-15-1-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-337-16-0",
+              "newText": "new-337-16-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000312",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/회의록/2016/0313.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 313,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2016/0313.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/회의록/2016/0313.csv",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-312-5-0",
+              "newText": "new-312-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-312-6-0",
+              "newText": "new-312-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-312-7-0",
+              "newText": "new-312-7-0-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2016/0313.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/회의록/2016/0313.csv",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-325-4-1",
+              "newText": "new-325-4-1-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-325-5-0",
+              "newText": "new-325-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-325-6-3",
+              "newText": "new-325-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-325-7-2",
+              "newText": "new-325-7-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2016/0313.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/회의록/2016/0313.csv",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-338-19-3",
+              "newText": "new-338-19-3-0"
+            },
+            {
+              "row": 20,
+              "col": 1,
+              "oldText": "old-338-20-1",
+              "newText": "new-338-20-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-338-1-4",
+              "newText": "new-338-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-338-2-2",
+              "newText": "new-338-2-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000313",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/회의록/2016/0314.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 314,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2016/0314.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/회의록/2016/0314.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-313-2-1",
+              "newText": "new-313-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-313-3-0",
+              "newText": "new-313-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-313-4-3",
+              "newText": "new-313-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-313-5-2",
+              "newText": "new-313-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2016/0314.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/회의록/2016/0314.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-326-7-1",
+              "newText": "new-326-7-1-0"
+            },
+            {
+              "row": 8,
+              "col": 4,
+              "oldText": "old-326-8-4",
+              "newText": "new-326-8-4-1"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-326-1-2",
+              "newText": "new-326-1-2-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-326-2-0",
+              "newText": "new-326-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2016/0314.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/회의록/2016/0314.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-339-4-3",
+              "newText": "new-339-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-339-5-0",
+              "newText": "new-339-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-339-6-3",
+              "newText": "new-339-6-3-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000314",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/회의록/2016/0315.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 315,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2016/0315.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/회의록/2016/0315.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-314-3-4",
+              "newText": "new-314-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-314-4-2",
+              "newText": "new-314-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-314-5-0",
+              "newText": "new-314-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-314-6-3",
+              "newText": "new-314-6-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2016/0315.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/회의록/2016/0315.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-327-4-3",
+              "newText": "new-327-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-327-5-0",
+              "newText": "new-327-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-327-6-3",
+              "newText": "new-327-6-3-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2016/0315.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/회의록/2016/0315.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000315",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/회의록/2016/0316.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 316,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2016/0316.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/회의록/2016/0316.csv",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2016/0316.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/중소벤처기업부/회의록/2016/0316.csv",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2016/0316.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/회의록/2016/0316.csv",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000316",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/회의록/2016/0317.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 317,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2016/0317.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/회의록/2016/0317.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2016/0317.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/회의록/2016/0317.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2016/0317.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/회의록/2016/0317.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000317",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/회의록/2016/0318.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 318,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2016/0318.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/회의록/2016/0318.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2016/0318.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/회의록/2016/0318.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2016/0318.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/회의록/2016/0318.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000318",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/회의록/2016/0319.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 319,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2016/0319.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/회의록/2016/0319.csv",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2016/0319.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/회의록/2016/0319.csv",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2016/0319.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/환경부/회의록/2016/0319.csv",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000319",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/회의록/2016/0320.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "회의록",
+    "year": 2016,
+    "serial": 320,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2016/0320.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양수산부/회의록/2016/0320.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2016/0320.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/회의록/2016/0320.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-332-11-2",
+              "newText": "new-332-11-2-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-332-12-0",
+              "newText": "new-332-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-332-13-3",
+              "newText": "new-332-13-3-2"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-332-14-1",
+              "newText": "new-332-14-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2016/0320.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/회의록/2016/0320.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-345-6-3",
+              "newText": "new-345-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-345-7-0",
+              "newText": "new-345-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-345-8-3",
+              "newText": "new-345-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-345-9-0",
+              "newText": "new-345-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000320",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/계약서/2016/0321.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 321,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2016/0321.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/계약서/2016/0321.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 17,
+              "col": 0,
+              "oldText": "old-320-17-0",
+              "newText": "new-320-17-0-0"
+            },
+            {
+              "row": 18,
+              "col": 3,
+              "oldText": "old-320-18-3",
+              "newText": "new-320-18-3-1"
+            },
+            {
+              "row": 19,
+              "col": 1,
+              "oldText": "old-320-19-1",
+              "newText": "new-320-19-1-2"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-320-1-4",
+              "newText": "new-320-1-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2016/0321.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/계약서/2016/0321.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-333-4-3",
+              "newText": "new-333-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-333-5-0",
+              "newText": "new-333-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-333-6-3",
+              "newText": "new-333-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-333-7-0",
+              "newText": "new-333-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2016/0321.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/계약서/2016/0321.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-346-6-3",
+              "newText": "new-346-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 6,
+              "oldText": "old-346-7-6",
+              "newText": "new-346-7-6-1"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-346-8-2",
+              "newText": "new-346-8-2-2"
+            },
+            {
+              "row": 9,
+              "col": 5,
+              "oldText": "old-346-9-5",
+              "newText": "new-346-9-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0005.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0005.json
@@ -1,0 +1,15151 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000321",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/계약서/2016/0322.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 322,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2016/0322.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/계약서/2016/0322.csv",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-321-2-3",
+              "newText": "new-321-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-321-3-0",
+              "newText": "new-321-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-321-4-3",
+              "newText": "new-321-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-321-5-0",
+              "newText": "new-321-5-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2016/0322.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/계약서/2016/0322.csv",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-334-15-5",
+              "newText": "new-334-15-5-0"
+            },
+            {
+              "row": 16,
+              "col": 1,
+              "oldText": "old-334-16-1",
+              "newText": "new-334-16-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-334-1-4",
+              "newText": "new-334-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-334-2-0",
+              "newText": "new-334-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2016/0322.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/계약서/2016/0322.csv",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-347-12-3",
+              "newText": "new-347-12-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-347-1-6",
+              "newText": "new-347-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-347-2-1",
+              "newText": "new-347-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-347-3-4",
+              "newText": "new-347-3-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000322",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/계약서/2016/0323.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 323,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2016/0323.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/계약서/2016/0323.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-322-8-0",
+              "newText": "new-322-8-0-0"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-322-9-3",
+              "newText": "new-322-9-3-1"
+            },
+            {
+              "row": 10,
+              "col": 6,
+              "oldText": "old-322-10-6",
+              "newText": "new-322-10-6-2"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-322-11-2",
+              "newText": "new-322-11-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2016/0323.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/계약서/2016/0323.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 13,
+              "col": 7,
+              "oldText": "old-335-13-7",
+              "newText": "new-335-13-7-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-335-14-2",
+              "newText": "new-335-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-335-15-5",
+              "newText": "new-335-15-5-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-335-16-0",
+              "newText": "new-335-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2016/0323.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/계약서/2016/0323.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000323",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/계약서/2016/0324.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 324,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2016/0324.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/계약서/2016/0324.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2016/0324.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/대법원/계약서/2016/0324.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2016/0324.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/계약서/2016/0324.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2016/0324.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/계약서/2016/0324.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000324",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/계약서/2016/0325.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 325,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2016/0325.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/계약서/2016/0325.csv",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2016/0325.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/계약서/2016/0325.csv",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2016/0325.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/계약서/2016/0325.csv",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2016/0325.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/계약서/2016/0325.csv",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000325",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/계약서/2016/0326.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 326,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2016/0326.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/계약서/2016/0326.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2016/0326.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/계약서/2016/0326.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2016/0326.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/계약서/2016/0326.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2016/0326.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/계약서/2016/0326.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000326",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/계약서/2016/0327.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 327,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2016/0327.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/계약서/2016/0327.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2016/0327.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/계약서/2016/0327.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2016/0327.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/계약서/2016/0327.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2016/0327.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/계약서/2016/0327.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-365-2-5",
+              "newText": "new-365-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-365-3-0",
+              "newText": "new-365-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-365-4-3",
+              "newText": "new-365-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-365-5-6",
+              "newText": "new-365-5-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000327",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/계약서/2016/0328.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 328,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2016/0328.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국토교통부/계약서/2016/0328.csv",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2016/0328.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/계약서/2016/0328.csv",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-340-1-4",
+              "newText": "new-340-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-340-2-0",
+              "newText": "new-340-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-340-3-3",
+              "newText": "new-340-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 6,
+              "oldText": "old-340-4-6",
+              "newText": "new-340-4-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2016/0328.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/계약서/2016/0328.csv",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-353-12-1",
+              "newText": "new-353-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-353-13-4",
+              "newText": "new-353-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-353-14-7",
+              "newText": "new-353-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-353-15-2",
+              "newText": "new-353-15-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2016/0328.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/계약서/2016/0328.csv",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-366-3-0",
+              "newText": "new-366-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-366-4-0",
+              "newText": "new-366-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-366-5-0",
+              "newText": "new-366-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-366-6-0",
+              "newText": "new-366-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000328",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/계약서/2016/0329.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 329,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2016/0329.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/계약서/2016/0329.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-328-9-6",
+              "newText": "new-328-9-6-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-328-10-2",
+              "newText": "new-328-10-2-1"
+            },
+            {
+              "row": 1,
+              "col": 5,
+              "oldText": "old-328-1-5",
+              "newText": "new-328-1-5-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-328-2-1",
+              "newText": "new-328-2-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2016/0329.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/계약서/2016/0329.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-341-6-5",
+              "newText": "new-341-6-5-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-341-1-0",
+              "newText": "new-341-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-341-2-3",
+              "newText": "new-341-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 6,
+              "oldText": "old-341-3-6",
+              "newText": "new-341-3-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2016/0329.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/계약서/2016/0329.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-354-13-0",
+              "newText": "new-354-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-354-14-0",
+              "newText": "new-354-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-354-15-0",
+              "newText": "new-354-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-354-16-0",
+              "newText": "new-354-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2016/0329.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/계약서/2016/0329.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-367-8-3",
+              "newText": "new-367-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-367-9-2",
+              "newText": "new-367-9-2-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-367-10-1",
+              "newText": "new-367-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-367-11-0",
+              "newText": "new-367-11-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000329",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/계약서/2016/0330.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 330,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2016/0330.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/계약서/2016/0330.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 11,
+              "col": 1,
+              "oldText": "old-329-11-1",
+              "newText": "new-329-11-1-0"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-329-1-4",
+              "newText": "new-329-1-4-1"
+            },
+            {
+              "row": 2,
+              "col": 7,
+              "oldText": "old-329-2-7",
+              "newText": "new-329-2-7-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-329-3-2",
+              "newText": "new-329-3-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2016/0330.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/계약서/2016/0330.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-342-7-0",
+              "newText": "new-342-7-0-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-342-1-0",
+              "newText": "new-342-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-342-2-0",
+              "newText": "new-342-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-342-3-0",
+              "newText": "new-342-3-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2016/0330.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/계약서/2016/0330.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 16,
+              "col": 3,
+              "oldText": "old-355-16-3",
+              "newText": "new-355-16-3-0"
+            },
+            {
+              "row": 17,
+              "col": 2,
+              "oldText": "old-355-17-2",
+              "newText": "new-355-17-2-1"
+            },
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-355-18-1",
+              "newText": "new-355-18-1-2"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-355-19-0",
+              "newText": "new-355-19-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2016/0330.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/계약서/2016/0330.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-368-1-3",
+              "newText": "new-368-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-368-2-1",
+              "newText": "new-368-2-1-1"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-368-3-4",
+              "newText": "new-368-3-4-2"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-368-4-2",
+              "newText": "new-368-4-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000330",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/계약서/2016/0331.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 331,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2016/0331.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/계약서/2016/0331.csv",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-330-7-0",
+              "newText": "new-330-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-330-8-0",
+              "newText": "new-330-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-330-9-0",
+              "newText": "new-330-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-330-10-0",
+              "newText": "new-330-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2016/0331.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/계약서/2016/0331.csv",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-343-8-3",
+              "newText": "new-343-8-3-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-343-1-2",
+              "newText": "new-343-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-343-2-1",
+              "newText": "new-343-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-343-3-0",
+              "newText": "new-343-3-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2016/0331.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/계약서/2016/0331.csv",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2016/0331.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/기획재정부/계약서/2016/0331.csv",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000331",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/계약서/2016/0332.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 332,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2016/0332.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/계약서/2016/0332.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2016/0332.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/공정거래위원회/계약서/2016/0332.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2016/0332.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/계약서/2016/0332.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2016/0332.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/계약서/2016/0332.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000332",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/계약서/2016/0333.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 333,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2016/0333.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/계약서/2016/0333.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2016/0333.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/계약서/2016/0333.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2016/0333.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/계약서/2016/0333.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2016/0333.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/계약서/2016/0333.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000333",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/계약서/2016/0334.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 334,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2016/0334.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/계약서/2016/0334.csv",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2016/0334.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/계약서/2016/0334.csv",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2016/0334.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/계약서/2016/0334.csv",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2016/0334.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/계약서/2016/0334.csv",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000334",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/계약서/2016/0335.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 335,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2016/0335.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/계약서/2016/0335.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2016/0335.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/계약서/2016/0335.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2016/0335.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/개인정보보호위원회/계약서/2016/0335.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2016/0335.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/계약서/2016/0335.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-373-17-1",
+              "newText": "new-373-17-1-0"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-373-18-0",
+              "newText": "new-373-18-0-1"
+            },
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-373-19-3",
+              "newText": "new-373-19-3-2"
+            },
+            {
+              "row": 20,
+              "col": 2,
+              "oldText": "old-373-20-2",
+              "newText": "new-373-20-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000335",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/계약서/2016/0336.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 336,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2016/0336.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/계약서/2016/0336.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2016/0336.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/계약서/2016/0336.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-348-11-0",
+              "newText": "new-348-11-0-0"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-348-12-0",
+              "newText": "new-348-12-0-1"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-348-13-0",
+              "newText": "new-348-13-0-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-348-1-0",
+              "newText": "new-348-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2016/0336.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/계약서/2016/0336.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-361-2-1",
+              "newText": "new-361-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-361-3-0",
+              "newText": "new-361-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-361-4-3",
+              "newText": "new-361-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-361-5-2",
+              "newText": "new-361-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2016/0336.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/계약서/2016/0336.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-374-5-4",
+              "newText": "new-374-5-4-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-374-1-2",
+              "newText": "new-374-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-374-2-0",
+              "newText": "new-374-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-374-3-3",
+              "newText": "new-374-3-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000336",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/계약서/2016/0337.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 337,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2016/0337.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/계약서/2016/0337.csv",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-336-13-0",
+              "newText": "new-336-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-336-14-0",
+              "newText": "new-336-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-336-15-0",
+              "newText": "new-336-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-336-16-0",
+              "newText": "new-336-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2016/0337.hwp",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/계약서/2016/0337.csv",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-349-14-1",
+              "newText": "new-349-14-1-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-349-1-0",
+              "newText": "new-349-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-349-2-3",
+              "newText": "new-349-2-3-2"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-349-3-2",
+              "newText": "new-349-3-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2016/0337.hwp",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/계약서/2016/0337.csv",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-362-3-2",
+              "newText": "new-362-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-362-4-0",
+              "newText": "new-362-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-362-5-3",
+              "newText": "new-362-5-3-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-362-6-1",
+              "newText": "new-362-6-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2016/0337.hwp",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/계약서/2016/0337.csv",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-375-4-3",
+              "newText": "new-375-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-375-5-0",
+              "newText": "new-375-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-375-6-3",
+              "newText": "new-375-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-375-1-0",
+              "newText": "new-375-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000337",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/계약서/2016/0338.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 338,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2016/0338.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/계약서/2016/0338.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-337-15-1",
+              "newText": "new-337-15-1-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-337-16-0",
+              "newText": "new-337-16-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2016/0338.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/계약서/2016/0338.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-350-6-0",
+              "newText": "new-350-6-0-0"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-350-7-3",
+              "newText": "new-350-7-3-1"
+            },
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-350-8-1",
+              "newText": "new-350-8-1-2"
+            },
+            {
+              "row": 9,
+              "col": 4,
+              "oldText": "old-350-9-4",
+              "newText": "new-350-9-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2016/0338.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/계약서/2016/0338.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2016/0338.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/계약서/2016/0338.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2016/0338.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/계약서/2016/0338.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000338",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/계약서/2016/0339.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 339,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2016/0339.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/계약서/2016/0339.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2016/0339.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/계약서/2016/0339.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2016/0339.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/계약서/2016/0339.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2016/0339.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/기상청/계약서/2016/0339.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2016/0339.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/계약서/2016/0339.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000339",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/계약서/2016/0340.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 340,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2016/0340.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/계약서/2016/0340.csv",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2016/0340.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/관세청/계약서/2016/0340.csv",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2016/0340.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/계약서/2016/0340.csv",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2016/0340.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/계약서/2016/0340.csv",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2016/0340.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/계약서/2016/0340.csv",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000340",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 341,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/계약서/2016/0341.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/계약서/2016/0341.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/계약서/2016/0341.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/계약서/2016/0341.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2016/0341.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/계약서/2016/0341.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000341",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 342,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/계약서/2016/0342.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/계약서/2016/0342.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/계약서/2016/0342.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/계약서/2016/0342.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2016/0342.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/경찰청/계약서/2016/0342.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000342",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/계약서/2016/0343.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 343,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2016/0343.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/계약서/2016/0343.csv",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2016/0343.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/계약서/2016/0343.csv",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2016/0343.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/소방청/계약서/2016/0343.csv",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2016/0343.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/계약서/2016/0343.csv",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-381-10-3",
+              "newText": "new-381-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-381-11-0",
+              "newText": "new-381-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-381-12-3",
+              "newText": "new-381-12-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-381-1-0",
+              "newText": "new-381-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2016/0343.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/계약서/2016/0343.csv",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-394-3-2",
+              "newText": "new-394-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-394-4-5",
+              "newText": "new-394-4-5-1"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-394-5-1",
+              "newText": "new-394-5-1-2"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-394-6-4",
+              "newText": "new-394-6-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000343",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 344,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양경찰청/계약서/2016/0344.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/계약서/2016/0344.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 21,
+              "col": 1,
+              "oldText": "old-356-21-1",
+              "newText": "new-356-21-1-0"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-356-1-4",
+              "newText": "new-356-1-4-1"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-356-2-2",
+              "newText": "new-356-2-2-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-356-3-0",
+              "newText": "new-356-3-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/계약서/2016/0344.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-369-13-3",
+              "newText": "new-369-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-369-14-0",
+              "newText": "new-369-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-369-15-3",
+              "newText": "new-369-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-369-16-0",
+              "newText": "new-369-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/계약서/2016/0344.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-382-6-4",
+              "newText": "new-382-6-4-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-382-7-0",
+              "newText": "new-382-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-382-8-3",
+              "newText": "new-382-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-382-9-6",
+              "newText": "new-382-9-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2016/0344.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/계약서/2016/0344.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-395-9-3",
+              "newText": "new-395-9-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-395-1-6",
+              "newText": "new-395-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-395-2-1",
+              "newText": "new-395-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-395-3-4",
+              "newText": "new-395-3-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000344",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/계약서/2016/0345.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 345,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2016/0345.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/계약서/2016/0345.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-344-3-4",
+              "newText": "new-344-3-4-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-344-4-2",
+              "newText": "new-344-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-344-5-0",
+              "newText": "new-344-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-344-6-3",
+              "newText": "new-344-6-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2016/0345.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/계약서/2016/0345.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-357-3-3",
+              "newText": "new-357-3-3-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-357-4-0",
+              "newText": "new-357-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-357-5-3",
+              "newText": "new-357-5-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-357-1-0",
+              "newText": "new-357-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2016/0345.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/계약서/2016/0345.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 6,
+              "oldText": "old-370-11-6",
+              "newText": "new-370-11-6-0"
+            },
+            {
+              "row": 12,
+              "col": 2,
+              "oldText": "old-370-12-2",
+              "newText": "new-370-12-2-1"
+            },
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-370-13-5",
+              "newText": "new-370-13-5-2"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-370-14-1",
+              "newText": "new-370-14-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2016/0345.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/계약서/2016/0345.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-383-6-7",
+              "newText": "new-383-6-7-0"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-383-7-2",
+              "newText": "new-383-7-2-1"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-383-8-5",
+              "newText": "new-383-8-5-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-383-9-0",
+              "newText": "new-383-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2016/0345.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/계약서/2016/0345.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-396-7-0",
+              "newText": "new-396-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-396-8-0",
+              "newText": "new-396-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-396-9-0",
+              "newText": "new-396-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-396-10-0",
+              "newText": "new-396-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000345",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/계약서/2016/0346.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 346,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2016/0346.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/계약서/2016/0346.csv",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-345-6-3",
+              "newText": "new-345-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-345-7-0",
+              "newText": "new-345-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-345-8-3",
+              "newText": "new-345-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-345-9-0",
+              "newText": "new-345-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2016/0346.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/계약서/2016/0346.csv",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-358-5-1",
+              "newText": "new-358-5-1-0"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-358-6-4",
+              "newText": "new-358-6-4-1"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-358-1-0",
+              "newText": "new-358-1-0-2"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-358-2-3",
+              "newText": "new-358-2-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2016/0346.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/계약서/2016/0346.csv",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 11,
+              "col": 3,
+              "oldText": "old-371-11-3",
+              "newText": "new-371-11-3-0"
+            },
+            {
+              "row": 12,
+              "col": 6,
+              "oldText": "old-371-12-6",
+              "newText": "new-371-12-6-1"
+            },
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-371-13-1",
+              "newText": "new-371-13-1-2"
+            },
+            {
+              "row": 14,
+              "col": 4,
+              "oldText": "old-371-14-4",
+              "newText": "new-371-14-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2016/0346.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/계약서/2016/0346.csv",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-384-10-0",
+              "newText": "new-384-10-0-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-384-11-0",
+              "newText": "new-384-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-384-12-0",
+              "newText": "new-384-12-0-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-384-13-0",
+              "newText": "new-384-13-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2016/0346.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/계약서/2016/0346.csv",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000346",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 347,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/계약서/2016/0347.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-346-6-3",
+              "newText": "new-346-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 6,
+              "oldText": "old-346-7-6",
+              "newText": "new-346-7-6-1"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-346-8-2",
+              "newText": "new-346-8-2-2"
+            },
+            {
+              "row": 9,
+              "col": 5,
+              "oldText": "old-346-9-5",
+              "newText": "new-346-9-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/계약서/2016/0347.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 3,
+              "col": 7,
+              "oldText": "old-359-3-7",
+              "newText": "new-359-3-7-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-359-4-2",
+              "newText": "new-359-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-359-5-5",
+              "newText": "new-359-5-5-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-359-6-0",
+              "newText": "new-359-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/계약서/2016/0347.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/농촌진흥청/계약서/2016/0347.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2016/0347.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/농촌진흥청/계약서/2016/0347.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000347",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 348,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/계약서/2016/0348.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/중소벤처기업부/계약서/2016/0348.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/계약서/2016/0348.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/계약서/2016/0348.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2016/0348.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/계약서/2016/0348.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000348",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 349,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/계약서/2016/0349.csv",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/계약서/2016/0349.csv",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/계약서/2016/0349.csv",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/계약서/2016/0349.csv",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2016/0349.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/계약서/2016/0349.csv",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000349",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 350,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/계약서/2016/0350.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/계약서/2016/0350.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/계약서/2016/0350.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/계약서/2016/0350.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2016/0350.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/문화체육관광부/계약서/2016/0350.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000350",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/계약서/2016/0351.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 351,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2016/0351.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/계약서/2016/0351.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2016/0351.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/계약서/2016/0351.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2016/0351.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/환경부/계약서/2016/0351.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2016/0351.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/계약서/2016/0351.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 10,
+              "col": 5,
+              "oldText": "old-389-10-5",
+              "newText": "new-389-10-5-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-389-11-0",
+              "newText": "new-389-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-389-12-3",
+              "newText": "new-389-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 6,
+              "oldText": "old-389-13-6",
+              "newText": "new-389-13-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2016/0351.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/계약서/2016/0351.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-402-3-0",
+              "newText": "new-402-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-402-4-0",
+              "newText": "new-402-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-402-5-0",
+              "newText": "new-402-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-402-6-0",
+              "newText": "new-402-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000351",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "계약서",
+    "year": 2016,
+    "serial": 352,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-364-5-0",
+              "newText": "new-364-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-364-6-3",
+              "newText": "new-364-6-3-1"
+            },
+            {
+              "row": 7,
+              "col": 6,
+              "oldText": "old-364-7-6",
+              "newText": "new-364-7-6-2"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-364-8-2",
+              "newText": "new-364-8-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-390-13-0",
+              "newText": "new-390-13-0-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-403-13-3",
+              "newText": "new-403-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-403-14-2",
+              "newText": "new-403-14-2-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2016/0352.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/계약서/2016/0352.csv",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-416-1-1",
+              "newText": "new-416-1-1-0"
+            },
+            {
+              "row": 2,
+              "col": 4,
+              "oldText": "old-416-2-4",
+              "newText": "new-416-2-4-1"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-416-3-2",
+              "newText": "new-416-3-2-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-416-4-0",
+              "newText": "new-416-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000352",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/점검표/2016/0353.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 353,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 2,
+              "oldText": "old-352-13-2",
+              "newText": "new-352-13-2-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-365-2-5",
+              "newText": "new-365-2-5-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-365-3-0",
+              "newText": "new-365-3-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-378-1-0",
+              "newText": "new-378-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-378-2-0",
+              "newText": "new-378-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-378-3-0",
+              "newText": "new-378-3-0-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-391-2-3",
+              "newText": "new-391-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-391-3-2",
+              "newText": "new-391-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-391-4-1",
+              "newText": "new-391-4-1-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-391-5-0",
+              "newText": "new-391-5-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2016/0353.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/점검표/2016/0353.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000353",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 354,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-353-12-1",
+              "newText": "new-353-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-353-13-4",
+              "newText": "new-353-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-353-14-7",
+              "newText": "new-353-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-353-15-2",
+              "newText": "new-353-15-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-366-3-0",
+              "newText": "new-366-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-366-4-0",
+              "newText": "new-366-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-366-5-0",
+              "newText": "new-366-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-366-6-0",
+              "newText": "new-366-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-379-10-3",
+              "newText": "new-379-10-3-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2016/0354.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/행정안전부/점검표/2016/0354.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000354",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/점검표/2016/0355.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 355,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-354-13-0",
+              "newText": "new-354-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-354-14-0",
+              "newText": "new-354-14-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-367-8-3",
+              "newText": "new-367-8-3-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2016/0355.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/점검표/2016/0355.csv",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000355",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/점검표/2016/0356.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 356,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2016/0356.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/점검표/2016/0356.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000356",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/점검표/2016/0357.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 357,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2016/0357.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/점검표/2016/0357.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000357",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/점검표/2016/0358.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 358,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2016/0358.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/점검표/2016/0358.csv",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-422-5-2",
+              "newText": "new-422-5-2-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-422-6-0",
+              "newText": "new-422-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-422-7-3",
+              "newText": "new-422-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-422-8-1",
+              "newText": "new-422-8-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000358",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 359,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-397-2-1",
+              "newText": "new-397-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-397-3-0",
+              "newText": "new-397-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-397-4-3",
+              "newText": "new-397-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-397-5-2",
+              "newText": "new-397-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-410-5-0",
+              "newText": "new-410-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-410-6-3",
+              "newText": "new-410-6-3-1"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-410-7-1",
+              "newText": "new-410-7-1-2"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-410-1-4",
+              "newText": "new-410-1-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2016/0359.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/점검표/2016/0359.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-423-4-3",
+              "newText": "new-423-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-423-5-0",
+              "newText": "new-423-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-423-6-3",
+              "newText": "new-423-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-423-7-0",
+              "newText": "new-423-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000359",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 360,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-372-13-0",
+              "newText": "new-372-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-372-14-0",
+              "newText": "new-372-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-372-15-0",
+              "newText": "new-372-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-372-16-0",
+              "newText": "new-372-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-385-2-1",
+              "newText": "new-385-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-385-3-0",
+              "newText": "new-385-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-385-4-3",
+              "newText": "new-385-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-385-5-2",
+              "newText": "new-385-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-398-3-3",
+              "newText": "new-398-3-3-0"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-398-4-1",
+              "newText": "new-398-4-1-1"
+            },
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-398-5-4",
+              "newText": "new-398-5-4-2"
+            },
+            {
+              "row": 6,
+              "col": 2,
+              "oldText": "old-398-6-2",
+              "newText": "new-398-6-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-411-4-3",
+              "newText": "new-411-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-411-5-0",
+              "newText": "new-411-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-411-6-3",
+              "newText": "new-411-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-411-7-0",
+              "newText": "new-411-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2016/0360.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/점검표/2016/0360.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-424-5-4",
+              "newText": "new-424-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-424-6-0",
+              "newText": "new-424-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-424-7-3",
+              "newText": "new-424-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-424-8-6",
+              "newText": "new-424-8-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000360",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 361,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-360-1-0",
+              "newText": "new-360-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-360-2-0",
+              "newText": "new-360-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-360-3-0",
+              "newText": "new-360-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-360-4-0",
+              "newText": "new-360-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 17,
+              "col": 1,
+              "oldText": "old-373-17-1",
+              "newText": "new-373-17-1-0"
+            },
+            {
+              "row": 18,
+              "col": 0,
+              "oldText": "old-373-18-0",
+              "newText": "new-373-18-0-1"
+            },
+            {
+              "row": 19,
+              "col": 3,
+              "oldText": "old-373-19-3",
+              "newText": "new-373-19-3-2"
+            },
+            {
+              "row": 20,
+              "col": 2,
+              "oldText": "old-373-20-2",
+              "newText": "new-373-20-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-386-13-1",
+              "newText": "new-386-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 4,
+              "oldText": "old-386-14-4",
+              "newText": "new-386-14-4-1"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-386-15-2",
+              "newText": "new-386-15-2-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-386-16-0",
+              "newText": "new-386-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-399-10-3",
+              "newText": "new-399-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-399-11-0",
+              "newText": "new-399-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-399-12-3",
+              "newText": "new-399-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-399-13-0",
+              "newText": "new-399-13-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-412-8-6",
+              "newText": "new-412-8-6-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-412-9-2",
+              "newText": "new-412-9-2-1"
+            },
+            {
+              "row": 1,
+              "col": 5,
+              "oldText": "old-412-1-5",
+              "newText": "new-412-1-5-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-412-2-1",
+              "newText": "new-412-2-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2016/0361.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/점검표/2016/0361.csv",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-425-1-1",
+              "newText": "new-425-1-1-0"
+            },
+            {
+              "row": 2,
+              "col": 4,
+              "oldText": "old-425-2-4",
+              "newText": "new-425-2-4-1"
+            },
+            {
+              "row": 3,
+              "col": 7,
+              "oldText": "old-425-3-7",
+              "newText": "new-425-3-7-2"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-425-4-2",
+              "newText": "new-425-4-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000361",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/점검표/2016/0362.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 362,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-361-2-1",
+              "newText": "new-361-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-361-3-0",
+              "newText": "new-361-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-361-4-3",
+              "newText": "new-361-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-361-5-2",
+              "newText": "new-361-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-374-5-4",
+              "newText": "new-374-5-4-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-374-1-2",
+              "newText": "new-374-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-374-2-0",
+              "newText": "new-374-2-0-2"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-374-3-3",
+              "newText": "new-374-3-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-387-10-3",
+              "newText": "new-387-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-387-11-0",
+              "newText": "new-387-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-387-12-3",
+              "newText": "new-387-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-387-13-0",
+              "newText": "new-387-13-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-400-9-1",
+              "newText": "new-400-9-1-0"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-400-10-4",
+              "newText": "new-400-10-4-1"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-400-11-0",
+              "newText": "new-400-11-0-2"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-400-12-3",
+              "newText": "new-400-12-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2016/0362.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/외교부/점검표/2016/0362.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000362",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 363,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-362-3-2",
+              "newText": "new-362-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-362-4-0",
+              "newText": "new-362-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-362-5-3",
+              "newText": "new-362-5-3-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-362-6-1",
+              "newText": "new-362-6-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-375-4-3",
+              "newText": "new-375-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-375-5-0",
+              "newText": "new-375-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-375-6-3",
+              "newText": "new-375-6-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-375-1-0",
+              "newText": "new-375-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2016/0363.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기획재정부/점검표/2016/0363.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000363",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 364,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2016/0364.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/공정거래위원회/점검표/2016/0364.csv",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000364",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 365,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2016/0365.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/금융위원회/점검표/2016/0365.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000365",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 366,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-430-1-3",
+              "newText": "new-430-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-430-2-6",
+              "newText": "new-430-2-6-1"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-430-3-2",
+              "newText": "new-430-3-2-2"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-430-4-5",
+              "newText": "new-430-4-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2016/0366.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/방송통신위원회/점검표/2016/0366.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000366",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 367,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-405-7-3",
+              "newText": "new-405-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-405-8-0",
+              "newText": "new-405-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-405-9-3",
+              "newText": "new-405-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-405-10-0",
+              "newText": "new-405-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-418-14-5",
+              "newText": "new-418-14-5-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 3,
+              "col": 7,
+              "oldText": "old-431-3-7",
+              "newText": "new-431-3-7-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-431-4-2",
+              "newText": "new-431-4-2-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2016/0367.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/개인정보보호위원회/점검표/2016/0367.csv",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-444-4-0",
+              "newText": "new-444-4-0-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-444-5-0",
+              "newText": "new-444-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-444-6-0",
+              "newText": "new-444-6-0-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000367",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 368,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-380-7-0",
+              "newText": "new-380-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-380-8-3",
+              "newText": "new-380-8-3-1"
+            },
+            {
+              "row": 9,
+              "col": 1,
+              "oldText": "old-380-9-1",
+              "newText": "new-380-9-1-2"
+            },
+            {
+              "row": 10,
+              "col": 4,
+              "oldText": "old-380-10-4",
+              "newText": "new-380-10-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-393-2-3",
+              "newText": "new-393-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-393-3-0",
+              "newText": "new-393-3-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-406-7-0",
+              "newText": "new-406-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-406-8-3",
+              "newText": "new-406-8-3-1"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-406-9-6",
+              "newText": "new-406-9-6-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-419-4-3",
+              "newText": "new-419-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 6,
+              "oldText": "old-419-5-6",
+              "newText": "new-419-5-6-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-419-6-1",
+              "newText": "new-419-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-419-7-4",
+              "newText": "new-419-7-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-432-1-0",
+              "newText": "new-432-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-432-2-0",
+              "newText": "new-432-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-432-3-0",
+              "newText": "new-432-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-432-4-0",
+              "newText": "new-432-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2016/0368.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국민권익위원회/점검표/2016/0368.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-445-6-1",
+              "newText": "new-445-6-1-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000368",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 369,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-368-1-3",
+              "newText": "new-368-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-368-2-1",
+              "newText": "new-368-2-1-1"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-368-3-4",
+              "newText": "new-368-3-4-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-381-10-3",
+              "newText": "new-381-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-381-11-0",
+              "newText": "new-381-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-381-12-3",
+              "newText": "new-381-12-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-381-1-0",
+              "newText": "new-381-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-394-3-2",
+              "newText": "new-394-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-394-4-5",
+              "newText": "new-394-4-5-1"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-394-5-1",
+              "newText": "new-394-5-1-2"
+            },
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-394-6-4",
+              "newText": "new-394-6-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 9,
+              "col": 7,
+              "oldText": "old-407-9-7",
+              "newText": "new-407-9-7-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-407-10-2",
+              "newText": "new-407-10-2-1"
+            },
+            {
+              "row": 11,
+              "col": 5,
+              "oldText": "old-407-11-5",
+              "newText": "new-407-11-5-2"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-407-12-0",
+              "newText": "new-407-12-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-420-13-0",
+              "newText": "new-420-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-420-14-0",
+              "newText": "new-420-14-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-433-5-1",
+              "newText": "new-433-5-1-0"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2016/0369.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국가인권위원회/점검표/2016/0369.csvx",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000369",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/점검표/2016/0370.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 370,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-369-13-3",
+              "newText": "new-369-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-369-14-0",
+              "newText": "new-369-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-369-15-3",
+              "newText": "new-369-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-369-16-0",
+              "newText": "new-369-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 4,
+              "oldText": "old-382-6-4",
+              "newText": "new-382-6-4-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-382-7-0",
+              "newText": "new-382-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-382-8-3",
+              "newText": "new-382-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 6,
+              "oldText": "old-382-9-6",
+              "newText": "new-382-9-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-395-9-3",
+              "newText": "new-395-9-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-395-1-6",
+              "newText": "new-395-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-395-2-1",
+              "newText": "new-395-2-1-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-408-4-0",
+              "newText": "new-408-4-0-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-408-5-0",
+              "newText": "new-408-5-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2016/0370.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/통계청/점검표/2016/0370.csv",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000370",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/점검표/2016/0371.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 371,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 11,
+              "col": 6,
+              "oldText": "old-370-11-6",
+              "newText": "new-370-11-6-0"
+            },
+            {
+              "row": 12,
+              "col": 2,
+              "oldText": "old-370-12-2",
+              "newText": "new-370-12-2-1"
+            },
+            {
+              "row": 13,
+              "col": 5,
+              "oldText": "old-370-13-5",
+              "newText": "new-370-13-5-2"
+            },
+            {
+              "row": 14,
+              "col": 1,
+              "oldText": "old-370-14-1",
+              "newText": "new-370-14-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-383-6-7",
+              "newText": "new-383-6-7-0"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-383-7-2",
+              "newText": "new-383-7-2-1"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-383-8-5",
+              "newText": "new-383-8-5-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2016/0371.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/기상청/점검표/2016/0371.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000371",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/점검표/2016/0372.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 372,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2016/0372.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/관세청/점검표/2016/0372.csvx",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000372",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/점검표/2016/0373.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 373,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2016/0373.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/검찰청/점검표/2016/0373.csv",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000373",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 374,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-438-7-0",
+              "newText": "new-438-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-438-8-0",
+              "newText": "new-438-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-438-9-0",
+              "newText": "new-438-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-438-10-0",
+              "newText": "new-438-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2016/0374.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/경찰청/점검표/2016/0374.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-451-4-3",
+              "newText": "new-451-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-451-5-2",
+              "newText": "new-451-5-2-1"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-451-6-1",
+              "newText": "new-451-6-1-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-451-7-0",
+              "newText": "new-451-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000374",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/점검표/2016/0375.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 375,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-413-4-5",
+              "newText": "new-413-4-5-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-413-5-0",
+              "newText": "new-413-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-413-6-3",
+              "newText": "new-413-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 6,
+              "oldText": "old-413-7-6",
+              "newText": "new-413-7-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-426-1-0",
+              "newText": "new-426-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-426-2-0",
+              "newText": "new-426-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-426-3-0",
+              "newText": "new-426-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-426-4-0",
+              "newText": "new-426-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-439-3-3",
+              "newText": "new-439-3-3-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-439-4-2",
+              "newText": "new-439-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-439-5-1",
+              "newText": "new-439-5-1-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-439-6-0",
+              "newText": "new-439-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2016/0375.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/소방청/점검표/2016/0375.csvx",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-452-3-2",
+              "newText": "new-452-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-452-4-0",
+              "newText": "new-452-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-452-5-3",
+              "newText": "new-452-5-3-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-452-6-1",
+              "newText": "new-452-6-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000375",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 376,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-388-9-3",
+              "newText": "new-388-9-3-0"
+            },
+            {
+              "row": 10,
+              "col": 6,
+              "oldText": "old-388-10-6",
+              "newText": "new-388-10-6-1"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-388-11-2",
+              "newText": "new-388-11-2-2"
+            },
+            {
+              "row": 12,
+              "col": 5,
+              "oldText": "old-388-12-5",
+              "newText": "new-388-12-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 12,
+              "col": 1,
+              "oldText": "old-401-12-1",
+              "newText": "new-401-12-1-0"
+            },
+            {
+              "row": 13,
+              "col": 4,
+              "oldText": "old-401-13-4",
+              "newText": "new-401-13-4-1"
+            },
+            {
+              "row": 14,
+              "col": 7,
+              "oldText": "old-401-14-7",
+              "newText": "new-401-14-7-2"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-401-15-2",
+              "newText": "new-401-15-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-414-8-0",
+              "newText": "new-414-8-0-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-414-9-0",
+              "newText": "new-414-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-414-10-0",
+              "newText": "new-414-10-0-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-414-11-0",
+              "newText": "new-414-11-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-427-1-3",
+              "newText": "new-427-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-427-2-2",
+              "newText": "new-427-2-2-1"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-427-3-1",
+              "newText": "new-427-3-1-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-427-4-0",
+              "newText": "new-427-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-440-1-0",
+              "newText": "new-440-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-440-2-3",
+              "newText": "new-440-2-3-1"
+            },
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-440-3-1",
+              "newText": "new-440-3-1-2"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-440-4-4",
+              "newText": "new-440-4-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2016/0376.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양경찰청/점검표/2016/0376.csv",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-453-6-3",
+              "newText": "new-453-6-3-0"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-453-7-0",
+              "newText": "new-453-7-0-1"
+            },
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-453-8-3",
+              "newText": "new-453-8-3-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-453-9-0",
+              "newText": "new-453-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000376",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/점검표/2016/0377.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 377,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-376-6-5",
+              "newText": "new-376-6-5-0"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-376-7-1",
+              "newText": "new-376-7-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-376-1-4",
+              "newText": "new-376-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-376-2-0",
+              "newText": "new-376-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 10,
+              "col": 5,
+              "oldText": "old-389-10-5",
+              "newText": "new-389-10-5-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-389-11-0",
+              "newText": "new-389-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-389-12-3",
+              "newText": "new-389-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 6,
+              "oldText": "old-389-13-6",
+              "newText": "new-389-13-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-402-3-0",
+              "newText": "new-402-3-0-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-402-4-0",
+              "newText": "new-402-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-402-5-0",
+              "newText": "new-402-5-0-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-402-6-0",
+              "newText": "new-402-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-415-8-3",
+              "newText": "new-415-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 2,
+              "oldText": "old-415-9-2",
+              "newText": "new-415-9-2-1"
+            },
+            {
+              "row": 10,
+              "col": 1,
+              "oldText": "old-415-10-1",
+              "newText": "new-415-10-1-2"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-415-11-0",
+              "newText": "new-415-11-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-428-5-3",
+              "newText": "new-428-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-428-6-1",
+              "newText": "new-428-6-1-1"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-428-7-4",
+              "newText": "new-428-7-4-2"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-428-8-2",
+              "newText": "new-428-8-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-441-1-3",
+              "newText": "new-441-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-441-2-0",
+              "newText": "new-441-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-441-3-3",
+              "newText": "new-441-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-441-4-0",
+              "newText": "new-441-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2016/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/병무청/점검표/2016/0377.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000377",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/점검표/2016/0378.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 378,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-377-2-1",
+              "newText": "new-377-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-377-3-4",
+              "newText": "new-377-3-4-1"
+            },
+            {
+              "row": 4,
+              "col": 7,
+              "oldText": "old-377-4-7",
+              "newText": "new-377-4-7-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-377-5-2",
+              "newText": "new-377-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-390-13-0",
+              "newText": "new-390-13-0-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-390-14-0",
+              "newText": "new-390-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-390-15-0",
+              "newText": "new-390-15-0-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-390-16-0",
+              "newText": "new-390-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-403-13-3",
+              "newText": "new-403-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-403-14-2",
+              "newText": "new-403-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-403-15-1",
+              "newText": "new-403-15-1-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-403-16-0",
+              "newText": "new-403-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 1,
+              "oldText": "old-416-1-1",
+              "newText": "new-416-1-1-0"
+            },
+            {
+              "row": 2,
+              "col": 4,
+              "oldText": "old-416-2-4",
+              "newText": "new-416-2-4-1"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-416-3-2",
+              "newText": "new-416-3-2-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-416-4-0",
+              "newText": "new-416-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2016/0378.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/산림청/점검표/2016/0378.csvx",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000378",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 379,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-378-1-0",
+              "newText": "new-378-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-378-2-0",
+              "newText": "new-378-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-378-3-0",
+              "newText": "new-378-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-378-4-0",
+              "newText": "new-378-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-391-2-3",
+              "newText": "new-391-2-3-0"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-391-3-2",
+              "newText": "new-391-3-2-1"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-391-4-1",
+              "newText": "new-391-4-1-2"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-391-5-0",
+              "newText": "new-391-5-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2016/0379.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/농촌진흥청/점검표/2016/0379.csv",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000379",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 380,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2016/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/중소벤처기업부/점검표/2016/0380.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000380",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 381,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 1,
+          "rowCount": 21,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 4,
+          "rowCount": 17,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 2,
+          "rowCount": 13,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 0,
+          "rowCount": 9,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 3,
+          "rowCount": 22,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2016/0381.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/과학기술정보통신부/점검표/2016/0381.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-471-13-3",
+              "newText": "new-471-13-3-0"
+            },
+            {
+              "row": 14,
+              "col": 0,
+              "oldText": "old-471-14-0",
+              "newText": "new-471-14-0-1"
+            },
+            {
+              "row": 15,
+              "col": 3,
+              "oldText": "old-471-15-3",
+              "newText": "new-471-15-3-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-471-16-0",
+              "newText": "new-471-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000381",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 382,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 2,
+          "rowCount": 22,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 0,
+          "rowCount": 18,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 3,
+          "rowCount": 14,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 1,
+          "rowCount": 10,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-446-6-1",
+              "newText": "new-446-6-1-0"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-446-7-4",
+              "newText": "new-446-7-4-1"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-446-8-2",
+              "newText": "new-446-8-2-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-446-9-0",
+              "newText": "new-446-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 4,
+          "rowCount": 6,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-459-5-3",
+              "newText": "new-459-5-3-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-459-1-0",
+              "newText": "new-459-1-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2016/0382.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/문화체육관광부/점검표/2016/0382.csv",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-472-5-3",
+              "newText": "new-472-5-3-0"
+            },
+            {
+              "row": 6,
+              "col": 6,
+              "oldText": "old-472-6-6",
+              "newText": "new-472-6-6-1"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-472-7-2",
+              "newText": "new-472-7-2-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000382",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/점검표/2016/0383.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 383,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 3,
+          "rowCount": 6,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 1,
+          "rowCount": 19,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-421-8-1",
+              "newText": "new-421-8-1-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-421-9-0",
+              "newText": "new-421-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-421-10-3",
+              "newText": "new-421-10-3-2"
+            },
+            {
+              "row": 11,
+              "col": 2,
+              "oldText": "old-421-11-2",
+              "newText": "new-421-11-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 4,
+          "rowCount": 15,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-434-1-4",
+              "newText": "new-434-1-4-0"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-434-2-2",
+              "newText": "new-434-2-2-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-434-3-0",
+              "newText": "new-434-3-0-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 2,
+          "rowCount": 11,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 8,
+              "col": 3,
+              "oldText": "old-447-8-3",
+              "newText": "new-447-8-3-0"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-447-9-0",
+              "newText": "new-447-9-0-1"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-447-10-3",
+              "newText": "new-447-10-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-447-1-0",
+              "newText": "new-447-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 0,
+          "rowCount": 7,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-460-5-5",
+              "newText": "new-460-5-5-0"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-460-6-1",
+              "newText": "new-460-6-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-460-1-4",
+              "newText": "new-460-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-460-2-0",
+              "newText": "new-460-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2016/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/환경부/점검표/2016/0383.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-473-18-1",
+              "newText": "new-473-18-1-0"
+            },
+            {
+              "row": 19,
+              "col": 4,
+              "oldText": "old-473-19-4",
+              "newText": "new-473-19-4-1"
+            },
+            {
+              "row": 1,
+              "col": 7,
+              "oldText": "old-473-1-7",
+              "newText": "new-473-1-7-2"
+            },
+            {
+              "row": 2,
+              "col": 2,
+              "oldText": "old-473-2-2",
+              "newText": "new-473-2-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000383",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "점검표",
+    "year": 2016,
+    "serial": 384,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-396-7-0",
+              "newText": "new-396-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-396-8-0",
+              "newText": "new-396-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-396-9-0",
+              "newText": "new-396-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-396-10-0",
+              "newText": "new-396-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 4,
+          "rowCount": 7,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-409-2-1",
+              "newText": "new-409-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-409-3-0",
+              "newText": "new-409-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-409-4-3",
+              "newText": "new-409-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-409-5-2",
+              "newText": "new-409-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 2,
+          "rowCount": 20,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-422-5-2",
+              "newText": "new-422-5-2-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-422-6-0",
+              "newText": "new-422-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-422-7-3",
+              "newText": "new-422-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 1,
+              "oldText": "old-422-8-1",
+              "newText": "new-422-8-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 0,
+          "rowCount": 16,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-435-1-3",
+              "newText": "new-435-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-435-2-0",
+              "newText": "new-435-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-435-3-3",
+              "newText": "new-435-3-3-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-435-4-0",
+              "newText": "new-435-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 3,
+          "rowCount": 12,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-448-9-0",
+              "newText": "new-448-9-0-0"
+            },
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-448-10-3",
+              "newText": "new-448-10-3-1"
+            },
+            {
+              "row": 11,
+              "col": 6,
+              "oldText": "old-448-11-6",
+              "newText": "new-448-11-6-2"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-448-1-2",
+              "newText": "new-448-1-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 1,
+          "rowCount": 8,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 7,
+              "col": 5,
+              "oldText": "old-461-7-5",
+              "newText": "new-461-7-5-0"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-461-1-0",
+              "newText": "new-461-1-0-1"
+            },
+            {
+              "row": 2,
+              "col": 3,
+              "oldText": "old-461-2-3",
+              "newText": "new-461-2-3-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2016/0384.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/해양수산부/점검표/2016/0384.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 15,
+              "col": 0,
+              "oldText": "old-474-15-0",
+              "newText": "new-474-15-0-0"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-474-16-0",
+              "newText": "new-474-16-0-1"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000384",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/고시/2017/0385.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 385,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-384-10-0",
+              "newText": "new-384-10-0-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-384-11-0",
+              "newText": "new-384-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 0,
+              "oldText": "old-384-12-0",
+              "newText": "new-384-12-0-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-384-13-0",
+              "newText": "new-384-13-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-397-2-1",
+              "newText": "new-397-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-397-3-0",
+              "newText": "new-397-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-397-4-3",
+              "newText": "new-397-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-397-5-2",
+              "newText": "new-397-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 0,
+          "rowCount": 8,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-410-5-0",
+              "newText": "new-410-5-0-0"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-410-6-3",
+              "newText": "new-410-6-3-1"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-410-7-1",
+              "newText": "new-410-7-1-2"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-410-1-4",
+              "newText": "new-410-1-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 3,
+          "rowCount": 21,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-423-4-3",
+              "newText": "new-423-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-423-5-0",
+              "newText": "new-423-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-423-6-3",
+              "newText": "new-423-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-423-7-0",
+              "newText": "new-423-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 1,
+          "rowCount": 17,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-436-5-2",
+              "newText": "new-436-5-2-0"
+            },
+            {
+              "row": 6,
+              "col": 5,
+              "oldText": "old-436-6-5",
+              "newText": "new-436-6-5-1"
+            },
+            {
+              "row": 7,
+              "col": 1,
+              "oldText": "old-436-7-1",
+              "newText": "new-436-7-1-2"
+            },
+            {
+              "row": 8,
+              "col": 4,
+              "oldText": "old-436-8-4",
+              "newText": "new-436-8-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 4,
+          "rowCount": 13,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-449-6-1",
+              "newText": "new-449-6-1-0"
+            },
+            {
+              "row": 7,
+              "col": 4,
+              "oldText": "old-449-7-4",
+              "newText": "new-449-7-4-1"
+            },
+            {
+              "row": 8,
+              "col": 7,
+              "oldText": "old-449-8-7",
+              "newText": "new-449-8-7-2"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 2,
+          "rowCount": 9,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2017/0385.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/법제처/고시/2017/0385.csv",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0006.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0006.json
@@ -1,0 +1,10025 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000385",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 386,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-385-2-1",
+              "newText": "new-385-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-385-3-0",
+              "newText": "new-385-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-385-4-3",
+              "newText": "new-385-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-385-5-2",
+              "newText": "new-385-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 3,
+              "oldText": "old-398-3-3",
+              "newText": "new-398-3-3-0"
+            },
+            {
+              "row": 4,
+              "col": 1,
+              "oldText": "old-398-4-1",
+              "newText": "new-398-4-1-1"
+            },
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-398-5-4",
+              "newText": "new-398-5-4-2"
+            },
+            {
+              "row": 6,
+              "col": 2,
+              "oldText": "old-398-6-2",
+              "newText": "new-398-6-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 1,
+          "rowCount": 9,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-411-4-3",
+              "newText": "new-411-4-3-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-411-5-0",
+              "newText": "new-411-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-411-6-3",
+              "newText": "new-411-6-3-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-411-7-0",
+              "newText": "new-411-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 4,
+          "rowCount": 22,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 5,
+              "col": 4,
+              "oldText": "old-424-5-4",
+              "newText": "new-424-5-4-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-424-6-0",
+              "newText": "new-424-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-424-7-3",
+              "newText": "new-424-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 6,
+              "oldText": "old-424-8-6",
+              "newText": "new-424-8-6-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 2,
+          "rowCount": 18,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 0,
+          "rowCount": 14,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 3,
+          "rowCount": 10,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2017/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/행정안전부/고시/2017/0386.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000386",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/고시/2017/0387.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 387,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 1,
+          "rowCount": 18,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 13,
+              "col": 1,
+              "oldText": "old-386-13-1",
+              "newText": "new-386-13-1-0"
+            },
+            {
+              "row": 14,
+              "col": 4,
+              "oldText": "old-386-14-4",
+              "newText": "new-386-14-4-1"
+            },
+            {
+              "row": 15,
+              "col": 2,
+              "oldText": "old-386-15-2",
+              "newText": "new-386-15-2-2"
+            },
+            {
+              "row": 16,
+              "col": 0,
+              "oldText": "old-386-16-0",
+              "newText": "new-386-16-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 4,
+          "rowCount": 14,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 10,
+              "col": 3,
+              "oldText": "old-399-10-3",
+              "newText": "new-399-10-3-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-399-11-0",
+              "newText": "new-399-11-0-1"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-399-12-3",
+              "newText": "new-399-12-3-2"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-399-13-0",
+              "newText": "new-399-13-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 2,
+          "rowCount": 10,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 0,
+          "rowCount": 6,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 3,
+          "rowCount": 19,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 1,
+          "rowCount": 15,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 4,
+          "rowCount": 11,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2017/0387.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/국세청/고시/2017/0387.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000387",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/고시/2017/0388.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 388,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 2,
+          "rowCount": 19,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 0,
+          "rowCount": 15,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 3,
+          "rowCount": 11,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 1,
+          "rowCount": 7,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 4,
+          "rowCount": 20,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 2,
+          "rowCount": 16,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 0,
+          "rowCount": 12,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2017/0388.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/대법원/고시/2017/0388.csv",
+          "table": 3,
+          "rowCount": 8,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000388",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/고시/2017/0389.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 389,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 3,
+          "rowCount": 20,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 1,
+          "rowCount": 16,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 4,
+          "rowCount": 12,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 2,
+          "rowCount": 8,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 0,
+          "rowCount": 21,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 3,
+          "rowCount": 17,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 1,
+          "rowCount": 13,
+          "colCount": 7,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2017/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/특허청/고시/2017/0389.csvx",
+          "table": 4,
+          "rowCount": 9,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 8,
+              "col": 7,
+              "oldText": "old-479-8-7",
+              "newText": "new-479-8-7-0"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-479-1-2",
+              "newText": "new-479-1-2-1"
+            },
+            {
+              "row": 2,
+              "col": 5,
+              "oldText": "old-479-2-5",
+              "newText": "new-479-2-5-2"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-479-3-0",
+              "newText": "new-479-3-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000389",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/고시/2017/0390.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 390,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 4,
+          "rowCount": 21,
+          "colCount": 8,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 2,
+          "rowCount": 17,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 0,
+          "rowCount": 13,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 3,
+          "rowCount": 9,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 1,
+          "rowCount": 22,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 4,
+          "rowCount": 18,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 13,
+              "col": 6,
+              "oldText": "old-454-13-6",
+              "newText": "new-454-13-6-0"
+            },
+            {
+              "row": 14,
+              "col": 2,
+              "oldText": "old-454-14-2",
+              "newText": "new-454-14-2-1"
+            },
+            {
+              "row": 15,
+              "col": 5,
+              "oldText": "old-454-15-5",
+              "newText": "new-454-15-5-2"
+            },
+            {
+              "row": 16,
+              "col": 1,
+              "oldText": "old-454-16-1",
+              "newText": "new-454-16-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 2,
+          "rowCount": 14,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 13,
+              "col": 3,
+              "oldText": "old-467-13-3",
+              "newText": "new-467-13-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-467-1-6",
+              "newText": "new-467-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-467-2-1",
+              "newText": "new-467-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-467-3-4",
+              "newText": "new-467-3-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2017/0390.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/교육부/고시/2017/0390.csvx",
+          "table": 0,
+          "rowCount": 10,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-480-4-0",
+              "newText": "new-480-4-0-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-480-5-0",
+              "newText": "new-480-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-480-6-0",
+              "newText": "new-480-6-0-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-480-7-0",
+              "newText": "new-480-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000390",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/고시/2017/0391.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 391,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 0,
+          "rowCount": 22,
+          "colCount": 3,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 3,
+          "rowCount": 18,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 1,
+          "rowCount": 14,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 4,
+          "rowCount": 10,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-429-7-3",
+              "newText": "new-429-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-429-8-0",
+              "newText": "new-429-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-429-9-3",
+              "newText": "new-429-9-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-429-1-0",
+              "newText": "new-429-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 2,
+          "rowCount": 6,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 3,
+              "col": 1,
+              "oldText": "old-442-3-1",
+              "newText": "new-442-3-1-0"
+            },
+            {
+              "row": 4,
+              "col": 4,
+              "oldText": "old-442-4-4",
+              "newText": "new-442-4-4-1"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-442-5-0",
+              "newText": "new-442-5-0-2"
+            },
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-442-1-3",
+              "newText": "new-442-1-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 0,
+          "rowCount": 19,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 7,
+              "oldText": "old-455-6-7",
+              "newText": "new-455-6-7-0"
+            },
+            {
+              "row": 7,
+              "col": 2,
+              "oldText": "old-455-7-2",
+              "newText": "new-455-7-2-1"
+            },
+            {
+              "row": 8,
+              "col": 5,
+              "oldText": "old-455-8-5",
+              "newText": "new-455-8-5-2"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-455-9-0",
+              "newText": "new-455-9-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 3,
+          "rowCount": 15,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-468-7-0",
+              "newText": "new-468-7-0-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-468-8-0",
+              "newText": "new-468-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 0,
+              "oldText": "old-468-9-0",
+              "newText": "new-468-9-0-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-468-10-0",
+              "newText": "new-468-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2017/0391.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/보건복지부/고시/2017/0391.csv",
+          "table": 1,
+          "rowCount": 11,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-481-2-1",
+              "newText": "new-481-2-1-0"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-481-3-0",
+              "newText": "new-481-3-0-1"
+            },
+            {
+              "row": 4,
+              "col": 3,
+              "oldText": "old-481-4-3",
+              "newText": "new-481-4-3-2"
+            },
+            {
+              "row": 5,
+              "col": 2,
+              "oldText": "old-481-5-2",
+              "newText": "new-481-5-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000391",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 392,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 1,
+          "rowCount": 6,
+          "colCount": 4,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 4,
+          "rowCount": 19,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 9,
+              "col": 4,
+              "oldText": "old-404-9-4",
+              "newText": "new-404-9-4-0"
+            },
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-404-10-2",
+              "newText": "new-404-10-2-1"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-404-11-0",
+              "newText": "new-404-11-0-2"
+            },
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-404-12-3",
+              "newText": "new-404-12-3-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 2,
+          "rowCount": 15,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 12,
+              "col": 3,
+              "oldText": "old-417-12-3",
+              "newText": "new-417-12-3-0"
+            },
+            {
+              "row": 13,
+              "col": 0,
+              "oldText": "old-417-13-0",
+              "newText": "new-417-13-0-1"
+            },
+            {
+              "row": 14,
+              "col": 3,
+              "oldText": "old-417-14-3",
+              "newText": "new-417-14-3-2"
+            },
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-417-1-0",
+              "newText": "new-417-1-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 0,
+          "rowCount": 11,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-430-1-3",
+              "newText": "new-430-1-3-0"
+            },
+            {
+              "row": 2,
+              "col": 6,
+              "oldText": "old-430-2-6",
+              "newText": "new-430-2-6-1"
+            },
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-430-3-2",
+              "newText": "new-430-3-2-2"
+            },
+            {
+              "row": 4,
+              "col": 5,
+              "oldText": "old-430-4-5",
+              "newText": "new-430-4-5-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 3,
+          "rowCount": 7,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 6,
+              "col": 3,
+              "oldText": "old-443-6-3",
+              "newText": "new-443-6-3-0"
+            },
+            {
+              "row": 1,
+              "col": 6,
+              "oldText": "old-443-1-6",
+              "newText": "new-443-1-6-1"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-443-2-1",
+              "newText": "new-443-2-1-2"
+            },
+            {
+              "row": 3,
+              "col": 4,
+              "oldText": "old-443-3-4",
+              "newText": "new-443-3-4-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 1,
+          "rowCount": 20,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 1,
+              "col": 0,
+              "oldText": "old-456-1-0",
+              "newText": "new-456-1-0-0"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-456-2-0",
+              "newText": "new-456-2-0-1"
+            },
+            {
+              "row": 3,
+              "col": 0,
+              "oldText": "old-456-3-0",
+              "newText": "new-456-3-0-2"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-456-4-0",
+              "newText": "new-456-4-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 4,
+          "rowCount": 16,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 5,
+              "col": 1,
+              "oldText": "old-469-5-1",
+              "newText": "new-469-5-1-0"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-469-6-0",
+              "newText": "new-469-6-0-1"
+            },
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-469-7-3",
+              "newText": "new-469-7-3-2"
+            },
+            {
+              "row": 8,
+              "col": 2,
+              "oldText": "old-469-8-2",
+              "newText": "new-469-8-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2017/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/국토교통부/고시/2017/0392.csvx",
+          "table": 2,
+          "rowCount": 12,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 10,
+              "col": 2,
+              "oldText": "old-482-10-2",
+              "newText": "new-482-10-2-0"
+            },
+            {
+              "row": 11,
+              "col": 0,
+              "oldText": "old-482-11-0",
+              "newText": "new-482-11-0-1"
+            },
+            {
+              "row": 1,
+              "col": 3,
+              "oldText": "old-482-1-3",
+              "newText": "new-482-1-3-2"
+            },
+            {
+              "row": 2,
+              "col": 1,
+              "oldText": "old-482-2-1",
+              "newText": "new-482-2-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000392",
+    "command": "csv-to-table",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-table",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 393,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 2,
+          "rowCount": 7,
+          "colCount": 5,
+          "changed": [
+            {
+              "row": 3,
+              "col": 2,
+              "oldText": "old-392-3-2",
+              "newText": "new-392-3-2-0"
+            },
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-392-4-0",
+              "newText": "new-392-4-0-1"
+            },
+            {
+              "row": 5,
+              "col": 3,
+              "oldText": "old-392-5-3",
+              "newText": "new-392-5-3-2"
+            },
+            {
+              "row": 6,
+              "col": 1,
+              "oldText": "old-392-6-1",
+              "newText": "new-392-6-1-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 0,
+          "rowCount": 20,
+          "colCount": 6,
+          "changed": [
+            {
+              "row": 7,
+              "col": 3,
+              "oldText": "old-405-7-3",
+              "newText": "new-405-7-3-0"
+            },
+            {
+              "row": 8,
+              "col": 0,
+              "oldText": "old-405-8-0",
+              "newText": "new-405-8-0-1"
+            },
+            {
+              "row": 9,
+              "col": 3,
+              "oldText": "old-405-9-3",
+              "newText": "new-405-9-3-2"
+            },
+            {
+              "row": 10,
+              "col": 0,
+              "oldText": "old-405-10-0",
+              "newText": "new-405-10-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 3,
+          "rowCount": 16,
+          "colCount": 7,
+          "changed": [
+            {
+              "row": 14,
+              "col": 5,
+              "oldText": "old-418-14-5",
+              "newText": "new-418-14-5-0"
+            },
+            {
+              "row": 15,
+              "col": 1,
+              "oldText": "old-418-15-1",
+              "newText": "new-418-15-1-1"
+            },
+            {
+              "row": 1,
+              "col": 4,
+              "oldText": "old-418-1-4",
+              "newText": "new-418-1-4-2"
+            },
+            {
+              "row": 2,
+              "col": 0,
+              "oldText": "old-418-2-0",
+              "newText": "new-418-2-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 1,
+          "rowCount": 12,
+          "colCount": 8,
+          "changed": [
+            {
+              "row": 3,
+              "col": 7,
+              "oldText": "old-431-3-7",
+              "newText": "new-431-3-7-0"
+            },
+            {
+              "row": 4,
+              "col": 2,
+              "oldText": "old-431-4-2",
+              "newText": "new-431-4-2-1"
+            },
+            {
+              "row": 5,
+              "col": 5,
+              "oldText": "old-431-5-5",
+              "newText": "new-431-5-5-2"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-431-6-0",
+              "newText": "new-431-6-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 4,
+          "rowCount": 8,
+          "colCount": 3,
+          "changed": [
+            {
+              "row": 4,
+              "col": 0,
+              "oldText": "old-444-4-0",
+              "newText": "new-444-4-0-0"
+            },
+            {
+              "row": 5,
+              "col": 0,
+              "oldText": "old-444-5-0",
+              "newText": "new-444-5-0-1"
+            },
+            {
+              "row": 6,
+              "col": 0,
+              "oldText": "old-444-6-0",
+              "newText": "new-444-6-0-2"
+            },
+            {
+              "row": 7,
+              "col": 0,
+              "oldText": "old-444-7-0",
+              "newText": "new-444-7-0-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 2,
+          "rowCount": 21,
+          "colCount": 4,
+          "changed": [
+            {
+              "row": 18,
+              "col": 1,
+              "oldText": "old-457-18-1",
+              "newText": "new-457-18-1-0"
+            },
+            {
+              "row": 19,
+              "col": 0,
+              "oldText": "old-457-19-0",
+              "newText": "new-457-19-0-1"
+            },
+            {
+              "row": 20,
+              "col": 3,
+              "oldText": "old-457-20-3",
+              "newText": "new-457-20-3-2"
+            },
+            {
+              "row": 1,
+              "col": 2,
+              "oldText": "old-457-1-2",
+              "newText": "new-457-1-2-3"
+            }
+          ],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 0,
+          "rowCount": 17,
+          "colCount": 5,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2017/0393.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "csv": "samples/gov/고용노동부/고시/2017/0393.csvx",
+          "table": 3,
+          "rowCount": 13,
+          "colCount": 6,
+          "changed": [],
+          "changedPages": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000393",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/고시/2017/0394.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 394,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2017/0394.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/고시/2017/0394.hwp",
+          "right": "out/v-bon/외교부/고시/2017/0394.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2017/0394.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/고시/2017/0394.hwp",
+          "right": "out/v-bon/외교부/고시/2017/0394.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000394",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/고시/2017/0395.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 395,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2017/0395.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/고시/2017/0395.hwpx",
+          "right": "out/v-bon/기획재정부/고시/2017/0395.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2017/0395.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/기획재정부/고시/2017/0395.hwpx",
+          "right": "out/v-bon/기획재정부/고시/2017/0395.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000395",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/고시/2017/0396.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 396,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2017/0396.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/공정거래위원회/고시/2017/0396.hwpx",
+          "right": "out/v-bon/공정거래위원회/고시/2017/0396.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2017/0396.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/공정거래위원회/고시/2017/0396.hwpx",
+          "right": "out/v-bon/공정거래위원회/고시/2017/0396.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000396",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/고시/2017/0397.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 397,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2017/0397.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/고시/2017/0397.hwp",
+          "right": "out/v-bon/금융위원회/고시/2017/0397.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 1,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2017/0397.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/고시/2017/0397.hwp",
+          "right": "out/v-bon/금융위원회/고시/2017/0397.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000397",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/고시/2017/0398.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 398,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2017/0398.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/방송통신위원회/고시/2017/0398.hwpx",
+          "right": "out/v-bon/방송통신위원회/고시/2017/0398.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2017/0398.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/방송통신위원회/고시/2017/0398.hwpx",
+          "right": "out/v-bon/방송통신위원회/고시/2017/0398.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000398",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/고시/2017/0399.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 399,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2017/0399.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/개인정보보호위원회/고시/2017/0399.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/고시/2017/0399.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2017/0399.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/개인정보보호위원회/고시/2017/0399.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/고시/2017/0399.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000399",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/고시/2017/0400.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 400,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2017/0400.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국민권익위원회/고시/2017/0400.hwp",
+          "right": "out/v-bon/국민권익위원회/고시/2017/0400.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2017/0400.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/고시/2017/0400.hwp",
+          "right": "out/v-bon/국민권익위원회/고시/2017/0400.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000400",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/고시/2017/0401.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 401,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2017/0401.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국가인권위원회/고시/2017/0401.hwpx",
+          "right": "out/v-bon/국가인권위원회/고시/2017/0401.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2017/0401.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국가인권위원회/고시/2017/0401.hwpx",
+          "right": "out/v-bon/국가인권위원회/고시/2017/0401.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000401",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/고시/2017/0402.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 402,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2017/0402.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/통계청/고시/2017/0402.hwpx",
+          "right": "out/v-bon/통계청/고시/2017/0402.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2017/0402.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/통계청/고시/2017/0402.hwpx",
+          "right": "out/v-bon/통계청/고시/2017/0402.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000402",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/고시/2017/0403.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 403,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2017/0403.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/기상청/고시/2017/0403.hwp",
+          "right": "out/v-bon/기상청/고시/2017/0403.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2017/0403.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기상청/고시/2017/0403.hwp",
+          "right": "out/v-bon/기상청/고시/2017/0403.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000403",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/고시/2017/0404.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 404,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2017/0404.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/고시/2017/0404.hwpx",
+          "right": "out/v-bon/관세청/고시/2017/0404.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2017/0404.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/고시/2017/0404.hwpx",
+          "right": "out/v-bon/관세청/고시/2017/0404.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "para_count": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000404",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/고시/2017/0405.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 405,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2017/0405.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/검찰청/고시/2017/0405.hwpx",
+          "right": "out/v-bon/검찰청/고시/2017/0405.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2017/0405.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/검찰청/고시/2017/0405.hwpx",
+          "right": "out/v-bon/검찰청/고시/2017/0405.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000405",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/고시/2017/0406.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 406,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2017/0406.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/경찰청/고시/2017/0406.hwp",
+          "right": "out/v-bon/경찰청/고시/2017/0406.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2017/0406.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/경찰청/고시/2017/0406.hwp",
+          "right": "out/v-bon/경찰청/고시/2017/0406.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000406",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/고시/2017/0407.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 407,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2017/0407.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/소방청/고시/2017/0407.hwpx",
+          "right": "out/v-bon/소방청/고시/2017/0407.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2017/0407.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/고시/2017/0407.hwpx",
+          "right": "out/v-bon/소방청/고시/2017/0407.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000407",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 408,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "right": "out/v-bon/해양경찰청/고시/2017/0408.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "right": "out/v-bon/해양경찰청/고시/2017/0408.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/고시/2017/0408.hwpx",
+          "right": "out/v-bon/해양경찰청/고시/2017/0408.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000408",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/고시/2017/0409.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 409,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2017/0409.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/병무청/고시/2017/0409.hwp",
+          "right": "out/v-bon/병무청/고시/2017/0409.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2017/0409.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/병무청/고시/2017/0409.hwp",
+          "right": "out/v-bon/병무청/고시/2017/0409.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2017/0409.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/병무청/고시/2017/0409.hwp",
+          "right": "out/v-bon/병무청/고시/2017/0409.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000409",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/고시/2017/0410.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 410,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "right": "out/v-bon/산림청/고시/2017/0410.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "right": "out/v-bon/산림청/고시/2017/0410.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/산림청/고시/2017/0410.hwpx",
+          "right": "out/v-bon/산림청/고시/2017/0410.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000410",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 411,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "right": "out/v-bon/농촌진흥청/고시/2017/0411.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "right": "out/v-bon/농촌진흥청/고시/2017/0411.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/고시/2017/0411.hwpx",
+          "right": "out/v-bon/농촌진흥청/고시/2017/0411.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 2,
+            "cc": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000411",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 412,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "right": "out/v-bon/중소벤처기업부/고시/2017/0412.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "right": "out/v-bon/중소벤처기업부/고시/2017/0412.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/중소벤처기업부/고시/2017/0412.hwp",
+          "right": "out/v-bon/중소벤처기업부/고시/2017/0412.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000412",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 413,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/고시/2017/0413.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/고시/2017/0413.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/과학기술정보통신부/고시/2017/0413.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/고시/2017/0413.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000413",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 414,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "right": "out/v-bon/문화체육관광부/고시/2017/0414.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "right": "out/v-bon/문화체육관광부/고시/2017/0414.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/고시/2017/0414.hwpx",
+          "right": "out/v-bon/문화체육관광부/고시/2017/0414.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000414",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/고시/2017/0415.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 415,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2017/0415.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/고시/2017/0415.hwp",
+          "right": "out/v-bon/환경부/고시/2017/0415.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2017/0415.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/고시/2017/0415.hwp",
+          "right": "out/v-bon/환경부/고시/2017/0415.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2017/0415.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/고시/2017/0415.hwp",
+          "right": "out/v-bon/환경부/고시/2017/0415.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000415",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "고시",
+    "year": 2017,
+    "serial": 416,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "right": "out/v-bon/해양수산부/고시/2017/0416.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "right": "out/v-bon/해양수산부/고시/2017/0416.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/해양수산부/고시/2017/0416.hwpx",
+          "right": "out/v-bon/해양수산부/고시/2017/0416.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000416",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/훈령/2017/0417.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 417,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "right": "out/v-bon/법제처/훈령/2017/0417.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "right": "out/v-bon/법제처/훈령/2017/0417.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/법제처/훈령/2017/0417.hwpx",
+          "right": "out/v-bon/법제처/훈령/2017/0417.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000417",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 418,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "right": "out/v-bon/행정안전부/훈령/2017/0418.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "right": "out/v-bon/행정안전부/훈령/2017/0418.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/훈령/2017/0418.hwp",
+          "right": "out/v-bon/행정안전부/훈령/2017/0418.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000418",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/훈령/2017/0419.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 419,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "right": "out/v-bon/국세청/훈령/2017/0419.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "right": "out/v-bon/국세청/훈령/2017/0419.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/훈령/2017/0419.hwpx",
+          "right": "out/v-bon/국세청/훈령/2017/0419.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000419",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/훈령/2017/0420.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 420,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "right": "out/v-bon/대법원/훈령/2017/0420.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "right": "out/v-bon/대법원/훈령/2017/0420.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/대법원/훈령/2017/0420.hwpx",
+          "right": "out/v-bon/대법원/훈령/2017/0420.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000420",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/훈령/2017/0421.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 421,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "right": "out/v-bon/특허청/훈령/2017/0421.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "right": "out/v-bon/특허청/훈령/2017/0421.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/훈령/2017/0421.hwp",
+          "right": "out/v-bon/특허청/훈령/2017/0421.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000421",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/훈령/2017/0422.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 422,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "right": "out/v-bon/교육부/훈령/2017/0422.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "cc": 2,
+            "bullet": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "right": "out/v-bon/교육부/훈령/2017/0422.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "right": "out/v-bon/교육부/훈령/2017/0422.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/교육부/훈령/2017/0422.hwpx",
+          "right": "out/v-bon/교육부/훈령/2017/0422.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000422",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 423,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "right": "out/v-bon/보건복지부/훈령/2017/0423.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "right": "out/v-bon/보건복지부/훈령/2017/0423.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "right": "out/v-bon/보건복지부/훈령/2017/0423.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/보건복지부/훈령/2017/0423.hwpx",
+          "right": "out/v-bon/보건복지부/훈령/2017/0423.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "cc": 3,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000423",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 424,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "right": "out/v-bon/국토교통부/훈령/2017/0424.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "right": "out/v-bon/국토교통부/훈령/2017/0424.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "right": "out/v-bon/국토교통부/훈령/2017/0424.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/훈령/2017/0424.hwp",
+          "right": "out/v-bon/국토교통부/훈령/2017/0424.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000424",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 425,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "right": "out/v-bon/고용노동부/훈령/2017/0425.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "right": "out/v-bon/고용노동부/훈령/2017/0425.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "cc": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "right": "out/v-bon/고용노동부/훈령/2017/0425.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/훈령/2017/0425.hwpx",
+          "right": "out/v-bon/고용노동부/훈령/2017/0425.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000425",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/훈령/2017/0426.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 426,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "right": "out/v-bon/외교부/훈령/2017/0426.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "right": "out/v-bon/외교부/훈령/2017/0426.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "right": "out/v-bon/외교부/훈령/2017/0426.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/외교부/훈령/2017/0426.hwpx",
+          "right": "out/v-bon/외교부/훈령/2017/0426.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000426",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 427,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "right": "out/v-bon/기획재정부/훈령/2017/0427.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "right": "out/v-bon/기획재정부/훈령/2017/0427.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "right": "out/v-bon/기획재정부/훈령/2017/0427.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기획재정부/훈령/2017/0427.hwp",
+          "right": "out/v-bon/기획재정부/훈령/2017/0427.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000427",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 428,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "right": "out/v-bon/공정거래위원회/훈령/2017/0428.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "right": "out/v-bon/공정거래위원회/훈령/2017/0428.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "right": "out/v-bon/공정거래위원회/훈령/2017/0428.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/훈령/2017/0428.hwpx",
+          "right": "out/v-bon/공정거래위원회/훈령/2017/0428.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000428",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 429,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "right": "out/v-bon/금융위원회/훈령/2017/0429.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "right": "out/v-bon/금융위원회/훈령/2017/0429.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "right": "out/v-bon/금융위원회/훈령/2017/0429.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/금융위원회/훈령/2017/0429.hwpx",
+          "right": "out/v-bon/금융위원회/훈령/2017/0429.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000429",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 430,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "right": "out/v-bon/방송통신위원회/훈령/2017/0430.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "right": "out/v-bon/방송통신위원회/훈령/2017/0430.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "right": "out/v-bon/방송통신위원회/훈령/2017/0430.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/방송통신위원회/훈령/2017/0430.hwp",
+          "right": "out/v-bon/방송통신위원회/훈령/2017/0430.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000430",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 431,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/훈령/2017/0431.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/훈령/2017/0431.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/훈령/2017/0431.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/훈령/2017/0431.hwpx",
+          "right": "out/v-bon/개인정보보호위원회/훈령/2017/0431.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000431",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 432,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "right": "out/v-bon/국민권익위원회/훈령/2017/0432.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "right": "out/v-bon/국민권익위원회/훈령/2017/0432.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "section_def": 1,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "right": "out/v-bon/국민권익위원회/훈령/2017/0432.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/훈령/2017/0432.hwpx",
+          "right": "out/v-bon/국민권익위원회/훈령/2017/0432.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000432",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 433,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "right": "out/v-bon/국가인권위원회/훈령/2017/0433.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "right": "out/v-bon/국가인권위원회/훈령/2017/0433.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "right": "out/v-bon/국가인권위원회/훈령/2017/0433.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/국가인권위원회/훈령/2017/0433.hwp",
+          "right": "out/v-bon/국가인권위원회/훈령/2017/0433.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000433",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/훈령/2017/0434.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 434,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "right": "out/v-bon/통계청/훈령/2017/0434.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "right": "out/v-bon/통계청/훈령/2017/0434.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "right": "out/v-bon/통계청/훈령/2017/0434.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/통계청/훈령/2017/0434.hwpx",
+          "right": "out/v-bon/통계청/훈령/2017/0434.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000434",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/훈령/2017/0435.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 435,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "right": "out/v-bon/기상청/훈령/2017/0435.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "right": "out/v-bon/기상청/훈령/2017/0435.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "right": "out/v-bon/기상청/훈령/2017/0435.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/훈령/2017/0435.hwpx",
+          "right": "out/v-bon/기상청/훈령/2017/0435.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "char_offsets": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000435",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/훈령/2017/0436.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 436,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "right": "out/v-bon/관세청/훈령/2017/0436.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "right": "out/v-bon/관세청/훈령/2017/0436.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "right": "out/v-bon/관세청/훈령/2017/0436.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "right": "out/v-bon/관세청/훈령/2017/0436.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/훈령/2017/0436.hwp",
+          "right": "out/v-bon/관세청/훈령/2017/0436.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000436",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 437,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "right": "out/v-bon/검찰청/훈령/2017/0437.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "right": "out/v-bon/검찰청/훈령/2017/0437.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "right": "out/v-bon/검찰청/훈령/2017/0437.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "right": "out/v-bon/검찰청/훈령/2017/0437.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/검찰청/훈령/2017/0437.hwpx",
+          "right": "out/v-bon/검찰청/훈령/2017/0437.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000437",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 438,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "right": "out/v-bon/경찰청/훈령/2017/0438.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "right": "out/v-bon/경찰청/훈령/2017/0438.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "right": "out/v-bon/경찰청/훈령/2017/0438.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "right": "out/v-bon/경찰청/훈령/2017/0438.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/훈령/2017/0438.hwpx",
+          "right": "out/v-bon/경찰청/훈령/2017/0438.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000438",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/훈령/2017/0439.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 439,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "right": "out/v-bon/소방청/훈령/2017/0439.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "right": "out/v-bon/소방청/훈령/2017/0439.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "right": "out/v-bon/소방청/훈령/2017/0439.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "right": "out/v-bon/소방청/훈령/2017/0439.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/훈령/2017/0439.hwp",
+          "right": "out/v-bon/소방청/훈령/2017/0439.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000439",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 440,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "right": "out/v-bon/해양경찰청/훈령/2017/0440.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "right": "out/v-bon/해양경찰청/훈령/2017/0440.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "right": "out/v-bon/해양경찰청/훈령/2017/0440.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "right": "out/v-bon/해양경찰청/훈령/2017/0440.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/해양경찰청/훈령/2017/0440.hwpx",
+          "right": "out/v-bon/해양경찰청/훈령/2017/0440.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000440",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/훈령/2017/0441.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 441,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "right": "out/v-bon/병무청/훈령/2017/0441.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "right": "out/v-bon/병무청/훈령/2017/0441.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "right": "out/v-bon/병무청/훈령/2017/0441.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "right": "out/v-bon/병무청/훈령/2017/0441.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/병무청/훈령/2017/0441.hwpx",
+          "right": "out/v-bon/병무청/훈령/2017/0441.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000441",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/훈령/2017/0442.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 442,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "right": "out/v-bon/산림청/훈령/2017/0442.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "right": "out/v-bon/산림청/훈령/2017/0442.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "right": "out/v-bon/산림청/훈령/2017/0442.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "right": "out/v-bon/산림청/훈령/2017/0442.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/훈령/2017/0442.hwp",
+          "right": "out/v-bon/산림청/훈령/2017/0442.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "cc": 2,
+            "bullet": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000442",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 443,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "right": "out/v-bon/농촌진흥청/훈령/2017/0443.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "right": "out/v-bon/농촌진흥청/훈령/2017/0443.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "right": "out/v-bon/농촌진흥청/훈령/2017/0443.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "right": "out/v-bon/농촌진흥청/훈령/2017/0443.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/훈령/2017/0443.hwpx",
+          "right": "out/v-bon/농촌진흥청/훈령/2017/0443.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000443",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 444,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "right": "out/v-bon/중소벤처기업부/훈령/2017/0444.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "right": "out/v-bon/중소벤처기업부/훈령/2017/0444.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "right": "out/v-bon/중소벤처기업부/훈령/2017/0444.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "right": "out/v-bon/중소벤처기업부/훈령/2017/0444.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "table_cell": 3,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/중소벤처기업부/훈령/2017/0444.hwpx",
+          "right": "out/v-bon/중소벤처기업부/훈령/2017/0444.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000444",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 445,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "right": "out/v-bon/과학기술정보통신부/훈령/2017/0445.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "right": "out/v-bon/과학기술정보통신부/훈령/2017/0445.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "right": "out/v-bon/과학기술정보통신부/훈령/2017/0445.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "right": "out/v-bon/과학기술정보통신부/훈령/2017/0445.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/훈령/2017/0445.hwp",
+          "right": "out/v-bon/과학기술정보통신부/훈령/2017/0445.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000445",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 446,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "right": "out/v-bon/문화체육관광부/훈령/2017/0446.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "right": "out/v-bon/문화체육관광부/훈령/2017/0446.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "table_cell": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "right": "out/v-bon/문화체육관광부/훈령/2017/0446.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "right": "out/v-bon/문화체육관광부/훈령/2017/0446.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/훈령/2017/0446.hwpx",
+          "right": "out/v-bon/문화체육관광부/훈령/2017/0446.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000446",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/훈령/2017/0447.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 447,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "right": "out/v-bon/환경부/훈령/2017/0447.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "right": "out/v-bon/환경부/훈령/2017/0447.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "right": "out/v-bon/환경부/훈령/2017/0447.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "right": "out/v-bon/환경부/훈령/2017/0447.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/환경부/훈령/2017/0447.hwpx",
+          "right": "out/v-bon/환경부/훈령/2017/0447.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000447",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "훈령",
+    "year": 2017,
+    "serial": 448,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "right": "out/v-bon/해양수산부/훈령/2017/0448.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "right": "out/v-bon/해양수산부/훈령/2017/0448.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "section_def": 2,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "right": "out/v-bon/해양수산부/훈령/2017/0448.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "right": "out/v-bon/해양수산부/훈령/2017/0448.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양수산부/훈령/2017/0448.hwp",
+          "right": "out/v-bon/해양수산부/훈령/2017/0448.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000448",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/예규/2017/0449.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 449,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "right": "out/v-bon/법제처/예규/2017/0449.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "right": "out/v-bon/법제처/예규/2017/0449.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "right": "out/v-bon/법제처/예규/2017/0449.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "right": "out/v-bon/법제처/예규/2017/0449.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/예규/2017/0449.hwpx",
+          "right": "out/v-bon/법제처/예규/2017/0449.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0007.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0007.json
@@ -1,0 +1,11904 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000449",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 450,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/행정안전부/예규/2017/0450.hwpx",
+          "right": "out/v-bon/행정안전부/예규/2017/0450.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000450",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/예규/2017/0451.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 451,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2017/0451.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국세청/예규/2017/0451.hwp",
+          "right": "out/v-bon/국세청/예규/2017/0451.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000451",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/예규/2017/0452.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 452,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/예규/2017/0452.hwpx",
+          "right": "out/v-bon/대법원/예규/2017/0452.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "section_def": 1,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000452",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/예규/2017/0453.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 453,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/특허청/예규/2017/0453.hwpx",
+          "right": "out/v-bon/특허청/예규/2017/0453.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000453",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/예규/2017/0454.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 454,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2017/0454.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/교육부/예규/2017/0454.hwp",
+          "right": "out/v-bon/교육부/예규/2017/0454.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000454",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 455,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/예규/2017/0455.hwpx",
+          "right": "out/v-bon/보건복지부/예규/2017/0455.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000455",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 456,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "bullet": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/예규/2017/0456.hwpx",
+          "right": "out/v-bon/국토교통부/예규/2017/0456.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000456",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/예규/2017/0457.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 457,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/고용노동부/예규/2017/0457.hwp",
+          "right": "out/v-bon/고용노동부/예규/2017/0457.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000457",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/예규/2017/0458.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 458,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/외교부/예규/2017/0458.hwpx",
+          "right": "out/v-bon/외교부/예규/2017/0458.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000458",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 459,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/예규/2017/0459.hwpx",
+          "right": "out/v-bon/기획재정부/예규/2017/0459.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000459",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 460,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/공정거래위원회/예규/2017/0460.hwp",
+          "right": "out/v-bon/공정거래위원회/예규/2017/0460.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000460",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 461,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/금융위원회/예규/2017/0461.hwpx",
+          "right": "out/v-bon/금융위원회/예규/2017/0461.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000461",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 462,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/방송통신위원회/예규/2017/0462.hwpx",
+          "right": "out/v-bon/방송통신위원회/예규/2017/0462.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000462",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 463,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "cc": 1,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/개인정보보호위원회/예규/2017/0463.hwp",
+          "right": "out/v-bon/개인정보보호위원회/예규/2017/0463.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000463",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 464,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/국민권익위원회/예규/2017/0464.hwpx",
+          "right": "out/v-bon/국민권익위원회/예규/2017/0464.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000464",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 465,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국가인권위원회/예규/2017/0465.hwpx",
+          "right": "out/v-bon/국가인권위원회/예규/2017/0465.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000465",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/예규/2017/0466.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 466,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "table_cell": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2017/0466.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/통계청/예규/2017/0466.hwp",
+          "right": "out/v-bon/통계청/예규/2017/0466.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000466",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/예규/2017/0467.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 467,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "header_footer": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기상청/예규/2017/0467.hwpx",
+          "right": "out/v-bon/기상청/예규/2017/0467.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000467",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/예규/2017/0468.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 468,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "section_def": 2,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/관세청/예규/2017/0468.hwpx",
+          "right": "out/v-bon/관세청/예규/2017/0468.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000468",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/예규/2017/0469.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 469,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/검찰청/예규/2017/0469.hwp",
+          "right": "out/v-bon/검찰청/예규/2017/0469.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000469",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/예규/2017/0470.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 470,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "section_def": 2,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/경찰청/예규/2017/0470.hwpx",
+          "right": "out/v-bon/경찰청/예규/2017/0470.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000470",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/예규/2017/0471.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 471,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/소방청/예규/2017/0471.hwpx",
+          "right": "out/v-bon/소방청/예규/2017/0471.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000471",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 472,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양경찰청/예규/2017/0472.hwp",
+          "right": "out/v-bon/해양경찰청/예규/2017/0472.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000472",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/예규/2017/0473.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 473,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/병무청/예규/2017/0473.hwpx",
+          "right": "out/v-bon/병무청/예규/2017/0473.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000473",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/예규/2017/0474.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 474,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "ctrl_id": 2,
+            "section_def": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/산림청/예규/2017/0474.hwpx",
+          "right": "out/v-bon/산림청/예규/2017/0474.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000474",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 475,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/농촌진흥청/예규/2017/0475.hwp",
+          "right": "out/v-bon/농촌진흥청/예규/2017/0475.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000475",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 476,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "para_count": 3,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/중소벤처기업부/예규/2017/0476.hwpx",
+          "right": "out/v-bon/중소벤처기업부/예규/2017/0476.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000476",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 477,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "ctrl_id": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/과학기술정보통신부/예규/2017/0477.hwpx",
+          "right": "out/v-bon/과학기술정보통신부/예규/2017/0477.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000477",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 478,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 1,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/문화체육관광부/예규/2017/0478.hwp",
+          "right": "out/v-bon/문화체육관광부/예규/2017/0478.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000478",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/예규/2017/0479.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 479,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "cc": 2,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/환경부/예규/2017/0479.hwpx",
+          "right": "out/v-bon/환경부/예규/2017/0479.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000479",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예규",
+    "year": 2017,
+    "serial": 480,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/해양수산부/예규/2017/0480.hwpx",
+          "right": "out/v-bon/해양수산부/예규/2017/0480.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000480",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/공고/2017/0481.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 481,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "cc": 2,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2017/0481.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/법제처/공고/2017/0481.hwp",
+          "right": "out/v-bon/법제처/공고/2017/0481.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000481",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 482,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/행정안전부/공고/2017/0482.hwpx",
+          "right": "out/v-bon/행정안전부/공고/2017/0482.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000482",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/공고/2017/0483.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 483,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 2,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "ctrl_id": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국세청/공고/2017/0483.hwpx",
+          "right": "out/v-bon/국세청/공고/2017/0483.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "cc": 1,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000483",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/공고/2017/0484.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 484,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "table_cell": 1,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "header_footer": 2,
+            "para_count": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "section_def": 3,
+            "cc": 1,
+            "bullet": 2,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2017/0484.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/대법원/공고/2017/0484.hwp",
+          "right": "out/v-bon/대법원/공고/2017/0484.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000484",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/공고/2017/0485.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 485,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 2,
+            "cc": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "bullet": 1,
+            "header_footer": 2,
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/특허청/공고/2017/0485.hwpx",
+          "right": "out/v-bon/특허청/공고/2017/0485.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "header_footer": 3,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000485",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/공고/2017/0486.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 486,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "section_def": 3,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/교육부/공고/2017/0486.hwpx",
+          "right": "out/v-bon/교육부/공고/2017/0486.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000486",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/공고/2017/0487.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 487,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "header_footer": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/보건복지부/공고/2017/0487.hwp",
+          "right": "out/v-bon/보건복지부/공고/2017/0487.out.hwp",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 3,
+            "ctrl_id": 1,
+            "section_def": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000487",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 488,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "section_def": 3
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 3,
+            "para_count": 1,
+            "char_offsets": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2,
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "para_count": 1,
+            "char_offsets": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/국토교통부/공고/2017/0488.hwpx",
+          "right": "out/v-bon/국토교통부/공고/2017/0488.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000488",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 489,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 3,
+            "char_offsets": 1,
+            "table_cell": 2,
+            "ctrl_id": 3,
+            "section_def": 1,
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 1,
+            "bullet": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_exit3_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/고용노동부/공고/2017/0489.hwpx",
+          "right": "out/v-bon/고용노동부/공고/2017/0489.out.hwpx",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000489",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/공고/2017/0490.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 490,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_page",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": false,
+          "diffCount": 4,
+          "categories": {
+            "bullet": 2,
+            "header_footer": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_invalid",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "leftUnreadable"
+          }
+        ],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "leftUnreadable"
+            }
+          ],
+          "exitClass": 1,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": null,
+          "diffCount": 0,
+          "categories": {},
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2017/0490.hwp",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/외교부/공고/2017/0490.hwp",
+          "right": "out/v-bon/외교부/공고/2017/0490.out.hwp",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "section_def": 2,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000490",
+    "command": "ir-diff",
+    "mode": "ir-diff",
+    "argv": [
+      "rhwp",
+      "ir-diff",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 491,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "ir_identical",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": true,
+          "diffCount": 0,
+          "categories": {},
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "ir_one",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 1,
+          "categories": {
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "ir_two",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "section_def": 1,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "ir_three",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 3,
+          "categories": {
+            "char_offsets": 2,
+            "table_cell": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "ir_five",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 5,
+          "categories": {
+            "bullet": 3,
+            "header_footer": 1,
+            "para_count": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "ir_eight",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 8,
+          "categories": {
+            "ctrl_id": 1,
+            "section_def": 2,
+            "cc": 3,
+            "bullet": 1,
+            "header_footer": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "ir_twelve",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 12,
+          "categories": {
+            "para_count": 2,
+            "char_offsets": 3,
+            "table_cell": 1,
+            "ctrl_id": 2,
+            "section_def": 3,
+            "cc": 1
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "ir_exit0_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "left": "samples/gov/기획재정부/공고/2017/0491.hwpx",
+          "right": "out/v-bon/기획재정부/공고/2017/0491.out.hwpx",
+          "identical": false,
+          "diffCount": 2,
+          "categories": {
+            "cc": 2
+          },
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000491",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/공고/2017/0492.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 492,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2017/0492.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48347,
+          "output": "out/v-bon/공정거래위원회/공고/2017/0492.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2017/0492.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48568,
+          "output": "out/v-bon/공정거래위원회/공고/2017/0492.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000492",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/공고/2017/0493.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 493,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2017/0493.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 48620,
+          "output": "out/v-bon/금융위원회/공고/2017/0493.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2017/0493.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48585,
+          "output": "out/v-bon/금융위원회/공고/2017/0493.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000493",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/공고/2017/0494.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 494,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2017/0494.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48381,
+          "output": "out/v-bon/방송통신위원회/공고/2017/0494.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2017/0494.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48602,
+          "output": "out/v-bon/방송통신위원회/공고/2017/0494.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000494",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/공고/2017/0495.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 495,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2017/0495.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48590,
+          "output": "out/v-bon/개인정보보호위원회/공고/2017/0495.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2017/0495.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48875,
+          "output": "out/v-bon/개인정보보호위원회/공고/2017/0495.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000495",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/공고/2017/0496.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 496,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2017/0496.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48415,
+          "output": "out/v-bon/국민권익위원회/공고/2017/0496.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2017/0496.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 48636,
+          "output": "out/v-bon/국민권익위원회/공고/2017/0496.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000496",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/공고/2017/0497.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 497,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2017/0497.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48752,
+          "output": "out/v-bon/국가인권위원회/공고/2017/0497.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2017/0497.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49101,
+          "output": "out/v-bon/국가인권위원회/공고/2017/0497.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000497",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/공고/2017/0498.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 498,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2017/0498.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48961,
+          "output": "out/v-bon/통계청/공고/2017/0498.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2017/0498.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49246,
+          "output": "out/v-bon/통계청/공고/2017/0498.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000498",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/공고/2017/0499.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 499,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2017/0499.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 48466,
+          "output": "out/v-bon/기상청/공고/2017/0499.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2017/0499.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48687,
+          "output": "out/v-bon/기상청/공고/2017/0499.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000499",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/공고/2017/0500.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 500,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2017/0500.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49507,
+          "output": "out/v-bon/관세청/공고/2017/0500.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2017/0500.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49216,
+          "output": "out/v-bon/관세청/공고/2017/0500.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000500",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/공고/2017/0501.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 501,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2017/0501.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49396,
+          "output": "out/v-bon/검찰청/공고/2017/0501.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2017/0501.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49809,
+          "output": "out/v-bon/검찰청/공고/2017/0501.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000501",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/공고/2017/0502.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 502,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2017/0502.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48517,
+          "output": "out/v-bon/경찰청/공고/2017/0502.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2017/0502.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 48738,
+          "output": "out/v-bon/경찰청/공고/2017/0502.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000502",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/공고/2017/0503.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 503,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2017/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49302,
+          "output": "out/v-bon/소방청/공고/2017/0503.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2017/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49523,
+          "output": "out/v-bon/소방청/공고/2017/0503.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000503",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/공고/2017/0504.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 504,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2017/0504.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49511,
+          "output": "out/v-bon/해양경찰청/공고/2017/0504.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2017/0504.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49668,
+          "output": "out/v-bon/해양경찰청/공고/2017/0504.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000504",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/공고/2017/0505.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 505,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2017/0505.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49848,
+          "output": "out/v-bon/병무청/공고/2017/0505.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 21
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2017/0505.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48789,
+          "output": "out/v-bon/병무청/공고/2017/0505.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 21
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000505",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/공고/2017/0506.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 506,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2017/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48777,
+          "output": "out/v-bon/산림청/공고/2017/0506.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2017/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48806,
+          "output": "out/v-bon/산림청/공고/2017/0506.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2017/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49027,
+          "output": "out/v-bon/산림청/공고/2017/0506.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000506",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/공고/2017/0507.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 507,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2017/0507.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48602,
+          "output": "out/v-bon/농촌진흥청/공고/2017/0507.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2017/0507.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48823,
+          "output": "out/v-bon/농촌진흥청/공고/2017/0507.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2017/0507.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49108,
+          "output": "out/v-bon/농촌진흥청/공고/2017/0507.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000507",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/공고/2017/0508.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 508,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2017/0508.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48747,
+          "output": "out/v-bon/중소벤처기업부/공고/2017/0508.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2017/0508.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49032,
+          "output": "out/v-bon/중소벤처기업부/공고/2017/0508.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2017/0508.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49317,
+          "output": "out/v-bon/중소벤처기업부/공고/2017/0508.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000508",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/공고/2017/0509.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 509,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2017/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48636,
+          "output": "out/v-bon/과학기술정보통신부/공고/2017/0509.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2017/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48857,
+          "output": "out/v-bon/과학기술정보통신부/공고/2017/0509.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2017/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49078,
+          "output": "out/v-bon/과학기술정보통신부/공고/2017/0509.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000509",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/공고/2017/0510.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 510,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2017/0510.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48909,
+          "output": "out/v-bon/문화체육관광부/공고/2017/0510.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2017/0510.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49258,
+          "output": "out/v-bon/문화체육관광부/공고/2017/0510.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2017/0510.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49863,
+          "output": "out/v-bon/문화체육관광부/공고/2017/0510.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000510",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/공고/2017/0511.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 511,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2017/0511.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49118,
+          "output": "out/v-bon/환경부/공고/2017/0511.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2017/0511.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49403,
+          "output": "out/v-bon/환경부/공고/2017/0511.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2017/0511.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49752,
+          "output": "out/v-bon/환경부/공고/2017/0511.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000511",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/공고/2017/0512.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "공고",
+    "year": 2017,
+    "serial": 512,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2017/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48687,
+          "output": "out/v-bon/해양수산부/공고/2017/0512.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2017/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48908,
+          "output": "out/v-bon/해양수산부/공고/2017/0512.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2017/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49129,
+          "output": "out/v-bon/해양수산부/공고/2017/0512.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000512",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/지침/2017/0513.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 513,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2017/0513.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49664,
+          "output": "out/v-bon/법제처/지침/2017/0513.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2017/0513.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49373,
+          "output": "out/v-bon/법제처/지침/2017/0513.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2017/0513.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49594,
+          "output": "out/v-bon/법제처/지침/2017/0513.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0008.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0008.json
@@ -1,0 +1,11528 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000513",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/지침/2017/0514.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 514,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2017/0514.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49553,
+          "output": "out/v-bon/행정안전부/지침/2017/0514.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2017/0514.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49966,
+          "output": "out/v-bon/행정안전부/지침/2017/0514.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2017/0514.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49611,
+          "output": "out/v-bon/행정안전부/지침/2017/0514.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000514",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/지침/2017/0515.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 515,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2017/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48738,
+          "output": "out/v-bon/국세청/지침/2017/0515.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2017/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48959,
+          "output": "out/v-bon/국세청/지침/2017/0515.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2017/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49756,
+          "output": "out/v-bon/국세청/지침/2017/0515.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000515",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/지침/2017/0516.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 516,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2017/0516.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49395,
+          "output": "out/v-bon/대법원/지침/2017/0516.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2017/0516.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49616,
+          "output": "out/v-bon/대법원/지침/2017/0516.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2017/0516.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50029,
+          "output": "out/v-bon/대법원/지침/2017/0516.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000516",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/지침/2017/0517.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 517,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2017/0517.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49476,
+          "output": "out/v-bon/특허청/지침/2017/0517.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2017/0517.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49633,
+          "output": "out/v-bon/특허청/지침/2017/0517.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2017/0517.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49790,
+          "output": "out/v-bon/특허청/지침/2017/0517.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000517",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/지침/2017/0518.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 518,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2017/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49813,
+          "output": "out/v-bon/교육부/지침/2017/0518.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 18
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2017/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49010,
+          "output": "out/v-bon/교육부/지침/2017/0518.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 18
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2017/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50255,
+          "output": "out/v-bon/교육부/지침/2017/0518.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000518",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/지침/2017/0519.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 519,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2017/0519.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50278,
+          "output": "out/v-bon/보건복지부/지침/2017/0519.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2017/0519.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49027,
+          "output": "out/v-bon/보건복지부/지침/2017/0519.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2017/0519.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49248,
+          "output": "out/v-bon/보건복지부/지침/2017/0519.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000519",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/지침/2017/0520.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 520,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2017/0520.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 48823,
+          "output": "out/v-bon/국토교통부/지침/2017/0520.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2017/0520.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49044,
+          "output": "out/v-bon/국토교통부/지침/2017/0520.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2017/0520.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49265,
+          "output": "out/v-bon/국토교통부/지침/2017/0520.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2017/0520.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49614,
+          "output": "out/v-bon/국토교통부/지침/2017/0520.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000520",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/지침/2017/0521.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 521,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2017/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48904,
+          "output": "out/v-bon/고용노동부/지침/2017/0521.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2017/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49189,
+          "output": "out/v-bon/고용노동부/지침/2017/0521.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2017/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49474,
+          "output": "out/v-bon/고용노동부/지침/2017/0521.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2017/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49759,
+          "output": "out/v-bon/고용노동부/지침/2017/0521.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000521",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/지침/2017/0522.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 522,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2017/0522.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48857,
+          "output": "out/v-bon/외교부/지침/2017/0522.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2017/0522.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49078,
+          "output": "out/v-bon/외교부/지침/2017/0522.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2017/0522.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49299,
+          "output": "out/v-bon/외교부/지침/2017/0522.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2017/0522.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49520,
+          "output": "out/v-bon/외교부/지침/2017/0522.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000522",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/지침/2017/0523.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 523,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2017/0523.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49066,
+          "output": "out/v-bon/기획재정부/지침/2017/0523.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2017/0523.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49415,
+          "output": "out/v-bon/기획재정부/지침/2017/0523.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2017/0523.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50020,
+          "output": "out/v-bon/기획재정부/지침/2017/0523.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2017/0523.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49729,
+          "output": "out/v-bon/기획재정부/지침/2017/0523.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000523",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/지침/2017/0524.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 524,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2017/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49275,
+          "output": "out/v-bon/공정거래위원회/지침/2017/0524.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2017/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49560,
+          "output": "out/v-bon/공정거래위원회/지침/2017/0524.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2017/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49909,
+          "output": "out/v-bon/공정거래위원회/지침/2017/0524.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2017/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50322,
+          "output": "out/v-bon/공정거래위원회/지침/2017/0524.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000524",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/지침/2017/0525.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 525,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2017/0525.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 48908,
+          "output": "out/v-bon/금융위원회/지침/2017/0525.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2017/0525.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49129,
+          "output": "out/v-bon/금융위원회/지침/2017/0525.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2017/0525.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49350,
+          "output": "out/v-bon/금융위원회/지침/2017/0525.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2017/0525.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49571,
+          "output": "out/v-bon/금융위원회/지침/2017/0525.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000525",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/지침/2017/0526.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 526,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2017/0526.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49821,
+          "output": "out/v-bon/방송통신위원회/지침/2017/0526.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2017/0526.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49530,
+          "output": "out/v-bon/방송통신위원회/지침/2017/0526.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2017/0526.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49751,
+          "output": "out/v-bon/방송통신위원회/지침/2017/0526.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2017/0526.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49972,
+          "output": "out/v-bon/방송통신위원회/지침/2017/0526.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000526",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/지침/2017/0527.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 527,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2017/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49710,
+          "output": "out/v-bon/개인정보보호위원회/지침/2017/0527.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2017/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50123,
+          "output": "out/v-bon/개인정보보호위원회/지침/2017/0527.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2017/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49768,
+          "output": "out/v-bon/개인정보보호위원회/지침/2017/0527.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2017/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49925,
+          "output": "out/v-bon/개인정보보호위원회/지침/2017/0527.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000527",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/지침/2017/0528.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 528,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2017/0528.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 48959,
+          "output": "out/v-bon/국민권익위원회/지침/2017/0528.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2017/0528.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49180,
+          "output": "out/v-bon/국민권익위원회/지침/2017/0528.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2017/0528.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49913,
+          "output": "out/v-bon/국민권익위원회/지침/2017/0528.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2017/0528.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49622,
+          "output": "out/v-bon/국민권익위원회/지침/2017/0528.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000528",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/지침/2017/0529.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 529,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2017/0529.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49552,
+          "output": "out/v-bon/국가인권위원회/지침/2017/0529.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2017/0529.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49773,
+          "output": "out/v-bon/국가인권위원회/지침/2017/0529.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2017/0529.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50186,
+          "output": "out/v-bon/국가인권위원회/지침/2017/0529.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2017/0529.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49639,
+          "output": "out/v-bon/국가인권위원회/지침/2017/0529.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000529",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/지침/2017/0530.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 530,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2017/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49569,
+          "output": "out/v-bon/통계청/지침/2017/0530.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2017/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49726,
+          "output": "out/v-bon/통계청/지침/2017/0530.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2017/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49883,
+          "output": "out/v-bon/통계청/지침/2017/0530.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2017/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49656,
+          "output": "out/v-bon/통계청/지침/2017/0530.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000530",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/지침/2017/0531.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 531,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2017/0531.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49778,
+          "output": "out/v-bon/기상청/지침/2017/0531.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 15
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2017/0531.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49231,
+          "output": "out/v-bon/기상청/지침/2017/0531.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 15
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2017/0531.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50220,
+          "output": "out/v-bon/기상청/지침/2017/0531.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2017/0531.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50505,
+          "output": "out/v-bon/기상청/지침/2017/0531.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000531",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/지침/2017/0532.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 532,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2017/0532.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50243,
+          "output": "out/v-bon/관세청/지침/2017/0532.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2017/0532.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49248,
+          "output": "out/v-bon/관세청/지침/2017/0532.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2017/0532.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49469,
+          "output": "out/v-bon/관세청/지침/2017/0532.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2017/0532.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49690,
+          "output": "out/v-bon/관세청/지침/2017/0532.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000532",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/지침/2017/0533.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 533,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2017/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50132,
+          "output": "out/v-bon/검찰청/지침/2017/0533.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2017/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49265,
+          "output": "out/v-bon/검찰청/지침/2017/0533.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2017/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50766,
+          "output": "out/v-bon/검찰청/지침/2017/0533.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2017/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51115,
+          "output": "out/v-bon/검찰청/지침/2017/0533.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000533",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/지침/2017/0534.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 534,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2017/0534.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49061,
+          "output": "out/v-bon/경찰청/지침/2017/0534.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2017/0534.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49346,
+          "output": "out/v-bon/경찰청/지침/2017/0534.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2017/0534.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49631,
+          "output": "out/v-bon/경찰청/지침/2017/0534.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2017/0534.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49916,
+          "output": "out/v-bon/경찰청/지침/2017/0534.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2017/0534.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50265,
+          "output": "out/v-bon/경찰청/지침/2017/0534.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000534",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/지침/2017/0535.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 535,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2017/0535.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49078,
+          "output": "out/v-bon/소방청/지침/2017/0535.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2017/0535.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49299,
+          "output": "out/v-bon/소방청/지침/2017/0535.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2017/0535.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49520,
+          "output": "out/v-bon/소방청/지침/2017/0535.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2017/0535.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49741,
+          "output": "out/v-bon/소방청/지침/2017/0535.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2017/0535.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49962,
+          "output": "out/v-bon/소방청/지침/2017/0535.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000535",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 536,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49223,
+          "output": "out/v-bon/해양경찰청/지침/2017/0536.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49572,
+          "output": "out/v-bon/해양경찰청/지침/2017/0536.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50177,
+          "output": "out/v-bon/해양경찰청/지침/2017/0536.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49886,
+          "output": "out/v-bon/해양경찰청/지침/2017/0536.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2017/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50107,
+          "output": "out/v-bon/해양경찰청/지침/2017/0536.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000536",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/지침/2017/0537.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 537,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2017/0537.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49432,
+          "output": "out/v-bon/병무청/지침/2017/0537.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2017/0537.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49717,
+          "output": "out/v-bon/병무청/지침/2017/0537.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2017/0537.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50066,
+          "output": "out/v-bon/병무청/지침/2017/0537.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2017/0537.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50479,
+          "output": "out/v-bon/병무청/지침/2017/0537.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2017/0537.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50124,
+          "output": "out/v-bon/병무청/지침/2017/0537.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000537",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/지침/2017/0538.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 538,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2017/0538.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49129,
+          "output": "out/v-bon/산림청/지침/2017/0538.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2017/0538.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49350,
+          "output": "out/v-bon/산림청/지침/2017/0538.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2017/0538.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49571,
+          "output": "out/v-bon/산림청/지침/2017/0538.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2017/0538.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49792,
+          "output": "out/v-bon/산림청/지침/2017/0538.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2017/0538.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50269,
+          "output": "out/v-bon/산림청/지침/2017/0538.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000538",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 539,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49978,
+          "output": "out/v-bon/농촌진흥청/지침/2017/0539.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49687,
+          "output": "out/v-bon/농촌진흥청/지침/2017/0539.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49908,
+          "output": "out/v-bon/농촌진흥청/지침/2017/0539.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50129,
+          "output": "out/v-bon/농촌진흥청/지침/2017/0539.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2017/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50542,
+          "output": "out/v-bon/농촌진흥청/지침/2017/0539.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000539",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 540,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49867,
+          "output": "out/v-bon/중소벤처기업부/지침/2017/0540.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50280,
+          "output": "out/v-bon/중소벤처기업부/지침/2017/0540.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49925,
+          "output": "out/v-bon/중소벤처기업부/지침/2017/0540.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50082,
+          "output": "out/v-bon/중소벤처기업부/지침/2017/0540.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2017/0540.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50239,
+          "output": "out/v-bon/중소벤처기업부/지침/2017/0540.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000540",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 541,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49180,
+          "output": "out/v-bon/과학기술정보통신부/지침/2017/0541.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49401,
+          "output": "out/v-bon/과학기술정보통신부/지침/2017/0541.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50070,
+          "output": "out/v-bon/과학기술정보통신부/지침/2017/0541.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49843,
+          "output": "out/v-bon/과학기술정보통신부/지침/2017/0541.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2017/0541.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50512,
+          "output": "out/v-bon/과학기술정보통신부/지침/2017/0541.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000541",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 542,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49709,
+          "output": "out/v-bon/문화체육관광부/지침/2017/0542.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49930,
+          "output": "out/v-bon/문화체육관광부/지침/2017/0542.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50343,
+          "output": "out/v-bon/문화체육관광부/지침/2017/0542.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49860,
+          "output": "out/v-bon/문화체육관광부/지침/2017/0542.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2017/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50081,
+          "output": "out/v-bon/문화체육관광부/지침/2017/0542.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000542",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/지침/2017/0543.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 543,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2017/0543.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49726,
+          "output": "out/v-bon/환경부/지침/2017/0543.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2017/0543.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49883,
+          "output": "out/v-bon/환경부/지침/2017/0543.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2017/0543.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50040,
+          "output": "out/v-bon/환경부/지침/2017/0543.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2017/0543.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49877,
+          "output": "out/v-bon/환경부/지침/2017/0543.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2017/0543.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50674,
+          "output": "out/v-bon/환경부/지침/2017/0543.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000543",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/지침/2017/0544.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "지침",
+    "year": 2017,
+    "serial": 544,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2017/0544.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49871,
+          "output": "out/v-bon/해양수산부/지침/2017/0544.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2017/0544.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49452,
+          "output": "out/v-bon/해양수산부/지침/2017/0544.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2017/0544.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50313,
+          "output": "out/v-bon/해양수산부/지침/2017/0544.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2017/0544.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50598,
+          "output": "out/v-bon/해양수산부/지침/2017/0544.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2017/0544.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50883,
+          "output": "out/v-bon/해양수산부/지침/2017/0544.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000544",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/서식/2017/0545.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 545,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2017/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50208,
+          "output": "out/v-bon/법제처/서식/2017/0545.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2017/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49469,
+          "output": "out/v-bon/법제처/서식/2017/0545.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2017/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49690,
+          "output": "out/v-bon/법제처/서식/2017/0545.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2017/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49911,
+          "output": "out/v-bon/법제처/서식/2017/0545.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2017/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50132,
+          "output": "out/v-bon/법제처/서식/2017/0545.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000545",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 546,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50097,
+          "output": "out/v-bon/행정안전부/서식/2017/0546.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49486,
+          "output": "out/v-bon/행정안전부/서식/2017/0546.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50731,
+          "output": "out/v-bon/행정안전부/서식/2017/0546.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51080,
+          "output": "out/v-bon/행정안전부/서식/2017/0546.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2017/0546.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51685,
+          "output": "out/v-bon/행정안전부/서식/2017/0546.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000546",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/서식/2017/0547.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 547,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2017/0547.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50562,
+          "output": "out/v-bon/국세청/서식/2017/0547.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2017/0547.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50847,
+          "output": "out/v-bon/국세청/서식/2017/0547.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2017/0547.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51132,
+          "output": "out/v-bon/국세청/서식/2017/0547.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2017/0547.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51417,
+          "output": "out/v-bon/국세청/서식/2017/0547.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2017/0547.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51766,
+          "output": "out/v-bon/국세청/서식/2017/0547.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000547",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/서식/2017/0548.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 548,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49299,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49520,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49741,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49962,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50183,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2017/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50404,
+          "output": "out/v-bon/대법원/서식/2017/0548.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000548",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/서식/2017/0549.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 549,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49380,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49729,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50334,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50043,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50264,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2017/0549.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50485,
+          "output": "out/v-bon/특허청/서식/2017/0549.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000549",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/서식/2017/0550.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 550,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49589,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49874,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50223,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50636,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50281,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2017/0550.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50438,
+          "output": "out/v-bon/교육부/서식/2017/0550.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000550",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 551,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49350,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49571,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49792,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50013,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50426,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2017/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50455,
+          "output": "out/v-bon/보건복지부/서식/2017/0551.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000551",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 552,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50135,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49844,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50065,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50286,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50699,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2017/0552.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50472,
+          "output": "out/v-bon/국토교통부/서식/2017/0552.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000552",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/서식/2017/0553.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 553,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50024,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50437,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50082,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50239,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50396,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2017/0553.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50489,
+          "output": "out/v-bon/고용노동부/서식/2017/0553.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000553",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/서식/2017/0554.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 554,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49401,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49622,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50227,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50064,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50669,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2017/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50954,
+          "output": "out/v-bon/외교부/서식/2017/0554.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000554",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 555,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49866,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50087,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50500,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50081,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50302,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2017/0555.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50523,
+          "output": "out/v-bon/기획재정부/서식/2017/0555.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000555",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 556,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49883,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50040,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50197,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50098,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50831,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2017/0556.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51180,
+          "output": "out/v-bon/공정거래위원회/서식/2017/0556.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000556",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 557,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50028,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49673,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50470,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50755,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51040,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2017/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51325,
+          "output": "out/v-bon/금융위원회/서식/2017/0557.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000557",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 558,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50301,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49690,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49911,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50132,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50353,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2017/0558.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50574,
+          "output": "out/v-bon/방송통신위원회/서식/2017/0558.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000558",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 559,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50062,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49707,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50696,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51045,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51650,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2017/0559.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51359,
+          "output": "out/v-bon/개인정보보호위원회/서식/2017/0559.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000559",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 560,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50527,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50812,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51097,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51382,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51731,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2017/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 52144,
+          "output": "out/v-bon/국민권익위원회/서식/2017/0560.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000560",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 561,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49520,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49741,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49962,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50183,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50404,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2017/0561.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50625,
+          "output": "out/v-bon/국가인권위원회/서식/2017/0561.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000561",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/서식/2017/0562.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 562,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49537,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49886,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50491,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50200,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50421,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50642,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2017/0562.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51055,
+          "output": "out/v-bon/통계청/서식/2017/0562.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000562",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/서식/2017/0563.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 563,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49746,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50031,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50380,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50793,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50438,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50659,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2017/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50880,
+          "output": "out/v-bon/기상청/서식/2017/0563.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000563",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/서식/2017/0564.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 564,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49571,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49792,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50013,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50234,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50583,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50676,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2017/0564.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51025,
+          "output": "out/v-bon/관세청/서식/2017/0564.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000564",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/서식/2017/0565.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 565,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50292,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50001,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50222,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50443,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50856,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50693,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2017/0565.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50914,
+          "output": "out/v-bon/검찰청/서식/2017/0565.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000565",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/서식/2017/0566.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 566,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50181,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50594,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50239,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50396,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50553,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50710,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2017/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51187,
+          "output": "out/v-bon/경찰청/서식/2017/0566.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000566",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/서식/2017/0567.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 567,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49622,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49843,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50384,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50285,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50826,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51111,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2017/0567.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51396,
+          "output": "out/v-bon/소방청/서식/2017/0567.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000567",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 568,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50023,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50244,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50657,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50302,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50523,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50744,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2017/0568.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50965,
+          "output": "out/v-bon/해양경찰청/서식/2017/0568.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000568",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/서식/2017/0569.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 569,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50040,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50197,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50354,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50319,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50988,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51337,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2017/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51942,
+          "output": "out/v-bon/병무청/서식/2017/0569.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000569",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/서식/2017/0570.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 570,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50185,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49894,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50627,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50912,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51197,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51482,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2017/0570.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51831,
+          "output": "out/v-bon/산림청/서식/2017/0570.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000570",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 571,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50458,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49911,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50132,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50353,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50574,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50795,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2017/0571.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51016,
+          "output": "out/v-bon/농촌진흥청/서식/2017/0571.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000571",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 572,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50155,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49928,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50789,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51138,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51743,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51452,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2017/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51673,
+          "output": "out/v-bon/중소벤처기업부/서식/2017/0572.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000572",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 573,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50492,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50777,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51062,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51347,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51696,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 52109,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2017/0573.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51754,
+          "output": "out/v-bon/과학기술정보통신부/서식/2017/0573.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000573",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 574,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49741,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49962,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50183,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50404,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50625,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50846,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2017/0574.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 52091,
+          "output": "out/v-bon/문화체육관광부/서식/2017/0574.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000574",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/서식/2017/0575.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 575,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51038,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51387,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51992,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51701,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51922,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 52143,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2017/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 52556,
+          "output": "out/v-bon/환경부/서식/2017/0575.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000575",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "서식",
+    "year": 2017,
+    "serial": 576,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 49903,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50188,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50537,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50950,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50659,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50880,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51101,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2017/0576.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51322,
+          "output": "out/v-bon/해양수산부/서식/2017/0576.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000576",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/질의회신/2017/0577.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 577,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 49792,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50013,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50234,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50455,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50740,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50897,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51182,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2017/0577.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51467,
+          "output": "out/v-bon/법제처/질의회신/2017/0577.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0009.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0009.json
@@ -1,0 +1,9984 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000577",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 578,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50449,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50158,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50379,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50600,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51013,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50914,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51135,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2017/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51356,
+          "output": "out/v-bon/행정안전부/질의회신/2017/0578.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000578",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 579,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50338,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50751,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50396,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50553,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50710,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50931,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51344,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2017/0579.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51693,
+          "output": "out/v-bon/국세청/질의회신/2017/0579.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000579",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/질의회신/2017/0580.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 580,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 49843,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50064,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50541,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50506,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50983,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51268,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51553,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2017/0580.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51838,
+          "output": "out/v-bon/대법원/질의회신/2017/0580.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000580",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 581,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50180,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50401,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50814,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50523,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50744,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50965,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51186,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2017/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51407,
+          "output": "out/v-bon/특허청/질의회신/2017/0581.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000581",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 582,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50197,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50354,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50511,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50540,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51145,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51494,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 52099,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2017/0582.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51808,
+          "output": "out/v-bon/교육부/질의회신/2017/0582.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000582",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 583,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50342,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50115,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50784,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51069,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51354,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51639,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51988,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2017/0583.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 52401,
+          "output": "out/v-bon/보건복지부/질의회신/2017/0583.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000583",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 584,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50615,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50132,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50353,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50574,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50795,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51016,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51237,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2017/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51458,
+          "output": "out/v-bon/국토교통부/질의회신/2017/0584.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000584",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 585,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50312,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50149,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50946,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51295,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51900,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51609,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51830,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2017/0585.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 52051,
+          "output": "out/v-bon/고용노동부/질의회신/2017/0585.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000585",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/질의회신/2017/0586.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 586,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 50585,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 50870,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51155,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51440,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51789,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 52202,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51847,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2017/0586.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 52004,
+          "output": "out/v-bon/외교부/질의회신/2017/0586.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000586",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 587,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 49962,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50183,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50404,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 50625,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 50846,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51067,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 52056,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2017/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51509,
+          "output": "out/v-bon/기획재정부/질의회신/2017/0587.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000587",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 588,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51003,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51352,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51957,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51666,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 51887,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 52108,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "outputFormat": "hwpx",
+          "wasDistribution": true,
+          "bytes": 52521,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2017/0588.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "outputFormat": "hwpx",
+          "wasDistribution": false,
+          "bytes": 51526,
+          "output": "out/v-bon/공정거래위원회/질의회신/2017/0588.out.hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000588",
+    "command": "convert",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "convert",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 589,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 51404,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51689,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 52038,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 52451,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 52096,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 52253,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": false,
+          "bytes": 52410,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2017/0589.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "outputFormat": "hwp5",
+          "wasDistribution": true,
+          "bytes": 51543,
+          "output": "out/v-bon/금융위원회/질의회신/2017/0589.out.hwp",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000589",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/질의회신/2017/0590.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 590,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2017/0590.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-589",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/질의회신/2017/0590.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2017/0590.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-602",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/질의회신/2017/0590.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000590",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/질의회신/2017/0591.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 591,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2017/0591.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 9,
+          "find": "구분",
+          "replace": "치환-590",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2017/0591.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2017/0591.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "소속",
+          "replace": "치환-603",
+          "occurrence": 4,
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2017/0591.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000591",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/질의회신/2017/0592.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 592,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2017/0592.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-591",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/질의회신/2017/0592.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2017/0592.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "연락처",
+          "replace": "치환-604",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/질의회신/2017/0592.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000592",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/질의회신/2017/0593.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 593,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2017/0593.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-592",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/질의회신/2017/0593.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2017/0593.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-605",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/질의회신/2017/0593.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000593",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/질의회신/2017/0594.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 594,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2017/0594.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 4,
+          "find": "소속",
+          "replace": "치환-593",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/질의회신/2017/0594.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2017/0594.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 4,
+          "find": "수량",
+          "replace": "치환-606",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/질의회신/2017/0594.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000594",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/질의회신/2017/0595.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 595,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2017/0595.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-594",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/질의회신/2017/0595.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2017/0595.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "단가",
+          "replace": "치환-607",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/질의회신/2017/0595.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000595",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/질의회신/2017/0596.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 596,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2017/0596.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "비고",
+          "replace": "치환-595",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/질의회신/2017/0596.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2017/0596.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-608",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/질의회신/2017/0596.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000596",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/질의회신/2017/0597.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 597,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2017/0597.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 10,
+          "find": "수량",
+          "replace": "치환-596",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/질의회신/2017/0597.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2017/0597.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-609",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/질의회신/2017/0597.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000597",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/질의회신/2017/0598.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 598,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2017/0598.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "단가",
+          "replace": "치환-597",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/질의회신/2017/0598.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2017/0598.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-610",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/질의회신/2017/0598.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000598",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/질의회신/2017/0599.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 599,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2017/0599.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "금액",
+          "replace": "치환-598",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/질의회신/2017/0599.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2017/0599.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "성명",
+          "replace": "치환-611",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/질의회신/2017/0599.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000599",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/질의회신/2017/0600.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 600,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2017/0600.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-599",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/질의회신/2017/0600.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2017/0600.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-612",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/질의회신/2017/0600.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000600",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/질의회신/2017/0601.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 601,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2017/0601.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 12,
+          "find": "구분",
+          "replace": "치환-600",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/질의회신/2017/0601.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2017/0601.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 14,
+          "find": "소속",
+          "replace": "치환-613",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/질의회신/2017/0601.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000601",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/질의회신/2017/0602.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 602,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2017/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "성명",
+          "replace": "치환-601",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/질의회신/2017/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2017/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "연락처",
+          "replace": "치환-614",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/질의회신/2017/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000602",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/질의회신/2017/0603.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 603,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2017/0603.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-602",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/질의회신/2017/0603.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2017/0603.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-615",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/질의회신/2017/0603.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000603",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/질의회신/2017/0604.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 604,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2017/0604.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "소속",
+          "replace": "치환-603",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/질의회신/2017/0604.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2017/0604.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-616",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/질의회신/2017/0604.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2017/0604.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-629",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/질의회신/2017/0604.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000604",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/질의회신/2017/0605.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 605,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2017/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "연락처",
+          "replace": "치환-604",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2017/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2017/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "단가",
+          "replace": "치환-617",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2017/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2017/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-630",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2017/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000605",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/질의회신/2017/0606.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 606,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2017/0606.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-605",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/질의회신/2017/0606.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2017/0606.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-618",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/질의회신/2017/0606.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2017/0606.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "성명",
+          "replace": "치환-631",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/질의회신/2017/0606.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000606",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/질의회신/2017/0607.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 607,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2017/0607.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 3,
+          "find": "수량",
+          "replace": "치환-606",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/질의회신/2017/0607.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2017/0607.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 3,
+          "find": "일자",
+          "replace": "치환-619",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/질의회신/2017/0607.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2017/0607.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 6,
+          "find": "직급",
+          "replace": "치환-632",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/질의회신/2017/0607.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000607",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/질의회신/2017/0608.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "질의회신",
+    "year": 2017,
+    "serial": 608,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2017/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "단가",
+          "replace": "치환-607",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/질의회신/2017/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2017/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "구분",
+          "replace": "치환-620",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/질의회신/2017/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2017/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "소속",
+          "replace": "치환-633",
+          "occurrence": 2,
+          "output": "out/v-bon/해양수산부/질의회신/2017/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000608",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/업무계획/2017/0609.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 609,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2017/0609.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "금액",
+          "replace": "치환-608",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/업무계획/2017/0609.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2017/0609.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-621",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/업무계획/2017/0609.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2017/0609.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "연락처",
+          "replace": "치환-634",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/업무계획/2017/0609.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000609",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/업무계획/2017/0610.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 610,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2017/0610.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 9,
+          "find": "일자",
+          "replace": "치환-609",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/업무계획/2017/0610.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2017/0610.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-622",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/업무계획/2017/0610.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2017/0610.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-635",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/업무계획/2017/0610.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000610",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/업무계획/2017/0611.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 611,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2017/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "구분",
+          "replace": "치환-610",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/업무계획/2017/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2017/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-623",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/업무계획/2017/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2017/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 7,
+          "find": "수량",
+          "replace": "치환-636",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/업무계획/2017/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000611",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/업무계획/2017/0612.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 612,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2017/0612.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "성명",
+          "replace": "치환-611",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/업무계획/2017/0612.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2017/0612.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "연락처",
+          "replace": "치환-624",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/업무계획/2017/0612.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2017/0612.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-637",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/업무계획/2017/0612.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000612",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/업무계획/2017/0613.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 613,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2017/0613.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-612",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/업무계획/2017/0613.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2017/0613.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-625",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/업무계획/2017/0613.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2017/0613.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-638",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/업무계획/2017/0613.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000613",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/업무계획/2017/0614.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 614,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2017/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-613",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/업무계획/2017/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2017/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 12,
+          "find": "수량",
+          "replace": "치환-626",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/업무계획/2017/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2017/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 18,
+          "find": "일자",
+          "replace": "치환-639",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/업무계획/2017/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000614",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/업무계획/2017/0615.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 615,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2017/0615.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "연락처",
+          "replace": "치환-614",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/업무계획/2017/0615.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2017/0615.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "단가",
+          "replace": "치환-627",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/업무계획/2017/0615.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2017/0615.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "구분",
+          "replace": "치환-640",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/업무계획/2017/0615.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000615",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/업무계획/2017/0616.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 616,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2017/0616.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-615",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/업무계획/2017/0616.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2017/0616.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-628",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/업무계획/2017/0616.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2017/0616.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-641",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/업무계획/2017/0616.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000616",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/업무계획/2017/0617.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 617,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2017/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 28,
+          "find": "수량",
+          "replace": "치환-616",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/업무계획/2017/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2017/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "일자",
+          "replace": "치환-629",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/업무계획/2017/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2017/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 20,
+          "find": "직급",
+          "replace": "치환-642",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/업무계획/2017/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000617",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/업무계획/2017/0618.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 618,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2017/0618.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "단가",
+          "replace": "치환-617",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/업무계획/2017/0618.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2017/0618.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "구분",
+          "replace": "치환-630",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/업무계획/2017/0618.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2017/0618.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-643",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/업무계획/2017/0618.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2017/0618.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-656",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/업무계획/2017/0618.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000618",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/업무계획/2017/0619.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 619,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2017/0619.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-618",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/업무계획/2017/0619.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2017/0619.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-631",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/업무계획/2017/0619.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2017/0619.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "연락처",
+          "replace": "치환-644",
+          "occurrence": 1,
+          "output": "out/v-bon/기획재정부/업무계획/2017/0619.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2017/0619.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-657",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/업무계획/2017/0619.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000619",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/업무계획/2017/0620.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 620,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2017/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 2,
+          "find": "일자",
+          "replace": "치환-619",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/업무계획/2017/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2017/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 2,
+          "find": "직급",
+          "replace": "치환-632",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/업무계획/2017/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2017/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 5,
+          "find": "비고",
+          "replace": "치환-645",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/업무계획/2017/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2017/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-658",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/업무계획/2017/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000620",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/업무계획/2017/0621.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 621,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2017/0621.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "구분",
+          "replace": "치환-620",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/업무계획/2017/0621.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2017/0621.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "소속",
+          "replace": "치환-633",
+          "occurrence": 2,
+          "output": "out/v-bon/금융위원회/업무계획/2017/0621.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2017/0621.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-646",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/업무계획/2017/0621.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2017/0621.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-659",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/업무계획/2017/0621.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000621",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/업무계획/2017/0622.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 622,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2017/0622.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "성명",
+          "replace": "치환-621",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/업무계획/2017/0622.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2017/0622.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-634",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/업무계획/2017/0622.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2017/0622.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "단가",
+          "replace": "치환-647",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/업무계획/2017/0622.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2017/0622.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "구분",
+          "replace": "치환-660",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/업무계획/2017/0622.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000622",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/업무계획/2017/0623.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 623,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2017/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 8,
+          "find": "직급",
+          "replace": "치환-622",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2017/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2017/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-635",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2017/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2017/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-648",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2017/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2017/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-661",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2017/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000623",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/업무계획/2017/0624.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 624,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2017/0624.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "소속",
+          "replace": "치환-623",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/업무계획/2017/0624.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2017/0624.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-636",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/업무계획/2017/0624.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2017/0624.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 6,
+          "find": "일자",
+          "replace": "치환-649",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/업무계획/2017/0624.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2017/0624.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "직급",
+          "replace": "치환-662",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/업무계획/2017/0624.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000624",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/업무계획/2017/0625.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 625,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2017/0625.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "연락처",
+          "replace": "치환-624",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/업무계획/2017/0625.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2017/0625.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-637",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/업무계획/2017/0625.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2017/0625.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "구분",
+          "replace": "치환-650",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/업무계획/2017/0625.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2017/0625.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-663",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/업무계획/2017/0625.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000625",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/업무계획/2017/0626.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 626,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2017/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-625",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/업무계획/2017/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2017/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-638",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/업무계획/2017/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2017/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-651",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/업무계획/2017/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2017/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-664",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/업무계획/2017/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000626",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/업무계획/2017/0627.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 627,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2017/0627.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-626",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/업무계획/2017/0627.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2017/0627.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 11,
+          "find": "일자",
+          "replace": "치환-639",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/업무계획/2017/0627.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2017/0627.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 17,
+          "find": "직급",
+          "replace": "치환-652",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/업무계획/2017/0627.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2017/0627.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-665",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/업무계획/2017/0627.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000627",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/업무계획/2017/0628.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 628,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2017/0628.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "단가",
+          "replace": "치환-627",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/업무계획/2017/0628.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2017/0628.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "구분",
+          "replace": "치환-640",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/업무계획/2017/0628.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2017/0628.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "소속",
+          "replace": "치환-653",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/업무계획/2017/0628.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2017/0628.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "수량",
+          "replace": "치환-666",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/업무계획/2017/0628.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000628",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/업무계획/2017/0629.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 629,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2017/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-628",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/업무계획/2017/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2017/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-641",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/업무계획/2017/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2017/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-654",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/업무계획/2017/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2017/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-667",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/업무계획/2017/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000629",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/업무계획/2017/0630.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 630,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2017/0630.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 24,
+          "find": "일자",
+          "replace": "치환-629",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/업무계획/2017/0630.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2017/0630.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "직급",
+          "replace": "치환-642",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/업무계획/2017/0630.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2017/0630.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 16,
+          "find": "비고",
+          "replace": "치환-655",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/업무계획/2017/0630.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2017/0630.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 16,
+          "find": "금액",
+          "replace": "치환-668",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/업무계획/2017/0630.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000630",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/업무계획/2017/0631.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 631,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2017/0631.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 25,
+          "find": "구분",
+          "replace": "치환-630",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/업무계획/2017/0631.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2017/0631.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 28,
+          "find": "소속",
+          "replace": "치환-643",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/업무계획/2017/0631.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2017/0631.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "수량",
+          "replace": "치환-656",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/업무계획/2017/0631.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2017/0631.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "일자",
+          "replace": "치환-669",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/업무계획/2017/0631.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000631",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 632,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-631",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/업무계획/2017/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-644",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/업무계획/2017/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-657",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/업무계획/2017/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-670",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/업무계획/2017/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2017/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-683",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/업무계획/2017/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000632",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 633,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 1,
+          "find": "직급",
+          "replace": "치환-632",
+          "occurrence": 1,
+          "output": "out/v-bon/병무청/업무계획/2017/0633.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 1,
+          "find": "비고",
+          "replace": "치환-645",
+          "occurrence": 2,
+          "output": "out/v-bon/병무청/업무계획/2017/0633.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 4,
+          "find": "금액",
+          "replace": "치환-658",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/업무계획/2017/0633.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-671",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/업무계획/2017/0633.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2017/0633.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-684",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/업무계획/2017/0633.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000633",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/업무계획/2017/0634.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 634,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2017/0634.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "소속",
+          "replace": "치환-633",
+          "occurrence": 2,
+          "output": "out/v-bon/산림청/업무계획/2017/0634.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2017/0634.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-646",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/업무계획/2017/0634.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2017/0634.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-659",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/업무계획/2017/0634.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2017/0634.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-672",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/업무계획/2017/0634.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2017/0634.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 2,
+          "find": "비고",
+          "replace": "치환-685",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/업무계획/2017/0634.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000634",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 635,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "연락처",
+          "replace": "치환-634",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/업무계획/2017/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-647",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/업무계획/2017/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "구분",
+          "replace": "치환-660",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/업무계획/2017/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "소속",
+          "replace": "치환-673",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/업무계획/2017/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2017/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "수량",
+          "replace": "치환-686",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/업무계획/2017/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000635",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 636,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 7,
+          "find": "비고",
+          "replace": "치환-635",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2017/0636.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-648",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2017/0636.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-661",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2017/0636.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-674",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2017/0636.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2017/0636.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-687",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2017/0636.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000636",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 637,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "수량",
+          "replace": "치환-636",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2017/0637.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-649",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2017/0637.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 5,
+          "find": "직급",
+          "replace": "치환-662",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2017/0637.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 7,
+          "find": "비고",
+          "replace": "치환-675",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2017/0637.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2017/0637.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 13,
+          "find": "금액",
+          "replace": "치환-688",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2017/0637.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000637",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 638,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "단가",
+          "replace": "치환-637",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/업무계획/2017/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "구분",
+          "replace": "치환-650",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/업무계획/2017/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "소속",
+          "replace": "치환-663",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/업무계획/2017/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-676",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/업무계획/2017/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2017/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "일자",
+          "replace": "치환-689",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/업무계획/2017/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000638",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 639,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-638",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/업무계획/2017/0639.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-651",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/업무계획/2017/0639.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-664",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/업무계획/2017/0639.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-677",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/업무계획/2017/0639.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2017/0639.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-690",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/업무계획/2017/0639.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000639",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "업무계획",
+    "year": 2017,
+    "serial": 640,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "일자",
+          "replace": "치환-639",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/업무계획/2017/0640.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 10,
+          "find": "직급",
+          "replace": "치환-652",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/업무계획/2017/0640.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 16,
+          "find": "비고",
+          "replace": "치환-665",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/업무계획/2017/0640.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-678",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/업무계획/2017/0640.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2017/0640.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "성명",
+          "replace": "치환-691",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/업무계획/2017/0640.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000640",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/예산서/2017/0641.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 641,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2017/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "구분",
+          "replace": "치환-640",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/예산서/2017/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2017/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "소속",
+          "replace": "치환-653",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/예산서/2017/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2017/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "수량",
+          "replace": "치환-666",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/예산서/2017/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2017/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "일자",
+          "replace": "치환-679",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/예산서/2017/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2017/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "직급",
+          "replace": "치환-692",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/예산서/2017/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0010.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0010.json
@@ -1,0 +1,12418 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000641",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 642,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-641",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/예산서/2017/0642.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-654",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/예산서/2017/0642.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-667",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/예산서/2017/0642.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-680",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/예산서/2017/0642.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2017/0642.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-693",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/예산서/2017/0642.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000642",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/예산서/2017/0643.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 643,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2017/0643.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 20,
+          "find": "직급",
+          "replace": "치환-642",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/예산서/2017/0643.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2017/0643.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "비고",
+          "replace": "치환-655",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/예산서/2017/0643.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2017/0643.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 12,
+          "find": "금액",
+          "replace": "치환-668",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/예산서/2017/0643.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2017/0643.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 12,
+          "find": "성명",
+          "replace": "치환-681",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/예산서/2017/0643.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2017/0643.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 15,
+          "find": "연락처",
+          "replace": "치환-694",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/예산서/2017/0643.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000643",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/예산서/2017/0644.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 644,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2017/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 21,
+          "find": "소속",
+          "replace": "치환-643",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/예산서/2017/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2017/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 24,
+          "find": "수량",
+          "replace": "치환-656",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/예산서/2017/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2017/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "일자",
+          "replace": "치환-669",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/예산서/2017/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2017/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "직급",
+          "replace": "치환-682",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/예산서/2017/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2017/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "비고",
+          "replace": "치환-695",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/예산서/2017/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000644",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/예산서/2017/0645.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 645,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2017/0645.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-644",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/예산서/2017/0645.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2017/0645.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-657",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/예산서/2017/0645.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2017/0645.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "구분",
+          "replace": "치환-670",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/예산서/2017/0645.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2017/0645.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-683",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/예산서/2017/0645.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2017/0645.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "수량",
+          "replace": "치환-696",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/예산서/2017/0645.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000645",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/예산서/2017/0646.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 646,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-645",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-658",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 3,
+          "find": "성명",
+          "replace": "치환-671",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-684",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-697",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2017/0646.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/예산서/2017/0646.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000646",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 647,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-646",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-659",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-672",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-685",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 1,
+          "find": "금액",
+          "replace": "치환-698",
+          "occurrence": 3,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2017/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 3,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/예산서/2017/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000647",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 648,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "단가",
+          "replace": "치환-647",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-660",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "소속",
+          "replace": "치환-673",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "수량",
+          "replace": "치환-686",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "일자",
+          "replace": "치환-699",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2017/0648.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/예산서/2017/0648.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000648",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 649,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-648",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-661",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-674",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-687",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-700",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2017/0649.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-713",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/예산서/2017/0649.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000649",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/예산서/2017/0650.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 650,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "일자",
+          "replace": "치환-649",
+          "occurrence": 2,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-662",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 4,
+          "find": "비고",
+          "replace": "치환-675",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-688",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 12,
+          "find": "성명",
+          "replace": "치환-701",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2017/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-714",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/예산서/2017/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000650",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 651,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "구분",
+          "replace": "치환-650",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "소속",
+          "replace": "치환-663",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "수량",
+          "replace": "치환-676",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "일자",
+          "replace": "치환-689",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "직급",
+          "replace": "치환-702",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2017/0651.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "비고",
+          "replace": "치환-715",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/예산서/2017/0651.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000651",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 652,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-651",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-664",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-677",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-690",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-703",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2017/0652.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-716",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/예산서/2017/0652.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000652",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 653,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-652",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-665",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 15,
+          "find": "금액",
+          "replace": "치환-678",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-691",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 7,
+          "find": "연락처",
+          "replace": "치환-704",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2017/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 7,
+          "find": "단가",
+          "replace": "치환-717",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/예산서/2017/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000653",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 654,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-653",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "수량",
+          "replace": "치환-666",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "일자",
+          "replace": "치환-679",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "직급",
+          "replace": "치환-692",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "비고",
+          "replace": "치환-705",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2017/0654.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-718",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/예산서/2017/0654.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000654",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 655,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-654",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-667",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-680",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-693",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-706",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2017/0655.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-719",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2017/0655.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000655",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 656,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 18,
+          "find": "비고",
+          "replace": "치환-655",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "금액",
+          "replace": "치환-668",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 10,
+          "find": "성명",
+          "replace": "치환-681",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 10,
+          "find": "연락처",
+          "replace": "치환-694",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 13,
+          "find": "단가",
+          "replace": "치환-707",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2017/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-720",
+          "occurrence": null,
+          "output": "out/v-bon/국민권익위원회/예산서/2017/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000656",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 657,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "수량",
+          "replace": "치환-656",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "일자",
+          "replace": "치환-669",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "직급",
+          "replace": "치환-682",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "비고",
+          "replace": "치환-695",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "금액",
+          "replace": "치환-708",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2017/0657.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-721",
+          "occurrence": null,
+          "output": "out/v-bon/국가인권위원회/예산서/2017/0657.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000657",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/예산서/2017/0658.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 658,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-657",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-670",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "소속",
+          "replace": "치환-683",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-696",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "일자",
+          "replace": "치환-709",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2017/0658.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "직급",
+          "replace": "치환-722",
+          "occurrence": null,
+          "output": "out/v-bon/통계청/예산서/2017/0658.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000658",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/예산서/2017/0659.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 659,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 20,
+          "find": "금액",
+          "replace": "치환-658",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 20,
+          "find": "성명",
+          "replace": "치환-671",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 23,
+          "find": "연락처",
+          "replace": "치환-684",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-697",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2017/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-723",
+          "occurrence": null,
+          "output": "out/v-bon/기상청/예산서/2017/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000659",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/예산서/2017/0660.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 660,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-659",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-672",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-685",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-698",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 2,
+          "find": "연락처",
+          "replace": "치환-724",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2017/0660.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "output": "out/v-bon/관세청/예산서/2017/0660.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000660",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/예산서/2017/0661.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 661,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "구분",
+          "replace": "치환-660",
+          "occurrence": 1,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-673",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "수량",
+          "replace": "치환-686",
+          "occurrence": 3,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "일자",
+          "replace": "치환-699",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "비고",
+          "replace": "치환-725",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2017/0661.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "output": "out/v-bon/검찰청/예산서/2017/0661.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000661",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 662,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-661",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-674",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-687",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-700",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-713",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-726",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2017/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-739",
+          "occurrence": null,
+          "output": "out/v-bon/경찰청/예산서/2017/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000662",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/예산서/2017/0663.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 663,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-662",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-675",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 3,
+          "find": "금액",
+          "replace": "치환-688",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-701",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 11,
+          "find": "연락처",
+          "replace": "치환-714",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "단가",
+          "replace": "치환-727",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2017/0663.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 3,
+          "find": "구분",
+          "replace": "치환-740",
+          "occurrence": null,
+          "output": "out/v-bon/소방청/예산서/2017/0663.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000663",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 664,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "소속",
+          "replace": "치환-663",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "수량",
+          "replace": "치환-676",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "일자",
+          "replace": "치환-689",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-702",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-715",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "금액",
+          "replace": "치환-728",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2017/0664.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "성명",
+          "replace": "치환-741",
+          "occurrence": null,
+          "output": "out/v-bon/해양경찰청/예산서/2017/0664.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000664",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/예산서/2017/0665.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 665,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-664",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-677",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-690",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-703",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-716",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-729",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2017/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "직급",
+          "replace": "치환-742",
+          "occurrence": null,
+          "output": "out/v-bon/병무청/예산서/2017/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000665",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/예산서/2017/0666.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 666,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 6,
+          "find": "비고",
+          "replace": "치환-665",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-678",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 14,
+          "find": "성명",
+          "replace": "치환-691",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "연락처",
+          "replace": "치환-704",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 6,
+          "find": "단가",
+          "replace": "치환-717",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 6,
+          "find": "구분",
+          "replace": "치환-730",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2017/0666.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 9,
+          "find": "소속",
+          "replace": "치환-743",
+          "occurrence": null,
+          "output": "out/v-bon/산림청/예산서/2017/0666.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000666",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 667,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-666",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "일자",
+          "replace": "치환-679",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "직급",
+          "replace": "치환-692",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "비고",
+          "replace": "치환-705",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-718",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-731",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2017/0667.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-744",
+          "occurrence": null,
+          "output": "out/v-bon/농촌진흥청/예산서/2017/0667.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000667",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 668,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-667",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-680",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-693",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-706",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "일자",
+          "replace": "치환-719",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-732",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2017/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "비고",
+          "replace": "치환-745",
+          "occurrence": null,
+          "output": "out/v-bon/중소벤처기업부/예산서/2017/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000668",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 669,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 17,
+          "find": "금액",
+          "replace": "치환-668",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "성명",
+          "replace": "치환-681",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 9,
+          "find": "연락처",
+          "replace": "치환-694",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 9,
+          "find": "단가",
+          "replace": "치환-707",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 12,
+          "find": "구분",
+          "replace": "치환-720",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-733",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2017/0669.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-746",
+          "occurrence": null,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2017/0669.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000669",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 670,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "일자",
+          "replace": "치환-669",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "직급",
+          "replace": "치환-682",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-695",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-708",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-721",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-734",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2017/0670.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-747",
+          "occurrence": null,
+          "output": "out/v-bon/문화체육관광부/예산서/2017/0670.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000670",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/예산서/2017/0671.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 671,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-670",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-683",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "수량",
+          "replace": "치환-696",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-709",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "직급",
+          "replace": "치환-722",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "비고",
+          "replace": "치환-735",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2017/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "금액",
+          "replace": "치환-748",
+          "occurrence": null,
+          "output": "out/v-bon/환경부/예산서/2017/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000671",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예산서",
+    "year": 2017,
+    "serial": 672,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 16,
+          "find": "성명",
+          "replace": "치환-671",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 16,
+          "find": "연락처",
+          "replace": "치환-684",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 19,
+          "find": "단가",
+          "replace": "치환-697",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-723",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-736",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2017/0672.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-749",
+          "occurrence": null,
+          "output": "out/v-bon/해양수산부/예산서/2017/0672.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000672",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/회의록/2017/0673.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 673,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "직급",
+          "replace": "치환-672",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "비고",
+          "replace": "치환-685",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "금액",
+          "replace": "치환-698",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 20,
+          "find": "연락처",
+          "replace": "치환-724",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 22,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2017/0673.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 28,
+          "find": "구분",
+          "replace": "치환-750",
+          "occurrence": null,
+          "output": "out/v-bon/법제처/회의록/2017/0673.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000673",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 674,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-673",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-686",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-699",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": 1,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "비고",
+          "replace": "치환-725",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-751",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2017/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "output": "out/v-bon/행정안전부/회의록/2017/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000674",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/회의록/2017/0675.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 675,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-674",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-687",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-700",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-713",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-726",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-739",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-752",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2017/0675.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-765",
+          "occurrence": null,
+          "output": "out/v-bon/국세청/회의록/2017/0675.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000675",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/회의록/2017/0676.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 676,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-675",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-688",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 2,
+          "find": "성명",
+          "replace": "치환-701",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-714",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-727",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "구분",
+          "replace": "치환-740",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 2,
+          "find": "소속",
+          "replace": "치환-753",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2017/0676.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 2,
+          "find": "수량",
+          "replace": "치환-766",
+          "occurrence": null,
+          "output": "out/v-bon/대법원/회의록/2017/0676.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000676",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/회의록/2017/0677.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 677,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "수량",
+          "replace": "치환-676",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "일자",
+          "replace": "치환-689",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "직급",
+          "replace": "치환-702",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "비고",
+          "replace": "치환-715",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-728",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "성명",
+          "replace": "치환-741",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "연락처",
+          "replace": "치환-754",
+          "occurrence": null,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2017/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "단가",
+          "replace": "치환-767",
+          "occurrence": 4,
+          "output": "out/v-bon/특허청/회의록/2017/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000677",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/회의록/2017/0678.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 678,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-677",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-690",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-703",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-716",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-729",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-742",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "비고",
+          "replace": "치환-755",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2017/0678.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-768",
+          "occurrence": null,
+          "output": "out/v-bon/교육부/회의록/2017/0678.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000678",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 679,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 5,
+          "find": "금액",
+          "replace": "치환-678",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-691",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 13,
+          "find": "연락처",
+          "replace": "치환-704",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "단가",
+          "replace": "치환-717",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 5,
+          "find": "구분",
+          "replace": "치환-730",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 5,
+          "find": "소속",
+          "replace": "치환-743",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 8,
+          "find": "수량",
+          "replace": "치환-756",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2017/0679.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-769",
+          "occurrence": null,
+          "output": "out/v-bon/보건복지부/회의록/2017/0679.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000679",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 680,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "일자",
+          "replace": "치환-679",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "직급",
+          "replace": "치환-692",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "비고",
+          "replace": "치환-705",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "금액",
+          "replace": "치환-718",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-731",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "연락처",
+          "replace": "치환-744",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "단가",
+          "replace": "치환-757",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2017/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-770",
+          "occurrence": null,
+          "output": "out/v-bon/국토교통부/회의록/2017/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000680",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 681,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-680",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-693",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-706",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-719",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-732",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-745",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "금액",
+          "replace": "치환-758",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2017/0681.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "성명",
+          "replace": "치환-771",
+          "occurrence": null,
+          "output": "out/v-bon/고용노동부/회의록/2017/0681.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000681",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/회의록/2017/0682.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 682,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 16,
+          "find": "성명",
+          "replace": "치환-681",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "연락처",
+          "replace": "치환-694",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-707",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 8,
+          "find": "구분",
+          "replace": "치환-720",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 11,
+          "find": "소속",
+          "replace": "치환-733",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-746",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-759",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2017/0682.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-772",
+          "occurrence": null,
+          "output": "out/v-bon/외교부/회의록/2017/0682.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000682",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 683,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "직급",
+          "replace": "치환-682",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "비고",
+          "replace": "치환-695",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-708",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-721",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "연락처",
+          "replace": "치환-734",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-747",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 9,
+          "find": "구분",
+          "replace": "치환-760",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2017/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 11,
+          "find": "소속",
+          "replace": "치환-773",
+          "occurrence": null,
+          "output": "out/v-bon/기획재정부/회의록/2017/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000683",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 684,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-683",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-696",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "일자",
+          "replace": "치환-709",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-722",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "비고",
+          "replace": "치환-735",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "금액",
+          "replace": "치환-748",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "성명",
+          "replace": "치환-761",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2017/0684.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "연락처",
+          "replace": "치환-774",
+          "occurrence": null,
+          "output": "out/v-bon/공정거래위원회/회의록/2017/0684.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000684",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 685,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 12,
+          "find": "연락처",
+          "replace": "치환-684",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 12,
+          "find": "단가",
+          "replace": "치환-697",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 15,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-723",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-736",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-749",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-762",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2017/0685.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-775",
+          "occurrence": null,
+          "output": "out/v-bon/금융위원회/회의록/2017/0685.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000685",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 686,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "비고",
+          "replace": "치환-685",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "금액",
+          "replace": "치환-698",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-724",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 16,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 18,
+          "find": "구분",
+          "replace": "치환-750",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 24,
+          "find": "소속",
+          "replace": "치환-763",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2017/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "수량",
+          "replace": "치환-776",
+          "occurrence": null,
+          "output": "out/v-bon/방송통신위원회/회의록/2017/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000686",
+    "command": "replace-text",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 687,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "수량",
+          "replace": "치환-686",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-699",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 21,
+          "find": "비고",
+          "replace": "치환-725",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 22,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 23,
+          "find": "성명",
+          "replace": "치환-751",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 25,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2017/0687.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 28,
+          "find": "단가",
+          "replace": "치환-777",
+          "occurrence": null,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2017/0687.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000687",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/회의록/2017/0688.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 688,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2017/0688.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-687",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2017/0688.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "구분",
+          "replace": "치환-700",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000688",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/회의록/2017/0689.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 689,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2017/0689.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "금액",
+          "replace": "치환-688",
+          "occurrence": 1,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2017/0689.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "성명",
+          "replace": "치환-701",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000689",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/회의록/2017/0690.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 690,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2017/0690.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "일자",
+          "replace": "치환-689",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2017/0690.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "직급",
+          "replace": "치환-702",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000690",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/회의록/2017/0691.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 691,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2017/0691.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "구분",
+          "replace": "치환-690",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2017/0691.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "소속",
+          "replace": "치환-703",
+          "occurrence": 4,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000691",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/회의록/2017/0692.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 692,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2017/0692.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-691",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2017/0692.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-704",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000692",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/회의록/2017/0693.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 693,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2017/0693.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-692",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2017/0693.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-705",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000693",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/회의록/2017/0694.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 694,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2017/0694.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-693",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2017/0694.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-706",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000694",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/회의록/2017/0695.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 695,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2017/0695.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-694",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2017/0695.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-707",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000695",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/회의록/2017/0696.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 696,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2017/0696.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-695",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2017/0696.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "금액",
+          "replace": "치환-708",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000696",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/회의록/2017/0697.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 697,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2017/0697.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-696",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2017/0697.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "일자",
+          "replace": "치환-709",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000697",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/회의록/2017/0698.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 698,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2017/0698.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "단가",
+          "replace": "치환-697",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2017/0698.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000698",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/회의록/2017/0699.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 699,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2017/0699.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "금액",
+          "replace": "치환-698",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2017/0699.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000699",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/회의록/2017/0700.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 700,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2017/0700.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-699",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2017/0700.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000700",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/회의록/2017/0701.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 701,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2017/0701.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-700",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2017/0701.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-713",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000701",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/회의록/2017/0702.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 702,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2017/0702.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-701",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2017/0702.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-714",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2017/0702.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-727",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000702",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/회의록/2017/0703.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 703,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2017/0703.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-702",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2017/0703.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-715",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2017/0703.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-728",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000703",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/회의록/2017/0704.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "회의록",
+    "year": 2017,
+    "serial": 704,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2017/0704.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-703",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2017/0704.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "수량",
+          "replace": "치환-716",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2017/0704.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "일자",
+          "replace": "치환-729",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000704",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/계약서/2017/0705.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 705,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2017/0705.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "연락처",
+          "replace": "치환-704",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2017/0705.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "단가",
+          "replace": "치환-717",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2017/0705.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "구분",
+          "replace": "치환-730",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0011.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0011.json
@@ -1,0 +1,10094 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000705",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/계약서/2017/0706.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 706,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2017/0706.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "비고",
+          "replace": "치환-705",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2017/0706.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-718",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2017/0706.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "성명",
+          "replace": "치환-731",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000706",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/계약서/2017/0707.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 707,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2017/0707.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "수량",
+          "replace": "치환-706",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2017/0707.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "일자",
+          "replace": "치환-719",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2017/0707.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-732",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000707",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/계약서/2017/0708.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 708,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2017/0708.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-707",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2017/0708.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-720",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2017/0708.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-733",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000708",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/계약서/2017/0709.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 709,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2017/0709.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-708",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2017/0709.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-721",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2017/0709.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-734",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000709",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/계약서/2017/0710.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 710,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2017/0710.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-709",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2017/0710.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-722",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2017/0710.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-735",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000710",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/계약서/2017/0711.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 711,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2017/0711.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-710",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2017/0711.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-723",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2017/0711.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-736",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000711",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/계약서/2017/0712.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 712,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2017/0712.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-711",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2017/0712.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "연락처",
+          "replace": "치환-724",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2017/0712.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000712",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/계약서/2017/0713.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 713,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2017/0713.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "직급",
+          "replace": "치환-712",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2017/0713.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "비고",
+          "replace": "치환-725",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2017/0713.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000713",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/계약서/2017/0714.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 714,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2017/0714.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "소속",
+          "replace": "치환-713",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2017/0714.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "수량",
+          "replace": "치환-726",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2017/0714.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "일자",
+          "replace": "치환-739",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000714",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/계약서/2017/0715.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 715,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2017/0715.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "연락처",
+          "replace": "치환-714",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2017/0715.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "단가",
+          "replace": "치환-727",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2017/0715.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-740",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000715",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/계약서/2017/0716.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 716,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2017/0716.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-715",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2017/0716.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-728",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2017/0716.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-741",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2017/0716.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-754",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000716",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/계약서/2017/0717.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 717,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2017/0717.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-716",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2017/0717.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-729",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2017/0717.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-742",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2017/0717.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-755",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000717",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/계약서/2017/0718.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 718,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2017/0718.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-717",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2017/0718.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-730",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2017/0718.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-743",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2017/0718.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-756",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000718",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/계약서/2017/0719.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 719,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2017/0719.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-718",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2017/0719.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-731",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2017/0719.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-744",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2017/0719.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-757",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000719",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/계약서/2017/0720.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 720,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2017/0720.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-719",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2017/0720.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "직급",
+          "replace": "치환-732",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2017/0720.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "비고",
+          "replace": "치환-745",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2017/0720.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "금액",
+          "replace": "치환-758",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000720",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/계약서/2017/0721.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 721,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2017/0721.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "구분",
+          "replace": "치환-720",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2017/0721.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "소속",
+          "replace": "치환-733",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2017/0721.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "수량",
+          "replace": "치환-746",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2017/0721.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "일자",
+          "replace": "치환-759",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000721",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/계약서/2017/0722.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 722,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2017/0722.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "성명",
+          "replace": "치환-721",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2017/0722.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "연락처",
+          "replace": "치환-734",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2017/0722.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "단가",
+          "replace": "치환-747",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2017/0722.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "구분",
+          "replace": "치환-760",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000722",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/계약서/2017/0723.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 723,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2017/0723.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "직급",
+          "replace": "치환-722",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2017/0723.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "비고",
+          "replace": "치환-735",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2017/0723.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-748",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2017/0723.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-761",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000723",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/계약서/2017/0724.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 724,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2017/0724.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-723",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2017/0724.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-736",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2017/0724.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-749",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2017/0724.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-762",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000724",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/계약서/2017/0725.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 725,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2017/0725.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-724",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2017/0725.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2017/0725.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-750",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2017/0725.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-763",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000725",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/계약서/2017/0726.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 726,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2017/0726.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-725",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2017/0726.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2017/0726.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-751",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2017/0726.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000726",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/계약서/2017/0727.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 727,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2017/0727.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-726",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2017/0727.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-739",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2017/0727.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-752",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2017/0727.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "비고",
+          "replace": "치환-765",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000727",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/계약서/2017/0728.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 728,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2017/0728.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-727",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2017/0728.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 23,
+          "find": "구분",
+          "replace": "치환-740",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2017/0728.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "소속",
+          "replace": "치환-753",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2017/0728.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "수량",
+          "replace": "치환-766",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000728",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/계약서/2017/0729.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 729,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2017/0729.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "금액",
+          "replace": "치환-728",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2017/0729.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 21,
+          "find": "성명",
+          "replace": "치환-741",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2017/0729.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 22,
+          "find": "연락처",
+          "replace": "치환-754",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2017/0729.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 24,
+          "find": "단가",
+          "replace": "치환-767",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000729",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/계약서/2017/0730.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 730,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2017/0730.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "일자",
+          "replace": "치환-729",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2017/0730.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "직급",
+          "replace": "치환-742",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2017/0730.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-755",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2017/0730.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-768",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2017/0730.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-781",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000730",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 731,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-730",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-743",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-756",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-769",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2017/0731.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-782",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000731",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 732,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-731",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-744",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-757",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-770",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2017/0732.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-783",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000732",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 733,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-732",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-745",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-758",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-771",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2017/0733.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-784",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000733",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 734,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-733",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-746",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-759",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-772",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2017/0734.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-785",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000734",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/계약서/2017/0735.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 735,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2017/0735.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-734",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2017/0735.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-747",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2017/0735.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-760",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2017/0735.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "소속",
+          "replace": "치환-773",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2017/0735.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "수량",
+          "replace": "치환-786",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000735",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "계약서",
+    "year": 2017,
+    "serial": 736,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-735",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "금액",
+          "replace": "치환-748",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "성명",
+          "replace": "치환-761",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "연락처",
+          "replace": "치환-774",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2017/0736.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-787",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000736",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/점검표/2017/0737.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 737,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2017/0737.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "수량",
+          "replace": "치환-736",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2017/0737.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "일자",
+          "replace": "치환-749",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2017/0737.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "직급",
+          "replace": "치환-762",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2017/0737.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "비고",
+          "replace": "치환-775",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2017/0737.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-788",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000737",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 738,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-737",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "구분",
+          "replace": "치환-750",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "소속",
+          "replace": "치환-763",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "수량",
+          "replace": "치환-776",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2017/0738.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-789",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000738",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/점검표/2017/0739.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 739,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2017/0739.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "금액",
+          "replace": "치환-738",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2017/0739.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "성명",
+          "replace": "치환-751",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2017/0739.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2017/0739.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-777",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2017/0739.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-790",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000739",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/점검표/2017/0740.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 740,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2017/0740.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-739",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2017/0740.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-752",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2017/0740.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-765",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2017/0740.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-778",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2017/0740.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-791",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000740",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/점검표/2017/0741.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 741,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2017/0741.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-740",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2017/0741.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-753",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2017/0741.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-766",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2017/0741.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-779",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2017/0741.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-792",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000741",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/점검표/2017/0742.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 742,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2017/0742.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-741",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2017/0742.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-754",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2017/0742.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-767",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2017/0742.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-780",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2017/0742.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-793",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000742",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 743,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-742",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-755",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-768",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 27,
+          "find": "성명",
+          "replace": "치환-781",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2017/0743.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "연락처",
+          "replace": "치환-794",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000743",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 744,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-743",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "수량",
+          "replace": "치환-756",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-769",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "직급",
+          "replace": "치환-782",
+          "occurrence": 3,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "비고",
+          "replace": "치환-795",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2017/0744.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "금액",
+          "replace": "치환-808",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000744",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 745,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "연락처",
+          "replace": "치환-744",
+          "occurrence": 1,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "단가",
+          "replace": "치환-757",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "구분",
+          "replace": "치환-770",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "소속",
+          "replace": "치환-783",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-796",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2017/0745.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-809",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000745",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/점검표/2017/0746.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 746,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "비고",
+          "replace": "치환-745",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-758",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "성명",
+          "replace": "치환-771",
+          "occurrence": 4,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-784",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-797",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2017/0746.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-810",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000746",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 747,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "수량",
+          "replace": "치환-746",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "일자",
+          "replace": "치환-759",
+          "occurrence": 4,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-772",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-785",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-798",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2017/0747.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-811",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000747",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 748,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-747",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-760",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-773",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-786",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-799",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2017/0748.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-812",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000748",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 749,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-748",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-761",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-774",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-787",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-800",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2017/0749.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-813",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000749",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 750,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-749",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-762",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-775",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-788",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-801",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2017/0750.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "연락처",
+          "replace": "치환-814",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000750",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 751,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-750",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-763",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-776",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "일자",
+          "replace": "치환-789",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-802",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2017/0751.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "비고",
+          "replace": "치환-815",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000751",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 752,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-751",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-777",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "구분",
+          "replace": "치환-790",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-803",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2017/0752.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "수량",
+          "replace": "치환-816",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000752",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 753,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "직급",
+          "replace": "치환-752",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "비고",
+          "replace": "치환-765",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "금액",
+          "replace": "치환-778",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "성명",
+          "replace": "치환-791",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "연락처",
+          "replace": "치환-804",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2017/0753.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "단가",
+          "replace": "치환-817",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000753",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/점검표/2017/0754.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 754,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "소속",
+          "replace": "치환-753",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "수량",
+          "replace": "치환-766",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "일자",
+          "replace": "치환-779",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "직급",
+          "replace": "치환-792",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-805",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2017/0754.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-818",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000754",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/점검표/2017/0755.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 755,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "연락처",
+          "replace": "치환-754",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "단가",
+          "replace": "치환-767",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-780",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-793",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-806",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2017/0755.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-819",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000755",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/점검표/2017/0756.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 756,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-755",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-768",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-781",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-794",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-807",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2017/0756.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-820",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000756",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/점검표/2017/0757.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 757,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-756",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-769",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-782",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-795",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-808",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2017/0757.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-821",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000757",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 758,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-757",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-770",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-783",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-796",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-809",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-822",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2017/0758.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-835",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000758",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/점검표/2017/0759.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 759,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-758",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-771",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-784",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-797",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "구분",
+          "replace": "치환-810",
+          "occurrence": 3,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "소속",
+          "replace": "치환-823",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2017/0759.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "수량",
+          "replace": "치환-836",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000759",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 760,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-759",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "직급",
+          "replace": "치환-772",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "비고",
+          "replace": "치환-785",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "금액",
+          "replace": "치환-798",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "성명",
+          "replace": "치환-811",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "연락처",
+          "replace": "치환-824",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2017/0760.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "단가",
+          "replace": "치환-837",
+          "occurrence": 2,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000760",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/점검표/2017/0761.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 761,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "구분",
+          "replace": "치환-760",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "소속",
+          "replace": "치환-773",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "수량",
+          "replace": "치환-786",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "일자",
+          "replace": "치환-799",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "직급",
+          "replace": "치환-812",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 1,
+          "find": "비고",
+          "replace": "치환-825",
+          "occurrence": 2,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2017/0761.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-838",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000761",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/점검표/2017/0762.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 762,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "성명",
+          "replace": "치환-761",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "연락처",
+          "replace": "치환-774",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "단가",
+          "replace": "치환-787",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "구분",
+          "replace": "치환-800",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-813",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-826",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2017/0762.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-839",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000762",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 763,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "직급",
+          "replace": "치환-762",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "비고",
+          "replace": "치환-775",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-788",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-801",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-814",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-827",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2017/0763.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-840",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000763",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 764,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-763",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-776",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-789",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-802",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-815",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-828",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2017/0764.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-841",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000764",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 765,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-764",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-777",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-790",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-803",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-816",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-829",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2017/0765.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-842",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000765",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 766,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-765",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-778",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-791",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-804",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-817",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "구분",
+          "replace": "치환-830",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2017/0766.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "소속",
+          "replace": "치환-843",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000766",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/점검표/2017/0767.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 767,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-766",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-779",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-792",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "비고",
+          "replace": "치환-805",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "금액",
+          "replace": "치환-818",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "성명",
+          "replace": "치환-831",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2017/0767.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "연락처",
+          "replace": "치환-844",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000767",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "점검표",
+    "year": 2017,
+    "serial": 768,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-767",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "구분",
+          "replace": "치환-780",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-793",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "수량",
+          "replace": "치환-806",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "일자",
+          "replace": "치환-819",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "직급",
+          "replace": "치환-832",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2017/0768.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-845",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000768",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/고시/2018/0769.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 769,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "금액",
+          "replace": "치환-768",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "성명",
+          "replace": "치환-781",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "연락처",
+          "replace": "치환-794",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "단가",
+          "replace": "치환-807",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "구분",
+          "replace": "치환-820",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-833",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2018/0769.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-846",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0012.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0012.json
@@ -1,0 +1,9342 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000769",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 770,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "일자",
+          "replace": "치환-769",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "직급",
+          "replace": "치환-782",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "비고",
+          "replace": "치환-795",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "금액",
+          "replace": "치환-808",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-821",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-834",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2018/0770.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-847",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000770",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/고시/2018/0771.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 771,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "구분",
+          "replace": "치환-770",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "소속",
+          "replace": "치환-783",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-796",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-809",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-822",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-835",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2018/0771.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-848",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000771",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/고시/2018/0772.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 772,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-771",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-784",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-797",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-810",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-823",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-836",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-849",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2018/0772.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-862",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000772",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/고시/2018/0773.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 773,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-772",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-785",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-798",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-811",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-824",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-837",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-850",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2018/0773.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "소속",
+          "replace": "치환-863",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000773",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/고시/2018/0774.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 774,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-773",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-786",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-799",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-812",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-825",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "금액",
+          "replace": "치환-838",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "성명",
+          "replace": "치환-851",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2018/0774.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "연락처",
+          "replace": "치환-864",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000774",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/고시/2018/0775.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 775,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-774",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-787",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-800",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "소속",
+          "replace": "치환-813",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "수량",
+          "replace": "치환-826",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "일자",
+          "replace": "치환-839",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "직급",
+          "replace": "치환-852",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2018/0775.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "비고",
+          "replace": "치환-865",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000775",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 776,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-775",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "금액",
+          "replace": "치환-788",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "성명",
+          "replace": "치환-801",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "연락처",
+          "replace": "치환-814",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "단가",
+          "replace": "치환-827",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "구분",
+          "replace": "치환-840",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "소속",
+          "replace": "치환-853",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2018/0776.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 2,
+          "find": "수량",
+          "replace": "치환-866",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000776",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 777,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "수량",
+          "replace": "치환-776",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "일자",
+          "replace": "치환-789",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 7,
+          "find": "직급",
+          "replace": "치환-802",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 9,
+          "find": "비고",
+          "replace": "치환-815",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "금액",
+          "replace": "치환-828",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 3,
+          "find": "성명",
+          "replace": "치환-841",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-854",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2018/0777.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-867",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000777",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/고시/2018/0778.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 778,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 8,
+          "find": "단가",
+          "replace": "치환-777",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "구분",
+          "replace": "치환-790",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "소속",
+          "replace": "치환-803",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 4,
+          "find": "수량",
+          "replace": "치환-816",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-829",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-842",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-855",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2018/0778.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-868",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000778",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 779,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 6,
+          "find": "금액",
+          "replace": "치환-778",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 5,
+          "find": "성명",
+          "replace": "치환-791",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-804",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-817",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-830",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-843",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-856",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2018/0779.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-869",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000779",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 780,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-779",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-792",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-805",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-818",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-831",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-844",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-857",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2018/0780.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-870",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000780",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/고시/2018/0781.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 781,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-780",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-793",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "수량",
+          "replace": "치환-806",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "일자",
+          "replace": "치환-819",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-832",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-845",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-858",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2018/0781.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "성명",
+          "replace": "치환-871",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000781",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 782,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "성명",
+          "replace": "치환-781",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "연락처",
+          "replace": "치환-794",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "단가",
+          "replace": "치환-807",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "구분",
+          "replace": "치환-820",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-833",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "수량",
+          "replace": "치환-846",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 10,
+          "find": "일자",
+          "replace": "치환-859",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2018/0782.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 11,
+          "find": "직급",
+          "replace": "치환-872",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000782",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 783,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-782",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-795",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "금액",
+          "replace": "치환-808",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "성명",
+          "replace": "치환-821",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 12,
+          "find": "연락처",
+          "replace": "치환-834",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 13,
+          "find": "단가",
+          "replace": "치환-847",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "구분",
+          "replace": "치환-860",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2018/0783.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "소속",
+          "replace": "치환-873",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000783",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 784,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "replacedCount": 0,
+          "find": "소속",
+          "replace": "치환-783",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 23,
+          "find": "수량",
+          "replace": "치환-796",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 16,
+          "find": "일자",
+          "replace": "치환-809",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 17,
+          "find": "직급",
+          "replace": "치환-822",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "비고",
+          "replace": "치환-835",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "금액",
+          "replace": "치환-848",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 15,
+          "find": "성명",
+          "replace": "치환-861",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2018/0784.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 14,
+          "find": "연락처",
+          "replace": "치환-874",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000784",
+    "command": "replace-text",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "replace-text",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 785,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 20,
+          "find": "연락처",
+          "replace": "치환-784",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 21,
+          "find": "단가",
+          "replace": "치환-797",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 22,
+          "find": "구분",
+          "replace": "치환-810",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 24,
+          "find": "소속",
+          "replace": "치환-823",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 19,
+          "find": "수량",
+          "replace": "치환-836",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 18,
+          "find": "일자",
+          "replace": "치환-849",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "replacedCount": 0,
+          "find": "직급",
+          "replace": "치환-862",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2018/0785.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "replacedCount": 0,
+          "find": "비고",
+          "replace": "치환-875",
+          "occurrence": null,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000785",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/고시/2018/0786.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 786,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2018/0786.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2018/0786.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000786",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/고시/2018/0787.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 787,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2018/0787.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2018/0787.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000787",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/고시/2018/0788.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 788,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2018/0788.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2018/0788.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000788",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/고시/2018/0789.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 789,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2018/0789.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2018/0789.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000789",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/고시/2018/0790.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 790,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2018/0790.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2018/0790.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000790",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/고시/2018/0791.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 791,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2018/0791.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2018/0791.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000791",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/고시/2018/0792.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 792,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2018/0792.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2018/0792.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000792",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/고시/2018/0793.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 793,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2018/0793.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2018/0793.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000793",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/고시/2018/0794.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 794,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2018/0794.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2018/0794.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000794",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/고시/2018/0795.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 795,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2018/0795.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2018/0795.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000795",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/고시/2018/0796.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 796,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2018/0796.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2018/0796.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000796",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/고시/2018/0797.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 797,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2018/0797.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2018/0797.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000797",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/고시/2018/0798.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 798,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2018/0798.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2018/0798.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000798",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/고시/2018/0799.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 799,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2018/0799.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2018/0799.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000799",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/고시/2018/0800.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "고시",
+    "year": 2018,
+    "serial": 800,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2018/0800.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2018/0800.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2018/0800.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000800",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/훈령/2018/0801.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 801,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2018/0801.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2018/0801.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2018/0801.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000801",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/훈령/2018/0802.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 802,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2018/0802.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2018/0802.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2018/0802.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000802",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/훈령/2018/0803.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 803,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2018/0803.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2018/0803.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2018/0803.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000803",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/훈령/2018/0804.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 804,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2018/0804.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2018/0804.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2018/0804.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000804",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/훈령/2018/0805.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 805,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2018/0805.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2018/0805.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2018/0805.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000805",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/훈령/2018/0806.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 806,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2018/0806.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2018/0806.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2018/0806.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000806",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/훈령/2018/0807.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 807,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2018/0807.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2018/0807.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2018/0807.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000807",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/훈령/2018/0808.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 808,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2018/0808.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2018/0808.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2018/0808.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000808",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/훈령/2018/0809.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 809,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2018/0809.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2018/0809.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2018/0809.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000809",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/훈령/2018/0810.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 810,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2018/0810.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2018/0810.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2018/0810.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000810",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/훈령/2018/0811.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 811,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2018/0811.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2018/0811.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2018/0811.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000811",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/훈령/2018/0812.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 812,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2018/0812.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2018/0812.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2018/0812.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000812",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/훈령/2018/0813.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 813,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2018/0813.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2018/0813.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2018/0813.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000813",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/훈령/2018/0814.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 814,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2018/0814.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2018/0814.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2018/0814.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2018/0814.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000814",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/훈령/2018/0815.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 815,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2018/0815.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2018/0815.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2018/0815.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2018/0815.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000815",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/훈령/2018/0816.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 816,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2018/0816.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2018/0816.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2018/0816.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2018/0816.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000816",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/훈령/2018/0817.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 817,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2018/0817.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2018/0817.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2018/0817.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2018/0817.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000817",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/훈령/2018/0818.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 818,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2018/0818.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2018/0818.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2018/0818.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2018/0818.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000818",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/훈령/2018/0819.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 819,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2018/0819.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2018/0819.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2018/0819.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2018/0819.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000819",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/훈령/2018/0820.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 820,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2018/0820.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2018/0820.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2018/0820.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2018/0820.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000820",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/훈령/2018/0821.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 821,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2018/0821.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2018/0821.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2018/0821.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2018/0821.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000821",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/훈령/2018/0822.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 822,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2018/0822.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2018/0822.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2018/0822.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2018/0822.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000822",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/훈령/2018/0823.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 823,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2018/0823.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2018/0823.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2018/0823.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2018/0823.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000823",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/훈령/2018/0824.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 824,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2018/0824.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2018/0824.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2018/0824.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2018/0824.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000824",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/훈령/2018/0825.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 825,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2018/0825.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2018/0825.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2018/0825.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2018/0825.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000825",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/훈령/2018/0826.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 826,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2018/0826.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2018/0826.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2018/0826.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2018/0826.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000826",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/훈령/2018/0827.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 827,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2018/0827.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2018/0827.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2018/0827.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2018/0827.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000827",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 828,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2018/0828.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000828",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 829,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2018/0829.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000829",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 830,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2018/0830.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000830",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/훈령/2018/0831.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 831,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2018/0831.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2018/0831.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2018/0831.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2018/0831.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2018/0831.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000831",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "훈령",
+    "year": 2018,
+    "serial": 832,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2018/0832.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000832",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/예규/2018/0833.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 833,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2018/0833.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2018/0833.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2018/0833.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2018/0833.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2018/0833.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0013.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0013.json
@@ -1,0 +1,11898 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000833",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 834,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2018/0834.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000834",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/예규/2018/0835.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 835,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2018/0835.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2018/0835.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2018/0835.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2018/0835.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2018/0835.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000835",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/예규/2018/0836.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 836,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2018/0836.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2018/0836.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2018/0836.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2018/0836.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2018/0836.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000836",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/예규/2018/0837.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 837,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2018/0837.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2018/0837.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2018/0837.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2018/0837.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2018/0837.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000837",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/예규/2018/0838.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 838,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2018/0838.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2018/0838.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2018/0838.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2018/0838.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2018/0838.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000838",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 839,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2018/0839.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000839",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 840,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 23,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2018/0840.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000840",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/예규/2018/0841.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 841,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2018/0841.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2018/0841.hwp",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 21,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2018/0841.hwp",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 22,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2018/0841.hwp",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 24,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2018/0841.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000841",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/예규/2018/0842.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 842,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2018/0842.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000842",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 843,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2018/0843.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000843",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 844,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2018/0844.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000844",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 845,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2018/0845.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000845",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 846,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2018/0846.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000846",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 847,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2018/0847.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000847",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 848,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2018/0848.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000848",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 849,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2018/0849.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000849",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/예규/2018/0850.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 850,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2018/0850.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000850",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/예규/2018/0851.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 851,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2018/0851.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000851",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/예규/2018/0852.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 852,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2018/0852.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000852",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/예규/2018/0853.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 853,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2018/0853.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000853",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/예규/2018/0854.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 854,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2018/0854.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 23,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000854",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/예규/2018/0855.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 855,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 27,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2018/0855.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 21,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000855",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 856,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2018/0856.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000856",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/예규/2018/0857.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 857,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2018/0857.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000857",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/예규/2018/0858.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 858,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2018/0858.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000858",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 859,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2018/0859.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000859",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 860,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2018/0860.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000860",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 861,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2018/0861.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000861",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 862,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2018/0862.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000862",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/예규/2018/0863.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 863,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2018/0863.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000863",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예규",
+    "year": 2018,
+    "serial": 864,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2018/0864.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000864",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/공고/2018/0865.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 865,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2018/0865.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000865",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 866,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2018/0866.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000866",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/공고/2018/0867.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 867,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2018/0867.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000867",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/공고/2018/0868.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 868,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2018/0868.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000868",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/공고/2018/0869.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 869,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2018/0869.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000869",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/공고/2018/0870.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 870,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2018/0870.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000870",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/공고/2018/0871.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 871,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2018/0871.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000871",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 872,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2018/0872.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000872",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 873,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2018/0873.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000873",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/공고/2018/0874.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 874,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2018/0874.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000874",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 875,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2018/0875.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000875",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 876,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2018/0876.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000876",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/공고/2018/0877.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 877,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2018/0877.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000877",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 878,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2018/0878.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000878",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 879,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2018/0879.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000879",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 880,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2018/0880.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000880",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 881,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2018/0881.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000881",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/공고/2018/0882.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 882,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2018/0882.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000882",
+    "command": "redact",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/공고/2018/0883.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 883,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2018/0883.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000883",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/공고/2018/0884.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 884,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2018/0884.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/공고/2018/0884.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2018/0884.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/공고/2018/0884.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000884",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/공고/2018/0885.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 885,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2018/0885.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/공고/2018/0885.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2018/0885.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/공고/2018/0885.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000885",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/공고/2018/0886.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 886,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2018/0886.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/경찰청/공고/2018/0886.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2018/0886.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/경찰청/공고/2018/0886.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000886",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/공고/2018/0887.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 887,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2018/0887.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/소방청/공고/2018/0887.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2018/0887.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/소방청/공고/2018/0887.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000887",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/공고/2018/0888.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 888,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2018/0888.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2018/0888.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2018/0888.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2018/0888.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000888",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/공고/2018/0889.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 889,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2018/0889.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/병무청/공고/2018/0889.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2018/0889.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/병무청/공고/2018/0889.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000889",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/공고/2018/0890.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 890,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2018/0890.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/산림청/공고/2018/0890.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2018/0890.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/산림청/공고/2018/0890.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000890",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/공고/2018/0891.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 891,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2018/0891.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2018/0891.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2018/0891.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2018/0891.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000891",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/공고/2018/0892.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 892,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2018/0892.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2018/0892.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2018/0892.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2018/0892.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000892",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/공고/2018/0893.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 893,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2018/0893.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2018/0893.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2018/0893.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2018/0893.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000893",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/공고/2018/0894.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 894,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2018/0894.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2018/0894.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2018/0894.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2018/0894.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000894",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/공고/2018/0895.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 895,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2018/0895.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/환경부/공고/2018/0895.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 15
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2018/0895.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/환경부/공고/2018/0895.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 15
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000895",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/공고/2018/0896.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "공고",
+    "year": 2018,
+    "serial": 896,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2018/0896.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 19,
+          "redactedCount": 19,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양수산부/공고/2018/0896.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2018/0896.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양수산부/공고/2018/0896.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000896",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/지침/2018/0897.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 897,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2018/0897.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/법제처/지침/2018/0897.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2018/0897.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/법제처/지침/2018/0897.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0014.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0014.json
@@ -1,0 +1,11885 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000897",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/지침/2018/0898.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 898,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2018/0898.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/행정안전부/지침/2018/0898.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2018/0898.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/행정안전부/지침/2018/0898.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2018/0898.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/행정안전부/지침/2018/0898.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000898",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/지침/2018/0899.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 899,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2018/0899.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국세청/지침/2018/0899.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2018/0899.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국세청/지침/2018/0899.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2018/0899.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국세청/지침/2018/0899.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000899",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/지침/2018/0900.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 900,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2018/0900.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/대법원/지침/2018/0900.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2018/0900.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/대법원/지침/2018/0900.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2018/0900.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/대법원/지침/2018/0900.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000900",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/지침/2018/0901.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 901,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2018/0901.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/특허청/지침/2018/0901.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2018/0901.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/특허청/지침/2018/0901.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2018/0901.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/특허청/지침/2018/0901.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000901",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/지침/2018/0902.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 902,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2018/0902.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/교육부/지침/2018/0902.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2018/0902.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/교육부/지침/2018/0902.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2018/0902.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/교육부/지침/2018/0902.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000902",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/지침/2018/0903.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 903,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2018/0903.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/보건복지부/지침/2018/0903.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2018/0903.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/보건복지부/지침/2018/0903.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2018/0903.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/보건복지부/지침/2018/0903.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000903",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/지침/2018/0904.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 904,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2018/0904.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국토교통부/지침/2018/0904.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2018/0904.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국토교통부/지침/2018/0904.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2018/0904.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/지침/2018/0904.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000904",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/지침/2018/0905.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 905,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2018/0905.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/고용노동부/지침/2018/0905.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2018/0905.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/고용노동부/지침/2018/0905.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2018/0905.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/지침/2018/0905.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000905",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/지침/2018/0906.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 906,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2018/0906.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/외교부/지침/2018/0906.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2018/0906.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/외교부/지침/2018/0906.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2018/0906.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/지침/2018/0906.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000906",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/지침/2018/0907.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 907,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2018/0907.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기획재정부/지침/2018/0907.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2018/0907.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기획재정부/지침/2018/0907.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2018/0907.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/지침/2018/0907.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000907",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/지침/2018/0908.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 908,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2018/0908.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/공정거래위원회/지침/2018/0908.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2018/0908.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/지침/2018/0908.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2018/0908.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/지침/2018/0908.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000908",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/지침/2018/0909.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 909,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2018/0909.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/금융위원회/지침/2018/0909.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2018/0909.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/지침/2018/0909.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2018/0909.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/지침/2018/0909.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000909",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/지침/2018/0910.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 910,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2018/0910.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2018/0910.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2018/0910.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2018/0910.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2018/0910.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2018/0910.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000910",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/지침/2018/0911.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 911,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2018/0911.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2018/0911.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2018/0911.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 21,
+          "redactedCount": 21,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2018/0911.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2018/0911.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 22,
+          "redactedCount": 22,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2018/0911.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000911",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/지침/2018/0912.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 912,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2018/0912.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2018/0912.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2018/0912.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2018/0912.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2018/0912.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2018/0912.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2018/0912.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2018/0912.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000912",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/지침/2018/0913.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 913,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2018/0913.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2018/0913.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2018/0913.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2018/0913.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2018/0913.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2018/0913.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2018/0913.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2018/0913.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000913",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/지침/2018/0914.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 914,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2018/0914.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/지침/2018/0914.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2018/0914.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/지침/2018/0914.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2018/0914.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/지침/2018/0914.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2018/0914.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/지침/2018/0914.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000914",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/지침/2018/0915.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 915,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2018/0915.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/지침/2018/0915.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2018/0915.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/지침/2018/0915.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2018/0915.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/지침/2018/0915.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2018/0915.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/지침/2018/0915.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000915",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/지침/2018/0916.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 916,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2018/0916.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/지침/2018/0916.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2018/0916.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/지침/2018/0916.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2018/0916.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/지침/2018/0916.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2018/0916.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/지침/2018/0916.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000916",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/지침/2018/0917.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 917,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2018/0917.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/지침/2018/0917.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2018/0917.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/지침/2018/0917.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2018/0917.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/지침/2018/0917.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2018/0917.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/지침/2018/0917.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000917",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/지침/2018/0918.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 918,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2018/0918.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/경찰청/지침/2018/0918.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2018/0918.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/경찰청/지침/2018/0918.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2018/0918.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/경찰청/지침/2018/0918.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2018/0918.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/경찰청/지침/2018/0918.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000918",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/지침/2018/0919.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 919,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2018/0919.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/소방청/지침/2018/0919.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2018/0919.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/소방청/지침/2018/0919.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2018/0919.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/소방청/지침/2018/0919.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2018/0919.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/소방청/지침/2018/0919.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000919",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/지침/2018/0920.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 920,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2018/0920.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2018/0920.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2018/0920.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2018/0920.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2018/0920.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2018/0920.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2018/0920.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2018/0920.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000920",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/지침/2018/0921.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 921,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2018/0921.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/병무청/지침/2018/0921.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2018/0921.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/병무청/지침/2018/0921.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2018/0921.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/병무청/지침/2018/0921.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2018/0921.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/병무청/지침/2018/0921.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000921",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/지침/2018/0922.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 922,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2018/0922.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/산림청/지침/2018/0922.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2018/0922.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/산림청/지침/2018/0922.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2018/0922.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/산림청/지침/2018/0922.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2018/0922.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/산림청/지침/2018/0922.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000922",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/지침/2018/0923.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 923,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2018/0923.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2018/0923.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2018/0923.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2018/0923.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2018/0923.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2018/0923.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2018/0923.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2018/0923.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000923",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/지침/2018/0924.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 924,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2018/0924.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2018/0924.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2018/0924.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2018/0924.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2018/0924.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2018/0924.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2018/0924.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 19,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2018/0924.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000924",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/지침/2018/0925.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 925,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2018/0925.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2018/0925.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2018/0925.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2018/0925.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2018/0925.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2018/0925.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2018/0925.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2018/0925.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000925",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 926,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2018/0926.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2018/0926.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2018/0926.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2018/0926.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2018/0926.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2018/0926.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000926",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/지침/2018/0927.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 927,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2018/0927.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/환경부/지침/2018/0927.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2018/0927.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/환경부/지침/2018/0927.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2018/0927.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/환경부/지침/2018/0927.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2018/0927.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/환경부/지침/2018/0927.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2018/0927.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/환경부/지침/2018/0927.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000927",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/지침/2018/0928.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "지침",
+    "year": 2018,
+    "serial": 928,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2018/0928.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양수산부/지침/2018/0928.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2018/0928.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양수산부/지침/2018/0928.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2018/0928.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양수산부/지침/2018/0928.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2018/0928.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양수산부/지침/2018/0928.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2018/0928.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양수산부/지침/2018/0928.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000928",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/서식/2018/0929.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 929,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2018/0929.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/법제처/서식/2018/0929.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2018/0929.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/법제처/서식/2018/0929.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2018/0929.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/법제처/서식/2018/0929.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2018/0929.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/법제처/서식/2018/0929.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2018/0929.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/법제처/서식/2018/0929.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000929",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 930,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/행정안전부/서식/2018/0930.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/행정안전부/서식/2018/0930.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/행정안전부/서식/2018/0930.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/행정안전부/서식/2018/0930.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2018/0930.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/행정안전부/서식/2018/0930.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000930",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/서식/2018/0931.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 931,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2018/0931.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국세청/서식/2018/0931.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2018/0931.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국세청/서식/2018/0931.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2018/0931.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국세청/서식/2018/0931.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2018/0931.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국세청/서식/2018/0931.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2018/0931.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국세청/서식/2018/0931.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000931",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/서식/2018/0932.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 932,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2018/0932.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/대법원/서식/2018/0932.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2018/0932.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/대법원/서식/2018/0932.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2018/0932.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/대법원/서식/2018/0932.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2018/0932.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/대법원/서식/2018/0932.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2018/0932.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/대법원/서식/2018/0932.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000932",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/서식/2018/0933.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 933,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2018/0933.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/특허청/서식/2018/0933.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2018/0933.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/특허청/서식/2018/0933.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2018/0933.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/특허청/서식/2018/0933.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2018/0933.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/특허청/서식/2018/0933.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2018/0933.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/특허청/서식/2018/0933.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000933",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/서식/2018/0934.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 934,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2018/0934.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/교육부/서식/2018/0934.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2018/0934.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/교육부/서식/2018/0934.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2018/0934.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/교육부/서식/2018/0934.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2018/0934.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/교육부/서식/2018/0934.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2018/0934.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/교육부/서식/2018/0934.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000934",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 935,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/보건복지부/서식/2018/0935.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/보건복지부/서식/2018/0935.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/보건복지부/서식/2018/0935.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/보건복지부/서식/2018/0935.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2018/0935.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/보건복지부/서식/2018/0935.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000935",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 936,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/서식/2018/0936.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국토교통부/서식/2018/0936.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국토교통부/서식/2018/0936.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/서식/2018/0936.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2018/0936.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국토교통부/서식/2018/0936.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000936",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/서식/2018/0937.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 937,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2018/0937.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/서식/2018/0937.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2018/0937.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/고용노동부/서식/2018/0937.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2018/0937.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/고용노동부/서식/2018/0937.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2018/0937.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/서식/2018/0937.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2018/0937.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/고용노동부/서식/2018/0937.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000937",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/서식/2018/0938.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 938,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2018/0938.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/서식/2018/0938.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2018/0938.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/외교부/서식/2018/0938.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2018/0938.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/외교부/서식/2018/0938.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2018/0938.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/서식/2018/0938.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2018/0938.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/외교부/서식/2018/0938.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000938",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 939,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/서식/2018/0939.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 22,
+          "redactedCount": 22,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기획재정부/서식/2018/0939.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 28,
+          "redactedCount": 28,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기획재정부/서식/2018/0939.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/서식/2018/0939.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2018/0939.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기획재정부/서식/2018/0939.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000939",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 940,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2018/0940.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2018/0940.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000940",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 941,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2018/0941.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/서식/2018/0941.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000941",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 942,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2018/0942.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2018/0942.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000942",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 943,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2018/0943.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2018/0943.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000943",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 944,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2018/0944.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2018/0944.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000944",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 945,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2018/0945.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2018/0945.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000945",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/서식/2018/0946.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 946,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2018/0946.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/서식/2018/0946.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000946",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/서식/2018/0947.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 947,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2018/0947.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/서식/2018/0947.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000947",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/서식/2018/0948.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 948,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2018/0948.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/서식/2018/0948.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000948",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/서식/2018/0949.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 949,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2018/0949.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/서식/2018/0949.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000949",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/서식/2018/0950.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 950,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2018/0950.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/경찰청/서식/2018/0950.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000950",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/서식/2018/0951.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 951,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2018/0951.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/소방청/서식/2018/0951.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000951",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 952,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 24,
+          "redactedCount": 24,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2018/0952.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2018/0952.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000952",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/서식/2018/0953.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 953,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 22,
+          "redactedCount": 22,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 23,
+          "redactedCount": 23,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 25,
+          "redactedCount": 25,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 28,
+          "redactedCount": 28,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 19,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2018/0953.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/병무청/서식/2018/0953.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000953",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/서식/2018/0954.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 954,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2018/0954.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/산림청/서식/2018/0954.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000954",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 955,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2018/0955.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2018/0955.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000955",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 956,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2018/0956.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2018/0956.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000956",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 957,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2018/0957.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2018/0957.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000957",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 958,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2018/0958.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2018/0958.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000958",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/서식/2018/0959.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 959,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2018/0959.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/환경부/서식/2018/0959.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000959",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "서식",
+    "year": 2018,
+    "serial": 960,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2018/0960.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/해양수산부/서식/2018/0960.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000960",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/질의회신/2018/0961.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 961,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2018/0961.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/법제처/질의회신/2018/0961.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0015.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0015.json
@@ -1,0 +1,11297 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000961",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 962,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2018/0962.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2018/0962.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000962",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 963,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2018/0963.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국세청/질의회신/2018/0963.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000963",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/질의회신/2018/0964.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 964,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2018/0964.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/대법원/질의회신/2018/0964.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000964",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 965,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2018/0965.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/특허청/질의회신/2018/0965.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000965",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 966,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 19,
+          "redactedCount": 19,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 21,
+          "redactedCount": 21,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 24,
+          "redactedCount": 24,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2018/0966.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/교육부/질의회신/2018/0966.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000966",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 967,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2018/0967.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2018/0967.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000967",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 968,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2018/0968.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2018/0968.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000968",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 969,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2018/0969.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2018/0969.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000969",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/질의회신/2018/0970.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 970,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2018/0970.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/외교부/질의회신/2018/0970.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000970",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 971,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2018/0971.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2018/0971.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000971",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 972,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 3,
+          "redactedCount": 3,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 2,
+          "redactedCount": 2,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 1,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2018/0972.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2018/0972.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000972",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 973,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 5,
+          "redactedCount": 5,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2018/0973.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2018/0973.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000973",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 974,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2018/0974.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2018/0974.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000974",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 975,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 4,
+          "redactedCount": 4,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2018/0975.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2018/0975.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000975",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 976,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 8,
+          "redactedCount": 8,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 7,
+          "redactedCount": 7,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2018/0976.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 6,
+          "redactedCount": 6,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2018/0976.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000976",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 977,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2018/0977.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2018/0977.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000977",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 978,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 12,
+          "redactedCount": 12,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 18,
+          "redactedCount": 18,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 13,
+          "redactedCount": 13,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2018/0978.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/통계청/질의회신/2018/0978.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000978",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/질의회신/2018/0979.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 979,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 14,
+          "redactedCount": 14,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 15,
+          "redactedCount": 15,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 11,
+          "redactedCount": 11,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 10,
+          "redactedCount": 10,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 9,
+          "redactedCount": 9,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2018/0979.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 1,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/기상청/질의회신/2018/0979.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000979",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 980,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 16,
+          "redactedCount": 16,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2018/0980.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 17,
+          "redactedCount": 17,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/관세청/질의회신/2018/0980.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000980",
+    "command": "redact",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "redact",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 981,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 28,
+          "redactedCount": 28,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 20,
+          "redactedCount": 20,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "findingCount": 23,
+          "redactedCount": 23,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn",
+            "phone",
+            "email"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2018/0981.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "findingCount": 0,
+          "redactedCount": 0,
+          "kinds": [
+            "rrn"
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2018/0981.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000981",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/질의회신/2018/0982.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 982,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2018/0982.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-981",
+          "newText": "new-981-5",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/질의회신/2018/0982.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2018/0982.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-994",
+          "newText": "new-994-8",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/질의회신/2018/0982.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000982",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/질의회신/2018/0983.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 983,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2018/0983.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 14,
+          "col": 2,
+          "oldText": "old-982",
+          "newText": "new-982-0",
+          "overflow": false,
+          "output": "out/v-bon/소방청/질의회신/2018/0983.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2018/0983.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-995",
+          "newText": "new-995-0",
+          "overflow": false,
+          "output": "out/v-bon/소방청/질의회신/2018/0983.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000983",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/질의회신/2018/0984.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 984,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2018/0984.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 7,
+          "oldText": "old-983",
+          "newText": "new-983-2",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/질의회신/2018/0984.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2018/0984.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-996",
+          "newText": "new-996-2",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/질의회신/2018/0984.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000984",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/질의회신/2018/0985.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 985,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2018/0985.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 19,
+          "col": 0,
+          "oldText": "old-984",
+          "newText": "new-984-2",
+          "overflow": false,
+          "output": "out/v-bon/병무청/질의회신/2018/0985.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2018/0985.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-997",
+          "newText": "new-997-1",
+          "overflow": false,
+          "output": "out/v-bon/병무청/질의회신/2018/0985.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000985",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/질의회신/2018/0986.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 986,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2018/0986.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 18,
+          "col": 1,
+          "oldText": "old-985",
+          "newText": "new-985-4",
+          "overflow": false,
+          "output": "out/v-bon/산림청/질의회신/2018/0986.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2018/0986.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-998",
+          "newText": "new-998-0",
+          "overflow": false,
+          "output": "out/v-bon/산림청/질의회신/2018/0986.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000986",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/질의회신/2018/0987.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 987,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2018/0987.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-986",
+          "newText": "new-986-8",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/질의회신/2018/0987.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2018/0987.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-999",
+          "newText": "new-999-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/질의회신/2018/0987.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000987",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/질의회신/2018/0988.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 988,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2018/0988.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-987",
+          "newText": "new-987-3",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/질의회신/2018/0988.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2018/0988.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 6,
+          "oldText": "old-1000",
+          "newText": "new-1000-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/질의회신/2018/0988.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000988",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/질의회신/2018/0989.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 989,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2018/0989.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-988",
+          "newText": "new-988-7",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2018/0989.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2018/0989.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1001",
+          "newText": "new-1001-8",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2018/0989.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000989",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/질의회신/2018/0990.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 990,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2018/0990.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-989",
+          "newText": "new-989-0",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/질의회신/2018/0990.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2018/0990.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1002",
+          "newText": "new-1002-0",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/질의회신/2018/0990.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000990",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/질의회신/2018/0991.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 991,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2018/0991.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-990",
+          "newText": "new-990-9",
+          "overflow": false,
+          "output": "out/v-bon/환경부/질의회신/2018/0991.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2018/0991.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1003",
+          "newText": "new-1003-11",
+          "overflow": false,
+          "output": "out/v-bon/환경부/질의회신/2018/0991.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000991",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/질의회신/2018/0992.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "질의회신",
+    "year": 2018,
+    "serial": 992,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2018/0992.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-991",
+          "newText": "new-991-12",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/질의회신/2018/0992.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2018/0992.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 4,
+          "col": 4,
+          "oldText": "old-1004",
+          "newText": "new-1004-13",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/질의회신/2018/0992.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000992",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/업무계획/2018/0993.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 993,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2018/0993.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-992",
+          "newText": "new-992-0",
+          "overflow": false,
+          "output": "out/v-bon/법제처/업무계획/2018/0993.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2018/0993.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1005",
+          "newText": "new-1005-0",
+          "overflow": false,
+          "output": "out/v-bon/법제처/업무계획/2018/0993.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000993",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/업무계획/2018/0994.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 994,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2018/0994.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-993",
+          "newText": "new-993-24",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/업무계획/2018/0994.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2018/0994.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 8,
+          "col": 5,
+          "oldText": "old-1006",
+          "newText": "new-1006-16",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/업무계획/2018/0994.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000994",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/업무계획/2018/0995.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 995,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2018/0995.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-994",
+          "newText": "new-994-25",
+          "overflow": false,
+          "output": "out/v-bon/국세청/업무계획/2018/0995.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2018/0995.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1007",
+          "newText": "new-1007-28",
+          "overflow": false,
+          "output": "out/v-bon/국세청/업무계획/2018/0995.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000995",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/업무계획/2018/0996.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 996,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2018/0996.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-995",
+          "newText": "new-995-0",
+          "overflow": false,
+          "output": "out/v-bon/대법원/업무계획/2018/0996.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2018/0996.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1008",
+          "newText": "new-1008-0",
+          "overflow": false,
+          "output": "out/v-bon/대법원/업무계획/2018/0996.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2018/0996.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1021",
+          "newText": "new-1021-0",
+          "overflow": false,
+          "output": "out/v-bon/대법원/업무계획/2018/0996.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000996",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/업무계획/2018/0997.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 997,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2018/0997.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-996",
+          "newText": "new-996-1",
+          "overflow": false,
+          "output": "out/v-bon/특허청/업무계획/2018/0997.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2018/0997.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1009",
+          "newText": "new-1009-1",
+          "overflow": false,
+          "output": "out/v-bon/특허청/업무계획/2018/0997.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2018/0997.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1022",
+          "newText": "new-1022-4",
+          "overflow": false,
+          "output": "out/v-bon/특허청/업무계획/2018/0997.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000997",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/업무계획/2018/0001.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 1,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2018/0001.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-997",
+          "newText": "new-997-1",
+          "overflow": false,
+          "output": "out/v-bon/교육부/업무계획/2018/0001.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2018/0001.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 10,
+          "col": 0,
+          "oldText": "old-1010",
+          "newText": "new-1010-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/업무계획/2018/0001.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2018/0001.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1023",
+          "newText": "new-1023-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/업무계획/2018/0001.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000998",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/업무계획/2018/0002.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 2,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2018/0002.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-998",
+          "newText": "new-998-3",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/업무계획/2018/0002.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2018/0002.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1011",
+          "newText": "new-1011-0",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/업무계획/2018/0002.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2018/0002.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1024",
+          "newText": "new-1024-3",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/업무계획/2018/0002.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-000999",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/업무계획/2018/0003.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 3,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2018/0003.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-999",
+          "newText": "new-999-7",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/업무계획/2018/0003.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2018/0003.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 8,
+          "col": 4,
+          "oldText": "old-1012",
+          "newText": "new-1012-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/업무계획/2018/0003.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2018/0003.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1025",
+          "newText": "new-1025-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/업무계획/2018/0003.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001000",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/업무계획/2018/0004.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 4,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2018/0004.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 6,
+          "oldText": "old-1000",
+          "newText": "new-1000-2",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/업무계획/2018/0004.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2018/0004.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1013",
+          "newText": "new-1013-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/업무계획/2018/0004.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2018/0004.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1026",
+          "newText": "new-1026-5",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/업무계획/2018/0004.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001001",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/업무계획/2018/0005.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 5,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2018/0005.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1001",
+          "newText": "new-1001-6",
+          "overflow": false,
+          "output": "out/v-bon/외교부/업무계획/2018/0005.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2018/0005.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1014",
+          "newText": "new-1014-7",
+          "overflow": false,
+          "output": "out/v-bon/외교부/업무계획/2018/0005.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2018/0005.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1027",
+          "newText": "new-1027-8",
+          "overflow": false,
+          "output": "out/v-bon/외교부/업무계획/2018/0005.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001002",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/업무계획/2018/0006.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 6,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2018/0006.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1002",
+          "newText": "new-1002-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/업무계획/2018/0006.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2018/0006.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1015",
+          "newText": "new-1015-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/업무계획/2018/0006.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2018/0006.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1028",
+          "newText": "new-1028-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/업무계획/2018/0006.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001003",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/업무계획/2018/0007.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 7,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2018/0007.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1003",
+          "newText": "new-1003-8",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/업무계획/2018/0007.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2018/0007.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1016",
+          "newText": "new-1016-10",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/업무계획/2018/0007.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2018/0007.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1029",
+          "newText": "new-1029-16",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/업무계획/2018/0007.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001004",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/업무계획/2018/0008.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 8,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2018/0008.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 4,
+          "col": 4,
+          "oldText": "old-1004",
+          "newText": "new-1004-11",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/업무계획/2018/0008.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2018/0008.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 18,
+          "col": 3,
+          "oldText": "old-1017",
+          "newText": "new-1017-12",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/업무계획/2018/0008.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2018/0008.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1030",
+          "newText": "new-1030-14",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/업무계획/2018/0008.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001005",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/업무계획/2018/0009.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 9,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2018/0009.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1005",
+          "newText": "new-1005-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/업무계획/2018/0009.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2018/0009.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 3,
+          "oldText": "old-1018",
+          "newText": "new-1018-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/업무계획/2018/0009.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2018/0009.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1031",
+          "newText": "new-1031-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/업무계획/2018/0009.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001006",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/업무계획/2018/0010.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 10,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2018/0010.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 8,
+          "col": 5,
+          "oldText": "old-1006",
+          "newText": "new-1006-20",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2018/0010.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2018/0010.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1019",
+          "newText": "new-1019-12",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2018/0010.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2018/0010.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1032",
+          "newText": "new-1032-12",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/업무계획/2018/0010.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001007",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/업무계획/2018/0011.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 11,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2018/0011.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1007",
+          "newText": "new-1007-21",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/업무계획/2018/0011.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2018/0011.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1020",
+          "newText": "new-1020-24",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/업무계획/2018/0011.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2018/0011.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1033",
+          "newText": "new-1033-15",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/업무계획/2018/0011.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001008",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/업무계획/2018/0012.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 12,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2018/0012.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1008",
+          "newText": "new-1008-0",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/업무계획/2018/0012.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2018/0012.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1021",
+          "newText": "new-1021-0",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/업무계획/2018/0012.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2018/0012.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 4,
+          "oldText": "old-1034",
+          "newText": "new-1034-20",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/업무계획/2018/0012.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001009",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/업무계획/2018/0013.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 13,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2018/0013.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1009",
+          "newText": "new-1009-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/업무계획/2018/0013.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2018/0013.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1022",
+          "newText": "new-1022-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/업무계획/2018/0013.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2018/0013.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1035",
+          "newText": "new-1035-3",
+          "overflow": false,
+          "output": "out/v-bon/통계청/업무계획/2018/0013.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2018/0013.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1048",
+          "newText": "new-1048-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/업무계획/2018/0013.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001010",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/업무계획/2018/0014.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 14,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2018/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 10,
+          "col": 0,
+          "oldText": "old-1010",
+          "newText": "new-1010-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/업무계획/2018/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2018/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1023",
+          "newText": "new-1023-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/업무계획/2018/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2018/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1036",
+          "newText": "new-1036-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/업무계획/2018/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2018/0014.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1049",
+          "newText": "new-1049-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/업무계획/2018/0014.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001011",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/업무계획/2018/0015.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 15,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2018/0015.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1011",
+          "newText": "new-1011-2",
+          "overflow": false,
+          "output": "out/v-bon/관세청/업무계획/2018/0015.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2018/0015.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1024",
+          "newText": "new-1024-0",
+          "overflow": false,
+          "output": "out/v-bon/관세청/업무계획/2018/0015.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2018/0015.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1037",
+          "newText": "new-1037-2",
+          "overflow": false,
+          "output": "out/v-bon/관세청/업무계획/2018/0015.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2018/0015.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1050",
+          "newText": "new-1050-3",
+          "overflow": false,
+          "output": "out/v-bon/관세청/업무계획/2018/0015.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001012",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/업무계획/2018/0016.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 16,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2018/0016.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 8,
+          "col": 4,
+          "oldText": "old-1012",
+          "newText": "new-1012-6",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/업무계획/2018/0016.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2018/0016.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1025",
+          "newText": "new-1025-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/업무계획/2018/0016.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2018/0016.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1038",
+          "newText": "new-1038-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/업무계획/2018/0016.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2018/0016.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1051",
+          "newText": "new-1051-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/업무계획/2018/0016.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001013",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/업무계획/2018/0017.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 17,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2018/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1013",
+          "newText": "new-1013-1",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/업무계획/2018/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2018/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1026",
+          "newText": "new-1026-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/업무계획/2018/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2018/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1039",
+          "newText": "new-1039-4",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/업무계획/2018/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2018/0017.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1052",
+          "newText": "new-1052-6",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/업무계획/2018/0017.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001014",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/업무계획/2018/0018.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 18,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2018/0018.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1014",
+          "newText": "new-1014-5",
+          "overflow": false,
+          "output": "out/v-bon/소방청/업무계획/2018/0018.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2018/0018.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1027",
+          "newText": "new-1027-6",
+          "overflow": false,
+          "output": "out/v-bon/소방청/업무계획/2018/0018.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2018/0018.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1040",
+          "newText": "new-1040-7",
+          "overflow": false,
+          "output": "out/v-bon/소방청/업무계획/2018/0018.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2018/0018.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1053",
+          "newText": "new-1053-8",
+          "overflow": false,
+          "output": "out/v-bon/소방청/업무계획/2018/0018.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001015",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/업무계획/2018/0019.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 19,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2018/0019.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1015",
+          "newText": "new-1015-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/업무계획/2018/0019.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2018/0019.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1028",
+          "newText": "new-1028-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/업무계획/2018/0019.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2018/0019.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1041",
+          "newText": "new-1041-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/업무계획/2018/0019.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2018/0019.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1054",
+          "newText": "new-1054-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/업무계획/2018/0019.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001016",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/업무계획/2018/0020.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 20,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2018/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1016",
+          "newText": "new-1016-7",
+          "overflow": false,
+          "output": "out/v-bon/병무청/업무계획/2018/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2018/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1029",
+          "newText": "new-1029-9",
+          "overflow": false,
+          "output": "out/v-bon/병무청/업무계획/2018/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2018/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 6,
+          "oldText": "old-1042",
+          "newText": "new-1042-15",
+          "overflow": false,
+          "output": "out/v-bon/병무청/업무계획/2018/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2018/0020.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1055",
+          "newText": "new-1055-7",
+          "overflow": false,
+          "output": "out/v-bon/병무청/업무계획/2018/0020.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001017",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/업무계획/2018/0021.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 21,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2018/0021.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 18,
+          "col": 3,
+          "oldText": "old-1017",
+          "newText": "new-1017-10",
+          "overflow": false,
+          "output": "out/v-bon/산림청/업무계획/2018/0021.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2018/0021.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1030",
+          "newText": "new-1030-11",
+          "overflow": false,
+          "output": "out/v-bon/산림청/업무계획/2018/0021.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2018/0021.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1043",
+          "newText": "new-1043-13",
+          "overflow": false,
+          "output": "out/v-bon/산림청/업무계획/2018/0021.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2018/0021.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1056",
+          "newText": "new-1056-16",
+          "overflow": false,
+          "output": "out/v-bon/산림청/업무계획/2018/0021.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001018",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/업무계획/2018/0022.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 22,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2018/0022.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 3,
+          "oldText": "old-1018",
+          "newText": "new-1018-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/업무계획/2018/0022.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2018/0022.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1031",
+          "newText": "new-1031-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/업무계획/2018/0022.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2018/0022.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1044",
+          "newText": "new-1044-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/업무계획/2018/0022.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2018/0022.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1057",
+          "newText": "new-1057-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/업무계획/2018/0022.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001019",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/업무계획/2018/0023.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 23,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2018/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1019",
+          "newText": "new-1019-18",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2018/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2018/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1032",
+          "newText": "new-1032-10",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2018/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2018/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1045",
+          "newText": "new-1045-10",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2018/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2018/0023.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1058",
+          "newText": "new-1058-10",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/업무계획/2018/0023.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001020",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/업무계획/2018/0024.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 24,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2018/0024.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1020",
+          "newText": "new-1020-17",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2018/0024.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2018/0024.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1033",
+          "newText": "new-1033-20",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2018/0024.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2018/0024.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1046",
+          "newText": "new-1046-11",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2018/0024.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2018/0024.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1059",
+          "newText": "new-1059-10",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/업무계획/2018/0024.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001021",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/업무계획/2018/0025.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 25,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2018/0025.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1021",
+          "newText": "new-1021-0",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/업무계획/2018/0025.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2018/0025.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 4,
+          "oldText": "old-1034",
+          "newText": "new-1034-0",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/업무계획/2018/0025.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2018/0025.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1047",
+          "newText": "new-1047-16",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/업무계획/2018/0025.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2018/0025.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1060",
+          "newText": "new-1060-0",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/업무계획/2018/0025.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001022",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/업무계획/2018/0026.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 26,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2018/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1022",
+          "newText": "new-1022-20",
+          "overflow": false,
+          "output": "out/v-bon/환경부/업무계획/2018/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2018/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1035",
+          "newText": "new-1035-20",
+          "overflow": false,
+          "output": "out/v-bon/환경부/업무계획/2018/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2018/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1048",
+          "newText": "new-1048-23",
+          "overflow": false,
+          "output": "out/v-bon/환경부/업무계획/2018/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2018/0026.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1061",
+          "newText": "new-1061-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/업무계획/2018/0026.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001023",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "업무계획",
+    "year": 2018,
+    "serial": 27,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1023",
+          "newText": "new-1023-0",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/업무계획/2018/0027.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1036",
+          "newText": "new-1036-0",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/업무계획/2018/0027.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1049",
+          "newText": "new-1049-0",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/업무계획/2018/0027.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1062",
+          "newText": "new-1062-0",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/업무계획/2018/0027.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2018/0027.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1075",
+          "newText": "new-1075-0",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/업무계획/2018/0027.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001024",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/예산서/2018/0028.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 28,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2018/0028.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1024",
+          "newText": "new-1024-1",
+          "overflow": false,
+          "output": "out/v-bon/법제처/예산서/2018/0028.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2018/0028.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1037",
+          "newText": "new-1037-0",
+          "overflow": false,
+          "output": "out/v-bon/법제처/예산서/2018/0028.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2018/0028.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1050",
+          "newText": "new-1050-1",
+          "overflow": false,
+          "output": "out/v-bon/법제처/예산서/2018/0028.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2018/0028.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1063",
+          "newText": "new-1063-2",
+          "overflow": false,
+          "output": "out/v-bon/법제처/예산서/2018/0028.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2018/0028.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1076",
+          "newText": "new-1076-3",
+          "overflow": false,
+          "output": "out/v-bon/법제처/예산서/2018/0028.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0016.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0016.json
@@ -1,0 +1,13886 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001025",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 29,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1025",
+          "newText": "new-1025-5",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/예산서/2018/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1038",
+          "newText": "new-1038-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/예산서/2018/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1051",
+          "newText": "new-1051-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/예산서/2018/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 4,
+          "oldText": "old-1064",
+          "newText": "new-1064-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/예산서/2018/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2018/0029.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1077",
+          "newText": "new-1077-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/예산서/2018/0029.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001026",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/예산서/2018/0030.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 30,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2018/0030.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1026",
+          "newText": "new-1026-0",
+          "overflow": false,
+          "output": "out/v-bon/국세청/예산서/2018/0030.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2018/0030.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1039",
+          "newText": "new-1039-0",
+          "overflow": false,
+          "output": "out/v-bon/국세청/예산서/2018/0030.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2018/0030.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1052",
+          "newText": "new-1052-3",
+          "overflow": false,
+          "output": "out/v-bon/국세청/예산서/2018/0030.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2018/0030.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1065",
+          "newText": "new-1065-5",
+          "overflow": false,
+          "output": "out/v-bon/국세청/예산서/2018/0030.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2018/0030.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1078",
+          "newText": "new-1078-11",
+          "overflow": false,
+          "output": "out/v-bon/국세청/예산서/2018/0030.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001027",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/예산서/2018/0031.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 31,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2018/0031.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1027",
+          "newText": "new-1027-4",
+          "overflow": false,
+          "output": "out/v-bon/대법원/예산서/2018/0031.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2018/0031.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1040",
+          "newText": "new-1040-5",
+          "overflow": false,
+          "output": "out/v-bon/대법원/예산서/2018/0031.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2018/0031.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1053",
+          "newText": "new-1053-6",
+          "overflow": false,
+          "output": "out/v-bon/대법원/예산서/2018/0031.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2018/0031.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1066",
+          "newText": "new-1066-7",
+          "overflow": false,
+          "output": "out/v-bon/대법원/예산서/2018/0031.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2018/0031.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 7,
+          "oldText": "old-1079",
+          "newText": "new-1079-9",
+          "overflow": false,
+          "output": "out/v-bon/대법원/예산서/2018/0031.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001028",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/예산서/2018/0032.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 32,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2018/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1028",
+          "newText": "new-1028-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/예산서/2018/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2018/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1041",
+          "newText": "new-1041-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/예산서/2018/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2018/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1054",
+          "newText": "new-1054-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/예산서/2018/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2018/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1067",
+          "newText": "new-1067-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/예산서/2018/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2018/0032.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1080",
+          "newText": "new-1080-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/예산서/2018/0032.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001029",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/예산서/2018/0033.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 33,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2018/0033.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1029",
+          "newText": "new-1029-6",
+          "overflow": false,
+          "output": "out/v-bon/교육부/예산서/2018/0033.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2018/0033.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 6,
+          "oldText": "old-1042",
+          "newText": "new-1042-8",
+          "overflow": false,
+          "output": "out/v-bon/교육부/예산서/2018/0033.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2018/0033.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1055",
+          "newText": "new-1055-14",
+          "overflow": false,
+          "output": "out/v-bon/교육부/예산서/2018/0033.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2018/0033.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 0,
+          "oldText": "old-1068",
+          "newText": "new-1068-6",
+          "overflow": false,
+          "output": "out/v-bon/교육부/예산서/2018/0033.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2018/0033.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1081",
+          "newText": "new-1081-6",
+          "overflow": false,
+          "output": "out/v-bon/교육부/예산서/2018/0033.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001030",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 34,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 1,
+          "oldText": "old-1030",
+          "newText": "new-1030-9",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/예산서/2018/0034.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1043",
+          "newText": "new-1043-10",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/예산서/2018/0034.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1056",
+          "newText": "new-1056-12",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/예산서/2018/0034.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 1,
+          "oldText": "old-1069",
+          "newText": "new-1069-15",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/예산서/2018/0034.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2018/0034.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1082",
+          "newText": "new-1082-6",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/예산서/2018/0034.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001031",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 35,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1031",
+          "newText": "new-1031-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/예산서/2018/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1044",
+          "newText": "new-1044-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/예산서/2018/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1057",
+          "newText": "new-1057-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/예산서/2018/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 0,
+          "oldText": "old-1070",
+          "newText": "new-1070-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/예산서/2018/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2018/0035.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1083",
+          "newText": "new-1083-8",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/예산서/2018/0035.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001032",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 36,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1032",
+          "newText": "new-1032-17",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/예산서/2018/0036.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1045",
+          "newText": "new-1045-9",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/예산서/2018/0036.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1058",
+          "newText": "new-1058-9",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/예산서/2018/0036.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1071",
+          "newText": "new-1071-9",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/예산서/2018/0036.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2018/0036.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 2,
+          "col": 6,
+          "oldText": "old-1084",
+          "newText": "new-1084-12",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/예산서/2018/0036.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001033",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/예산서/2018/0037.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 37,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2018/0037.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1033",
+          "newText": "new-1033-15",
+          "overflow": false,
+          "output": "out/v-bon/외교부/예산서/2018/0037.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2018/0037.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1046",
+          "newText": "new-1046-18",
+          "overflow": false,
+          "output": "out/v-bon/외교부/예산서/2018/0037.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2018/0037.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1059",
+          "newText": "new-1059-9",
+          "overflow": false,
+          "output": "out/v-bon/외교부/예산서/2018/0037.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2018/0037.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1072",
+          "newText": "new-1072-8",
+          "overflow": false,
+          "output": "out/v-bon/외교부/예산서/2018/0037.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2018/0037.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1085",
+          "newText": "new-1085-7",
+          "overflow": false,
+          "output": "out/v-bon/외교부/예산서/2018/0037.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001034",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 38,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 4,
+          "oldText": "old-1034",
+          "newText": "new-1034-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/예산서/2018/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1047",
+          "newText": "new-1047-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/예산서/2018/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1060",
+          "newText": "new-1060-12",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/예산서/2018/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1073",
+          "newText": "new-1073-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/예산서/2018/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2018/0038.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 16,
+          "col": 0,
+          "oldText": "old-1086",
+          "newText": "new-1086-12",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/예산서/2018/0038.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001035",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 39,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1035",
+          "newText": "new-1035-16",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/예산서/2018/0039.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1048",
+          "newText": "new-1048-16",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/예산서/2018/0039.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1061",
+          "newText": "new-1061-19",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/예산서/2018/0039.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1074",
+          "newText": "new-1074-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/예산서/2018/0039.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2018/0039.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1087",
+          "newText": "new-1087-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/예산서/2018/0039.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001036",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 40,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1036",
+          "newText": "new-1036-19",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/예산서/2018/0040.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1049",
+          "newText": "new-1049-18",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/예산서/2018/0040.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1062",
+          "newText": "new-1062-17",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/예산서/2018/0040.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1075",
+          "newText": "new-1075-0",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/예산서/2018/0040.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2018/0040.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1088",
+          "newText": "new-1088-20",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/예산서/2018/0040.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001037",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 41,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1037",
+          "newText": "new-1037-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1050",
+          "newText": "new-1050-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1063",
+          "newText": "new-1063-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1076",
+          "newText": "new-1076-1",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1089",
+          "newText": "new-1089-2",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2018/0041.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-3",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/예산서/2018/0041.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001038",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 42,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1038",
+          "newText": "new-1038-4",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1051",
+          "newText": "new-1051-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 4,
+          "oldText": "old-1064",
+          "newText": "new-1064-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1077",
+          "newText": "new-1077-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1090",
+          "newText": "new-1090-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2018/0042.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/예산서/2018/0042.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001039",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 43,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1039",
+          "newText": "new-1039-0",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1052",
+          "newText": "new-1052-0",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1065",
+          "newText": "new-1065-2",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1078",
+          "newText": "new-1078-4",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1091",
+          "newText": "new-1091-10",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2018/0043.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-2",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/예산서/2018/0043.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001040",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 44,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1040",
+          "newText": "new-1040-3",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1053",
+          "newText": "new-1053-4",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1066",
+          "newText": "new-1066-5",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 7,
+          "oldText": "old-1079",
+          "newText": "new-1079-6",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1092",
+          "newText": "new-1092-8",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2018/0044.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1105",
+          "newText": "new-1105-11",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/예산서/2018/0044.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001041",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/예산서/2018/0045.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 45,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1041",
+          "newText": "new-1041-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1054",
+          "newText": "new-1054-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1067",
+          "newText": "new-1067-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1080",
+          "newText": "new-1080-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1093",
+          "newText": "new-1093-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2018/0045.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1106",
+          "newText": "new-1106-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/예산서/2018/0045.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001042",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/예산서/2018/0046.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 46,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 6,
+          "oldText": "old-1042",
+          "newText": "new-1042-5",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1055",
+          "newText": "new-1055-7",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 9,
+          "col": 0,
+          "oldText": "old-1068",
+          "newText": "new-1068-13",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1081",
+          "newText": "new-1081-5",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1094",
+          "newText": "new-1094-5",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2018/0046.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1107",
+          "newText": "new-1107-5",
+          "overflow": false,
+          "output": "out/v-bon/기상청/예산서/2018/0046.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001043",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/예산서/2018/0047.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 47,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1043",
+          "newText": "new-1043-8",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1056",
+          "newText": "new-1056-9",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 1,
+          "oldText": "old-1069",
+          "newText": "new-1069-11",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1082",
+          "newText": "new-1082-14",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1095",
+          "newText": "new-1095-5",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2018/0047.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 2,
+          "oldText": "old-1108",
+          "newText": "new-1108-4",
+          "overflow": false,
+          "output": "out/v-bon/관세청/예산서/2018/0047.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001044",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/예산서/2018/0048.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 48,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1044",
+          "newText": "new-1044-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1057",
+          "newText": "new-1057-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 0,
+          "oldText": "old-1070",
+          "newText": "new-1070-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1083",
+          "newText": "new-1083-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1096",
+          "newText": "new-1096-7",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2018/0048.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 5,
+          "oldText": "old-1109",
+          "newText": "new-1109-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/예산서/2018/0048.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001045",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 49,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1045",
+          "newText": "new-1045-16",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1058",
+          "newText": "new-1058-8",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1071",
+          "newText": "new-1071-8",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 2,
+          "col": 6,
+          "oldText": "old-1084",
+          "newText": "new-1084-8",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1097",
+          "newText": "new-1097-11",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2018/0049.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1110",
+          "newText": "new-1110-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/예산서/2018/0049.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001046",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/예산서/2018/0050.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 50,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1046",
+          "newText": "new-1046-14",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1059",
+          "newText": "new-1059-17",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1072",
+          "newText": "new-1072-8",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1085",
+          "newText": "new-1085-7",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1098",
+          "newText": "new-1098-6",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2018/0050.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1111",
+          "newText": "new-1111-0",
+          "overflow": false,
+          "output": "out/v-bon/소방청/예산서/2018/0050.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001047",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 51,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1047",
+          "newText": "new-1047-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1060",
+          "newText": "new-1060-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1073",
+          "newText": "new-1073-10",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 16,
+          "col": 0,
+          "oldText": "old-1086",
+          "newText": "new-1086-0",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1099",
+          "newText": "new-1099-10",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2018/0051.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 8,
+          "col": 2,
+          "oldText": "old-1112",
+          "newText": "new-1112-11",
+          "overflow": false,
+          "output": "out/v-bon/해양경찰청/예산서/2018/0051.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001048",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/예산서/2018/0052.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 52,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1048",
+          "newText": "new-1048-12",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1061",
+          "newText": "new-1061-12",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1074",
+          "newText": "new-1074-15",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1087",
+          "newText": "new-1087-0",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1100",
+          "newText": "new-1100-0",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2018/0052.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1113",
+          "newText": "new-1113-0",
+          "overflow": false,
+          "output": "out/v-bon/병무청/예산서/2018/0052.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001049",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/예산서/2018/0053.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 53,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1049",
+          "newText": "new-1049-15",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1062",
+          "newText": "new-1062-14",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1075",
+          "newText": "new-1075-13",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1088",
+          "newText": "new-1088-0",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1101",
+          "newText": "new-1101-16",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2018/0053.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1114",
+          "newText": "new-1114-18",
+          "overflow": false,
+          "output": "out/v-bon/산림청/예산서/2018/0053.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001050",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 54,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1050",
+          "newText": "new-1050-20",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1063",
+          "newText": "new-1063-0",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1076",
+          "newText": "new-1076-20",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1089",
+          "newText": "new-1089-21",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-22",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2018/0054.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1115",
+          "newText": "new-1115-23",
+          "overflow": false,
+          "output": "out/v-bon/농촌진흥청/예산서/2018/0054.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001051",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 55,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1051",
+          "newText": "new-1051-3",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 9,
+          "col": 4,
+          "oldText": "old-1064",
+          "newText": "new-1064-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1077",
+          "newText": "new-1077-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1090",
+          "newText": "new-1090-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1116",
+          "newText": "new-1116-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2018/0055.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-0",
+          "overflow": false,
+          "output": "out/v-bon/중소벤처기업부/예산서/2018/0055.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001052",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 56,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1052",
+          "newText": "new-1052-0",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1065",
+          "newText": "new-1065-0",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1078",
+          "newText": "new-1078-1",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1091",
+          "newText": "new-1091-3",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-9",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1117",
+          "newText": "new-1117-1",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2018/0056.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-1",
+          "overflow": false,
+          "output": "out/v-bon/과학기술정보통신부/예산서/2018/0056.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001053",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 57,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1053",
+          "newText": "new-1053-2",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1066",
+          "newText": "new-1066-3",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 7,
+          "oldText": "old-1079",
+          "newText": "new-1079-4",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1092",
+          "newText": "new-1092-5",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1105",
+          "newText": "new-1105-7",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1118",
+          "newText": "new-1118-10",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2018/0057.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1131",
+          "newText": "new-1131-1",
+          "overflow": false,
+          "output": "out/v-bon/문화체육관광부/예산서/2018/0057.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001054",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/예산서/2018/0058.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 58,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1054",
+          "newText": "new-1054-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1067",
+          "newText": "new-1067-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1080",
+          "newText": "new-1080-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1093",
+          "newText": "new-1093-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1106",
+          "newText": "new-1106-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1119",
+          "newText": "new-1119-0",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2018/0058.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 5,
+          "oldText": "old-1132",
+          "newText": "new-1132-3",
+          "overflow": false,
+          "output": "out/v-bon/환경부/예산서/2018/0058.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001055",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예산서",
+    "year": 2018,
+    "serial": 59,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1055",
+          "newText": "new-1055-4",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 9,
+          "col": 0,
+          "oldText": "old-1068",
+          "newText": "new-1068-6",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1081",
+          "newText": "new-1081-12",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1094",
+          "newText": "new-1094-4",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1107",
+          "newText": "new-1107-4",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1120",
+          "newText": "new-1120-4",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2018/0059.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1133",
+          "newText": "new-1133-7",
+          "overflow": false,
+          "output": "out/v-bon/해양수산부/예산서/2018/0059.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001056",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/회의록/2018/0060.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 60,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1056",
+          "newText": "new-1056-7",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 1,
+          "oldText": "old-1069",
+          "newText": "new-1069-8",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1082",
+          "newText": "new-1082-10",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1095",
+          "newText": "new-1095-13",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 2,
+          "oldText": "old-1108",
+          "newText": "new-1108-4",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 22,
+          "col": 1,
+          "oldText": "old-1121",
+          "newText": "new-1121-3",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2018/0060.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1134",
+          "newText": "new-1134-2",
+          "overflow": false,
+          "output": "out/v-bon/법제처/회의록/2018/0060.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001057",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 61,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1057",
+          "newText": "new-1057-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 0,
+          "oldText": "old-1070",
+          "newText": "new-1070-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1083",
+          "newText": "new-1083-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1096",
+          "newText": "new-1096-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 5,
+          "oldText": "old-1109",
+          "newText": "new-1109-6",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1122",
+          "newText": "new-1122-0",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2018/0061.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 15,
+          "col": 3,
+          "oldText": "old-1135",
+          "newText": "new-1135-6",
+          "overflow": false,
+          "output": "out/v-bon/행정안전부/회의록/2018/0061.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001058",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/회의록/2018/0062.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 62,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1058",
+          "newText": "new-1058-15",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1071",
+          "newText": "new-1071-7",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 2,
+          "col": 6,
+          "oldText": "old-1084",
+          "newText": "new-1084-7",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1097",
+          "newText": "new-1097-7",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1110",
+          "newText": "new-1110-10",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1123",
+          "newText": "new-1123-0",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2018/0062.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 17,
+          "col": 1,
+          "oldText": "old-1136",
+          "newText": "new-1136-0",
+          "overflow": false,
+          "output": "out/v-bon/국세청/회의록/2018/0062.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001059",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/회의록/2018/0063.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 63,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1059",
+          "newText": "new-1059-13",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1072",
+          "newText": "new-1072-16",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1085",
+          "newText": "new-1085-7",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1098",
+          "newText": "new-1098-6",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1111",
+          "newText": "new-1111-5",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1124",
+          "newText": "new-1124-0",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2018/0063.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1137",
+          "newText": "new-1137-8",
+          "overflow": false,
+          "output": "out/v-bon/대법원/회의록/2018/0063.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001060",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/회의록/2018/0064.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 64,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1060",
+          "newText": "new-1060-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1073",
+          "newText": "new-1073-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 16,
+          "col": 0,
+          "oldText": "old-1086",
+          "newText": "new-1086-9",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1099",
+          "newText": "new-1099-0",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 8,
+          "col": 2,
+          "oldText": "old-1112",
+          "newText": "new-1112-9",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1125",
+          "newText": "new-1125-10",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2018/0064.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 4,
+          "oldText": "old-1138",
+          "newText": "new-1138-11",
+          "overflow": false,
+          "output": "out/v-bon/특허청/회의록/2018/0064.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001061",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/회의록/2018/0065.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 65,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1061",
+          "newText": "new-1061-10",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1074",
+          "newText": "new-1074-10",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1087",
+          "newText": "new-1087-13",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1100",
+          "newText": "new-1100-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1113",
+          "newText": "new-1113-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 6,
+          "oldText": "old-1126",
+          "newText": "new-1126-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2018/0065.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1139",
+          "newText": "new-1139-0",
+          "overflow": false,
+          "output": "out/v-bon/교육부/회의록/2018/0065.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001062",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 66,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1062",
+          "newText": "new-1062-11",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1075",
+          "newText": "new-1075-10",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1088",
+          "newText": "new-1088-9",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1101",
+          "newText": "new-1101-0",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1114",
+          "newText": "new-1114-12",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1127",
+          "newText": "new-1127-14",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2018/0066.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1140",
+          "newText": "new-1140-20",
+          "overflow": false,
+          "output": "out/v-bon/보건복지부/회의록/2018/0066.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001063",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 67,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1063",
+          "newText": "new-1063-16",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1076",
+          "newText": "new-1076-0",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1089",
+          "newText": "new-1089-16",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-17",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1115",
+          "newText": "new-1115-18",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1128",
+          "newText": "new-1128-19",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2018/0067.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1141",
+          "newText": "new-1141-21",
+          "overflow": false,
+          "output": "out/v-bon/국토교통부/회의록/2018/0067.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001064",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 68,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 9,
+          "col": 4,
+          "oldText": "old-1064",
+          "newText": "new-1064-23",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1077",
+          "newText": "new-1077-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1090",
+          "newText": "new-1090-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1116",
+          "newText": "new-1116-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2018/0068.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-1142",
+          "newText": "new-1142-0",
+          "overflow": false,
+          "output": "out/v-bon/고용노동부/회의록/2018/0068.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001065",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/회의록/2018/0069.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 69,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1065",
+          "newText": "new-1065-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1078",
+          "newText": "new-1078-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1091",
+          "newText": "new-1091-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-2",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1117",
+          "newText": "new-1117-8",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1143",
+          "newText": "new-1143-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2018/0069.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-0",
+          "overflow": false,
+          "output": "out/v-bon/외교부/회의록/2018/0069.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001066",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 70,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 2,
+          "oldText": "old-1066",
+          "newText": "new-1066-1",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 7,
+          "oldText": "old-1079",
+          "newText": "new-1079-2",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1092",
+          "newText": "new-1092-3",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1105",
+          "newText": "new-1105-4",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1118",
+          "newText": "new-1118-6",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1131",
+          "newText": "new-1131-9",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1144",
+          "newText": "new-1144-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2018/0070.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1157",
+          "newText": "new-1157-0",
+          "overflow": false,
+          "output": "out/v-bon/기획재정부/회의록/2018/0070.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001067",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 71,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1067",
+          "newText": "new-1067-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1080",
+          "newText": "new-1080-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1093",
+          "newText": "new-1093-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1106",
+          "newText": "new-1106-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1119",
+          "newText": "new-1119-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 13,
+          "col": 5,
+          "oldText": "old-1132",
+          "newText": "new-1132-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1145",
+          "newText": "new-1145-2",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2018/0071.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1158",
+          "newText": "new-1158-0",
+          "overflow": false,
+          "output": "out/v-bon/공정거래위원회/회의록/2018/0071.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001068",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 72,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 9,
+          "col": 0,
+          "oldText": "old-1068",
+          "newText": "new-1068-3",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1081",
+          "newText": "new-1081-5",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1094",
+          "newText": "new-1094-11",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1107",
+          "newText": "new-1107-3",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1120",
+          "newText": "new-1120-3",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1133",
+          "newText": "new-1133-3",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1146",
+          "newText": "new-1146-6",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2018/0072.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1159",
+          "newText": "new-1159-0",
+          "overflow": false,
+          "output": "out/v-bon/금융위원회/회의록/2018/0072.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001069",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 73,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 20,
+          "col": 1,
+          "oldText": "old-1069",
+          "newText": "new-1069-6",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1082",
+          "newText": "new-1082-7",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1095",
+          "newText": "new-1095-9",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 2,
+          "oldText": "old-1108",
+          "newText": "new-1108-12",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 22,
+          "col": 1,
+          "oldText": "old-1121",
+          "newText": "new-1121-3",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1134",
+          "newText": "new-1134-2",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1147",
+          "newText": "new-1147-1",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2018/0073.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1160",
+          "newText": "new-1160-0",
+          "overflow": false,
+          "output": "out/v-bon/방송통신위원회/회의록/2018/0073.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001070",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 74,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 0,
+          "oldText": "old-1070",
+          "newText": "new-1070-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1083",
+          "newText": "new-1083-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1096",
+          "newText": "new-1096-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 10,
+          "col": 5,
+          "oldText": "old-1109",
+          "newText": "new-1109-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1122",
+          "newText": "new-1122-5",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 15,
+          "col": 3,
+          "oldText": "old-1135",
+          "newText": "new-1135-0",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1148",
+          "newText": "new-1148-5",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2018/0074.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1161",
+          "newText": "new-1161-6",
+          "overflow": false,
+          "output": "out/v-bon/개인정보보호위원회/회의록/2018/0074.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001071",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 75,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1071",
+          "newText": "new-1071-14",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 6,
+          "oldText": "old-1084",
+          "newText": "new-1084-6",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1097",
+          "newText": "new-1097-6",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1110",
+          "newText": "new-1110-6",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1123",
+          "newText": "new-1123-9",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 17,
+          "col": 1,
+          "oldText": "old-1136",
+          "newText": "new-1136-0",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1149",
+          "newText": "new-1149-0",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2018/0075.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1162",
+          "newText": "new-1162-0",
+          "overflow": false,
+          "output": "out/v-bon/국민권익위원회/회의록/2018/0075.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001072",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 76,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1072",
+          "newText": "new-1072-12",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1085",
+          "newText": "new-1085-15",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1098",
+          "newText": "new-1098-6",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1111",
+          "newText": "new-1111-5",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1124",
+          "newText": "new-1124-4",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1137",
+          "newText": "new-1137-0",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1150",
+          "newText": "new-1150-7",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2018/0076.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1163",
+          "newText": "new-1163-9",
+          "overflow": false,
+          "output": "out/v-bon/국가인권위원회/회의록/2018/0076.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001073",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/회의록/2018/0077.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 77,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1073",
+          "newText": "new-1073-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 16,
+          "col": 0,
+          "oldText": "old-1086",
+          "newText": "new-1086-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1099",
+          "newText": "new-1099-8",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 8,
+          "col": 2,
+          "oldText": "old-1112",
+          "newText": "new-1112-0",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1125",
+          "newText": "new-1125-8",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 4,
+          "oldText": "old-1138",
+          "newText": "new-1138-9",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 18,
+          "col": 7,
+          "oldText": "old-1151",
+          "newText": "new-1151-10",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2018/0077.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1164",
+          "newText": "new-1164-11",
+          "overflow": false,
+          "output": "out/v-bon/통계청/회의록/2018/0077.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001074",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/회의록/2018/0078.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 78,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1074",
+          "newText": "new-1074-9",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1087",
+          "newText": "new-1087-9",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1100",
+          "newText": "new-1100-12",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1113",
+          "newText": "new-1113-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 6,
+          "oldText": "old-1126",
+          "newText": "new-1126-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1139",
+          "newText": "new-1139-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1152",
+          "newText": "new-1152-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2018/0078.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1165",
+          "newText": "new-1165-0",
+          "overflow": false,
+          "output": "out/v-bon/기상청/회의록/2018/0078.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001075",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/회의록/2018/0079.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 79,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1075",
+          "newText": "new-1075-9",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1088",
+          "newText": "new-1088-8",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1101",
+          "newText": "new-1101-7",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1114",
+          "newText": "new-1114-0",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1127",
+          "newText": "new-1127-10",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1140",
+          "newText": "new-1140-12",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 14,
+          "col": 1,
+          "oldText": "old-1153",
+          "newText": "new-1153-18",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2018/0079.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1166",
+          "newText": "new-1166-10",
+          "overflow": false,
+          "output": "out/v-bon/관세청/회의록/2018/0079.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001076",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 80,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1076",
+          "newText": "new-1076-12",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1089",
+          "newText": "new-1089-0",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-12",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1115",
+          "newText": "new-1115-13",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1128",
+          "newText": "new-1128-14",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1141",
+          "newText": "new-1141-15",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 21,
+          "col": 4,
+          "oldText": "old-1154",
+          "newText": "new-1154-17",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2018/0080.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1167",
+          "newText": "new-1167-20",
+          "overflow": false,
+          "output": "out/v-bon/검찰청/회의록/2018/0080.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001077",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/회의록/2018/0081.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 81,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1077",
+          "newText": "new-1077-19",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1090",
+          "newText": "new-1090-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1116",
+          "newText": "new-1116-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-1142",
+          "newText": "new-1142-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1155",
+          "newText": "new-1155-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2018/0081.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 17,
+          "col": 6,
+          "oldText": "old-1168",
+          "newText": "new-1168-0",
+          "overflow": false,
+          "output": "out/v-bon/경찰청/회의록/2018/0081.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001078",
+    "command": "set-cell",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/회의록/2018/0082.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 82,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1078",
+          "newText": "new-1078-17",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1091",
+          "newText": "new-1091-0",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-20",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1117",
+          "newText": "new-1117-22",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-28",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1143",
+          "newText": "new-1143-20",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-20",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2018/0082.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1169",
+          "newText": "new-1169-20",
+          "overflow": false,
+          "output": "out/v-bon/소방청/회의록/2018/0082.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001079",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/회의록/2018/0083.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 83,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2018/0083.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 2,
+          "col": 7,
+          "oldText": "old-1079",
+          "newText": "new-1079-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2018/0083.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1092",
+          "newText": "new-1092-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001080",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/회의록/2018/0084.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 84,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2018/0084.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1080",
+          "newText": "new-1080-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2018/0084.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1093",
+          "newText": "new-1093-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001081",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/회의록/2018/0085.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 85,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2018/0085.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 1,
+          "oldText": "old-1081",
+          "newText": "new-1081-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2018/0085.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1094",
+          "newText": "new-1094-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001082",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/회의록/2018/0086.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 86,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2018/0086.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1082",
+          "newText": "new-1082-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2018/0086.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1095",
+          "newText": "new-1095-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001083",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/회의록/2018/0087.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 87,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2018/0087.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1083",
+          "newText": "new-1083-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2018/0087.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1096",
+          "newText": "new-1096-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001084",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/회의록/2018/0088.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 88,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2018/0088.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 2,
+          "col": 6,
+          "oldText": "old-1084",
+          "newText": "new-1084-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2018/0088.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1097",
+          "newText": "new-1097-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001085",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/회의록/2018/0089.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 89,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2018/0089.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1085",
+          "newText": "new-1085-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2018/0089.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1098",
+          "newText": "new-1098-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001086",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/회의록/2018/0090.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 90,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2018/0090.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 16,
+          "col": 0,
+          "oldText": "old-1086",
+          "newText": "new-1086-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2018/0090.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1099",
+          "newText": "new-1099-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001087",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/회의록/2018/0091.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "회의록",
+    "year": 2018,
+    "serial": 91,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2018/0091.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1087",
+          "newText": "new-1087-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2018/0091.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1100",
+          "newText": "new-1100-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001088",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/계약서/2018/0092.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 92,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2018/0092.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1088",
+          "newText": "new-1088-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2018/0092.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1101",
+          "newText": "new-1101-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0017.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0017.json
@@ -1,0 +1,9776 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001089",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/계약서/2018/0093.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 93,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2018/0093.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1089",
+          "newText": "new-1089-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2018/0093.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001090",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/계약서/2018/0094.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 94,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2018/0094.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1090",
+          "newText": "new-1090-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2018/0094.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001091",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/계약서/2018/0095.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 95,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2018/0095.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1091",
+          "newText": "new-1091-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2018/0095.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001092",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/계약서/2018/0096.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 96,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2018/0096.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1092",
+          "newText": "new-1092-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2018/0096.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1105",
+          "newText": "new-1105-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001093",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/계약서/2018/0097.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 97,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2018/0097.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1093",
+          "newText": "new-1093-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2018/0097.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1106",
+          "newText": "new-1106-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2018/0097.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1119",
+          "newText": "new-1119-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001094",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/계약서/2018/0098.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 98,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2018/0098.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1094",
+          "newText": "new-1094-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2018/0098.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1107",
+          "newText": "new-1107-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2018/0098.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1120",
+          "newText": "new-1120-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001095",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/계약서/2018/0099.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 99,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2018/0099.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1095",
+          "newText": "new-1095-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2018/0099.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 2,
+          "oldText": "old-1108",
+          "newText": "new-1108-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2018/0099.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 22,
+          "col": 1,
+          "oldText": "old-1121",
+          "newText": "new-1121-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001096",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/계약서/2018/0100.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 100,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2018/0100.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1096",
+          "newText": "new-1096-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2018/0100.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 10,
+          "col": 5,
+          "oldText": "old-1109",
+          "newText": "new-1109-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2018/0100.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1122",
+          "newText": "new-1122-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001097",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/계약서/2018/0101.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 101,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2018/0101.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1097",
+          "newText": "new-1097-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2018/0101.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1110",
+          "newText": "new-1110-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2018/0101.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1123",
+          "newText": "new-1123-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001098",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/계약서/2018/0102.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 102,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2018/0102.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1098",
+          "newText": "new-1098-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2018/0102.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1111",
+          "newText": "new-1111-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2018/0102.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1124",
+          "newText": "new-1124-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001099",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/계약서/2018/0103.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 103,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2018/0103.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1099",
+          "newText": "new-1099-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2018/0103.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 8,
+          "col": 2,
+          "oldText": "old-1112",
+          "newText": "new-1112-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2018/0103.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1125",
+          "newText": "new-1125-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001100",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/계약서/2018/0104.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 104,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2018/0104.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1100",
+          "newText": "new-1100-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2018/0104.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1113",
+          "newText": "new-1113-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2018/0104.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 6,
+          "oldText": "old-1126",
+          "newText": "new-1126-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001101",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/계약서/2018/0105.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 105,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2018/0105.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1101",
+          "newText": "new-1101-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2018/0105.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1114",
+          "newText": "new-1114-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2018/0105.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1127",
+          "newText": "new-1127-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001102",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/계약서/2018/0106.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 106,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2018/0106.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 3,
+          "oldText": "old-1102",
+          "newText": "new-1102-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2018/0106.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1115",
+          "newText": "new-1115-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2018/0106.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1128",
+          "newText": "new-1128-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001103",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/계약서/2018/0107.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 107,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2018/0107.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1103",
+          "newText": "new-1103-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2018/0107.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1116",
+          "newText": "new-1116-17",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2018/0107.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001104",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/계약서/2018/0108.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 108,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2018/0108.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1104",
+          "newText": "new-1104-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2018/0108.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1117",
+          "newText": "new-1117-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2018/0108.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001105",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/계약서/2018/0109.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 109,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2018/0109.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1105",
+          "newText": "new-1105-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2018/0109.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1118",
+          "newText": "new-1118-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2018/0109.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1131",
+          "newText": "new-1131-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001106",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/계약서/2018/0110.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 110,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2018/0110.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1106",
+          "newText": "new-1106-19",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2018/0110.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1119",
+          "newText": "new-1119-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2018/0110.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 5,
+          "oldText": "old-1132",
+          "newText": "new-1132-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001107",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/계약서/2018/0111.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 111,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2018/0111.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1107",
+          "newText": "new-1107-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2018/0111.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1120",
+          "newText": "new-1120-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2018/0111.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1133",
+          "newText": "new-1133-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2018/0111.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1146",
+          "newText": "new-1146-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001108",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/계약서/2018/0112.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 112,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2018/0112.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 2,
+          "col": 2,
+          "oldText": "old-1108",
+          "newText": "new-1108-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2018/0112.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 22,
+          "col": 1,
+          "oldText": "old-1121",
+          "newText": "new-1121-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2018/0112.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1134",
+          "newText": "new-1134-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2018/0112.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1147",
+          "newText": "new-1147-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001109",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/계약서/2018/0113.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 113,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2018/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 10,
+          "col": 5,
+          "oldText": "old-1109",
+          "newText": "new-1109-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2018/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1122",
+          "newText": "new-1122-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2018/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 15,
+          "col": 3,
+          "oldText": "old-1135",
+          "newText": "new-1135-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2018/0113.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1148",
+          "newText": "new-1148-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001110",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/계약서/2018/0114.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 114,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2018/0114.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1110",
+          "newText": "new-1110-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2018/0114.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1123",
+          "newText": "new-1123-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2018/0114.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 17,
+          "col": 1,
+          "oldText": "old-1136",
+          "newText": "new-1136-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2018/0114.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1149",
+          "newText": "new-1149-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001111",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/계약서/2018/0115.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 115,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2018/0115.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1111",
+          "newText": "new-1111-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2018/0115.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1124",
+          "newText": "new-1124-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2018/0115.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1137",
+          "newText": "new-1137-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2018/0115.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1150",
+          "newText": "new-1150-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001112",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/계약서/2018/0116.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 116,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2018/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 8,
+          "col": 2,
+          "oldText": "old-1112",
+          "newText": "new-1112-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2018/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1125",
+          "newText": "new-1125-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2018/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 4,
+          "oldText": "old-1138",
+          "newText": "new-1138-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2018/0116.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 18,
+          "col": 7,
+          "oldText": "old-1151",
+          "newText": "new-1151-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001113",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/계약서/2018/0117.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 117,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2018/0117.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1113",
+          "newText": "new-1113-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2018/0117.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 6,
+          "oldText": "old-1126",
+          "newText": "new-1126-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2018/0117.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1139",
+          "newText": "new-1139-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2018/0117.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1152",
+          "newText": "new-1152-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001114",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/계약서/2018/0118.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 118,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2018/0118.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1114",
+          "newText": "new-1114-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2018/0118.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1127",
+          "newText": "new-1127-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2018/0118.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1140",
+          "newText": "new-1140-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2018/0118.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 14,
+          "col": 1,
+          "oldText": "old-1153",
+          "newText": "new-1153-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001115",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/계약서/2018/0119.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 119,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2018/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1115",
+          "newText": "new-1115-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2018/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1128",
+          "newText": "new-1128-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2018/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1141",
+          "newText": "new-1141-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2018/0119.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 21,
+          "col": 4,
+          "oldText": "old-1154",
+          "newText": "new-1154-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001116",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/계약서/2018/0120.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 120,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2018/0120.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1116",
+          "newText": "new-1116-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2018/0120.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2018/0120.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-1142",
+          "newText": "new-1142-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2018/0120.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1155",
+          "newText": "new-1155-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001117",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/계약서/2018/0121.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 121,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2018/0121.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1117",
+          "newText": "new-1117-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2018/0121.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2018/0121.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1143",
+          "newText": "new-1143-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2018/0121.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001118",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/계약서/2018/0122.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 122,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2018/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1118",
+          "newText": "new-1118-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2018/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1131",
+          "newText": "new-1131-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2018/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1144",
+          "newText": "new-1144-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2018/0122.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1157",
+          "newText": "new-1157-19",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001119",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/계약서/2018/0123.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "계약서",
+    "year": 2018,
+    "serial": 123,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2018/0123.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 20,
+          "col": 3,
+          "oldText": "old-1119",
+          "newText": "new-1119-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2018/0123.hwp",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 5,
+          "oldText": "old-1132",
+          "newText": "new-1132-23",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2018/0123.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1145",
+          "newText": "new-1145-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2018/0123.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1158",
+          "newText": "new-1158-17",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001120",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/점검표/2018/0124.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 124,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2018/0124.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 8,
+          "col": 0,
+          "oldText": "old-1120",
+          "newText": "new-1120-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2018/0124.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1133",
+          "newText": "new-1133-21",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2018/0124.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1146",
+          "newText": "new-1146-22",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2018/0124.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1159",
+          "newText": "new-1159-24",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001121",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 125,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 22,
+          "col": 1,
+          "oldText": "old-1121",
+          "newText": "new-1121-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1134",
+          "newText": "new-1134-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1147",
+          "newText": "new-1147-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1160",
+          "newText": "new-1160-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2018/0125.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1173",
+          "newText": "new-1173-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001122",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/점검표/2018/0126.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 126,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2018/0126.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1122",
+          "newText": "new-1122-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2018/0126.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 15,
+          "col": 3,
+          "oldText": "old-1135",
+          "newText": "new-1135-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2018/0126.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1148",
+          "newText": "new-1148-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2018/0126.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1161",
+          "newText": "new-1161-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2018/0126.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1174",
+          "newText": "new-1174-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001123",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/점검표/2018/0127.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 127,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2018/0127.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1123",
+          "newText": "new-1123-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2018/0127.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 17,
+          "col": 1,
+          "oldText": "old-1136",
+          "newText": "new-1136-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2018/0127.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1149",
+          "newText": "new-1149-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2018/0127.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1162",
+          "newText": "new-1162-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2018/0127.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1175",
+          "newText": "new-1175-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001124",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/점검표/2018/0128.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 128,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2018/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1124",
+          "newText": "new-1124-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2018/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1137",
+          "newText": "new-1137-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2018/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1150",
+          "newText": "new-1150-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2018/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1163",
+          "newText": "new-1163-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2018/0128.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1176",
+          "newText": "new-1176-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001125",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/점검표/2018/0129.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 129,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2018/0129.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1125",
+          "newText": "new-1125-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2018/0129.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 17,
+          "col": 4,
+          "oldText": "old-1138",
+          "newText": "new-1138-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2018/0129.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 18,
+          "col": 7,
+          "oldText": "old-1151",
+          "newText": "new-1151-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2018/0129.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1164",
+          "newText": "new-1164-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2018/0129.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1177",
+          "newText": "new-1177-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001126",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 130,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 6,
+          "oldText": "old-1126",
+          "newText": "new-1126-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1139",
+          "newText": "new-1139-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1152",
+          "newText": "new-1152-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1165",
+          "newText": "new-1165-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2018/0130.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1178",
+          "newText": "new-1178-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001127",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 131,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 6,
+          "col": 7,
+          "oldText": "old-1127",
+          "newText": "new-1127-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1140",
+          "newText": "new-1140-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 14,
+          "col": 1,
+          "oldText": "old-1153",
+          "newText": "new-1153-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1166",
+          "newText": "new-1166-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2018/0131.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1179",
+          "newText": "new-1179-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001128",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 132,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1128",
+          "newText": "new-1128-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1141",
+          "newText": "new-1141-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 21,
+          "col": 4,
+          "oldText": "old-1154",
+          "newText": "new-1154-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1167",
+          "newText": "new-1167-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2018/0132.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 11,
+          "col": 4,
+          "oldText": "old-1180",
+          "newText": "new-1180-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001129",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/점검표/2018/0133.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 133,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2018/0133.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1129",
+          "newText": "new-1129-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2018/0133.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-1142",
+          "newText": "new-1142-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2018/0133.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1155",
+          "newText": "new-1155-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2018/0133.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 17,
+          "col": 6,
+          "oldText": "old-1168",
+          "newText": "new-1168-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2018/0133.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1181",
+          "newText": "new-1181-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001130",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 134,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1130",
+          "newText": "new-1130-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1143",
+          "newText": "new-1143-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1169",
+          "newText": "new-1169-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2018/0134.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1182",
+          "newText": "new-1182-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001131",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 135,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1131",
+          "newText": "new-1131-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1144",
+          "newText": "new-1144-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1157",
+          "newText": "new-1157-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1170",
+          "newText": "new-1170-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2018/0135.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1183",
+          "newText": "new-1183-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001132",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 136,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 13,
+          "col": 5,
+          "oldText": "old-1132",
+          "newText": "new-1132-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1145",
+          "newText": "new-1145-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1158",
+          "newText": "new-1158-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1171",
+          "newText": "new-1171-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2018/0136.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 12,
+          "col": 4,
+          "oldText": "old-1184",
+          "newText": "new-1184-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001133",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 137,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1133",
+          "newText": "new-1133-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1146",
+          "newText": "new-1146-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1159",
+          "newText": "new-1159-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1172",
+          "newText": "new-1172-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2018/0137.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1185",
+          "newText": "new-1185-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001134",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 138,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1134",
+          "newText": "new-1134-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1147",
+          "newText": "new-1147-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1160",
+          "newText": "new-1160-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1173",
+          "newText": "new-1173-27",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2018/0138.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1186",
+          "newText": "new-1186-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001135",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 139,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 15,
+          "col": 3,
+          "oldText": "old-1135",
+          "newText": "new-1135-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1148",
+          "newText": "new-1148-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1161",
+          "newText": "new-1161-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1174",
+          "newText": "new-1174-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1187",
+          "newText": "new-1187-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2018/0139.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1200",
+          "newText": "new-1200-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001136",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 140,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 17,
+          "col": 1,
+          "oldText": "old-1136",
+          "newText": "new-1136-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1149",
+          "newText": "new-1149-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1162",
+          "newText": "new-1162-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1175",
+          "newText": "new-1175-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1188",
+          "newText": "new-1188-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2018/0140.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1201",
+          "newText": "new-1201-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001137",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/점검표/2018/0141.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 141,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1137",
+          "newText": "new-1137-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1150",
+          "newText": "new-1150-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1163",
+          "newText": "new-1163-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1176",
+          "newText": "new-1176-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1189",
+          "newText": "new-1189-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2018/0141.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 15,
+          "col": 2,
+          "oldText": "old-1202",
+          "newText": "new-1202-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001138",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/점검표/2018/0142.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 142,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 17,
+          "col": 4,
+          "oldText": "old-1138",
+          "newText": "new-1138-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 18,
+          "col": 7,
+          "oldText": "old-1151",
+          "newText": "new-1151-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1164",
+          "newText": "new-1164-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1177",
+          "newText": "new-1177-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1190",
+          "newText": "new-1190-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2018/0142.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1203",
+          "newText": "new-1203-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001139",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/점검표/2018/0143.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 143,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1139",
+          "newText": "new-1139-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1152",
+          "newText": "new-1152-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1165",
+          "newText": "new-1165-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1178",
+          "newText": "new-1178-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1191",
+          "newText": "new-1191-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2018/0143.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1204",
+          "newText": "new-1204-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001140",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/점검표/2018/0144.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 144,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1140",
+          "newText": "new-1140-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 14,
+          "col": 1,
+          "oldText": "old-1153",
+          "newText": "new-1153-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1166",
+          "newText": "new-1166-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1179",
+          "newText": "new-1179-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 2,
+          "oldText": "old-1192",
+          "newText": "new-1192-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2018/0144.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1205",
+          "newText": "new-1205-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001141",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 145,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1141",
+          "newText": "new-1141-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 21,
+          "col": 4,
+          "oldText": "old-1154",
+          "newText": "new-1154-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1167",
+          "newText": "new-1167-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 11,
+          "col": 4,
+          "oldText": "old-1180",
+          "newText": "new-1180-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1193",
+          "newText": "new-1193-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2018/0145.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 19,
+          "col": 0,
+          "oldText": "old-1206",
+          "newText": "new-1206-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001142",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/점검표/2018/0146.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 146,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 2,
+          "oldText": "old-1142",
+          "newText": "new-1142-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1155",
+          "newText": "new-1155-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 17,
+          "col": 6,
+          "oldText": "old-1168",
+          "newText": "new-1168-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1181",
+          "newText": "new-1181-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1194",
+          "newText": "new-1194-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2018/0146.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1207",
+          "newText": "new-1207-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001143",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 147,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1143",
+          "newText": "new-1143-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1169",
+          "newText": "new-1169-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1182",
+          "newText": "new-1182-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1195",
+          "newText": "new-1195-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2018/0147.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1208",
+          "newText": "new-1208-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001144",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/점검표/2018/0148.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 148,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1144",
+          "newText": "new-1144-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1157",
+          "newText": "new-1157-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1170",
+          "newText": "new-1170-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1183",
+          "newText": "new-1183-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1196",
+          "newText": "new-1196-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2018/0148.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1209",
+          "newText": "new-1209-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001145",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/점검표/2018/0149.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 149,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1145",
+          "newText": "new-1145-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1158",
+          "newText": "new-1158-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1171",
+          "newText": "new-1171-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 12,
+          "col": 4,
+          "oldText": "old-1184",
+          "newText": "new-1184-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1197",
+          "newText": "new-1197-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2018/0149.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 5,
+          "col": 6,
+          "oldText": "old-1210",
+          "newText": "new-1210-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001146",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 150,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1146",
+          "newText": "new-1146-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1159",
+          "newText": "new-1159-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1172",
+          "newText": "new-1172-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1185",
+          "newText": "new-1185-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1198",
+          "newText": "new-1198-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2018/0150.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1211",
+          "newText": "new-1211-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001147",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 151,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1147",
+          "newText": "new-1147-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1160",
+          "newText": "new-1160-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1173",
+          "newText": "new-1173-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1186",
+          "newText": "new-1186-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 15,
+          "col": 7,
+          "oldText": "old-1199",
+          "newText": "new-1199-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2018/0151.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1212",
+          "newText": "new-1212-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001148",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 152,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1148",
+          "newText": "new-1148-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1161",
+          "newText": "new-1161-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1174",
+          "newText": "new-1174-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1187",
+          "newText": "new-1187-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1200",
+          "newText": "new-1200-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2018/0152.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1213",
+          "newText": "new-1213-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001149",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 153,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1149",
+          "newText": "new-1149-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1162",
+          "newText": "new-1162-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1175",
+          "newText": "new-1175-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1188",
+          "newText": "new-1188-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1201",
+          "newText": "new-1201-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 4,
+          "oldText": "old-1214",
+          "newText": "new-1214-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2018/0153.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1227",
+          "newText": "new-1227-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001150",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/점검표/2018/0154.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 154,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 12,
+          "col": 2,
+          "oldText": "old-1150",
+          "newText": "new-1150-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1163",
+          "newText": "new-1163-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1176",
+          "newText": "new-1176-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1189",
+          "newText": "new-1189-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 2,
+          "oldText": "old-1202",
+          "newText": "new-1202-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1215",
+          "newText": "new-1215-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2018/0154.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1228",
+          "newText": "new-1228-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001151",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "점검표",
+    "year": 2018,
+    "serial": 155,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 18,
+          "col": 7,
+          "oldText": "old-1151",
+          "newText": "new-1151-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1164",
+          "newText": "new-1164-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1177",
+          "newText": "new-1177-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1190",
+          "newText": "new-1190-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1203",
+          "newText": "new-1203-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 2,
+          "col": 5,
+          "oldText": "old-1216",
+          "newText": "new-1216-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2018/0155.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1229",
+          "newText": "new-1229-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001152",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/고시/2019/0156.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 156,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1152",
+          "newText": "new-1152-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1165",
+          "newText": "new-1165-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1178",
+          "newText": "new-1178-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1191",
+          "newText": "new-1191-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1204",
+          "newText": "new-1204-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1217",
+          "newText": "new-1217-1",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2019/0156.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1230",
+          "newText": "new-1230-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0018.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0018.json
@@ -1,0 +1,11176 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001153",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 157,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 14,
+          "col": 1,
+          "oldText": "old-1153",
+          "newText": "new-1153-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1166",
+          "newText": "new-1166-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1179",
+          "newText": "new-1179-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 2,
+          "oldText": "old-1192",
+          "newText": "new-1192-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1205",
+          "newText": "new-1205-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1218",
+          "newText": "new-1218-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2019/0157.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1231",
+          "newText": "new-1231-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001154",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/고시/2019/0158.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 158,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 21,
+          "col": 4,
+          "oldText": "old-1154",
+          "newText": "new-1154-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1167",
+          "newText": "new-1167-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 11,
+          "col": 4,
+          "oldText": "old-1180",
+          "newText": "new-1180-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1193",
+          "newText": "new-1193-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 19,
+          "col": 0,
+          "oldText": "old-1206",
+          "newText": "new-1206-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1219",
+          "newText": "new-1219-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2019/0158.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 2,
+          "oldText": "old-1232",
+          "newText": "new-1232-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001155",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/고시/2019/0159.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 159,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1155",
+          "newText": "new-1155-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 17,
+          "col": 6,
+          "oldText": "old-1168",
+          "newText": "new-1168-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1181",
+          "newText": "new-1181-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1194",
+          "newText": "new-1194-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1207",
+          "newText": "new-1207-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1220",
+          "newText": "new-1220-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2019/0159.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1233",
+          "newText": "new-1233-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001156",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/고시/2019/0160.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 160,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1156",
+          "newText": "new-1156-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1169",
+          "newText": "new-1169-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1182",
+          "newText": "new-1182-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1195",
+          "newText": "new-1195-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1208",
+          "newText": "new-1208-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1221",
+          "newText": "new-1221-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2019/0160.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1234",
+          "newText": "new-1234-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001157",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/고시/2019/0161.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 161,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 3,
+          "col": 5,
+          "oldText": "old-1157",
+          "newText": "new-1157-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1170",
+          "newText": "new-1170-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1183",
+          "newText": "new-1183-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1196",
+          "newText": "new-1196-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1209",
+          "newText": "new-1209-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1222",
+          "newText": "new-1222-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2019/0161.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1235",
+          "newText": "new-1235-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001158",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/고시/2019/0162.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 162,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1158",
+          "newText": "new-1158-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1171",
+          "newText": "new-1171-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 12,
+          "col": 4,
+          "oldText": "old-1184",
+          "newText": "new-1184-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1197",
+          "newText": "new-1197-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 6,
+          "oldText": "old-1210",
+          "newText": "new-1210-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 7,
+          "oldText": "old-1223",
+          "newText": "new-1223-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2019/0162.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1236",
+          "newText": "new-1236-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001159",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 163,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1159",
+          "newText": "new-1159-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1172",
+          "newText": "new-1172-17",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1185",
+          "newText": "new-1185-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1198",
+          "newText": "new-1198-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1211",
+          "newText": "new-1211-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1224",
+          "newText": "new-1224-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2019/0163.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1237",
+          "newText": "new-1237-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001160",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 164,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1160",
+          "newText": "new-1160-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1173",
+          "newText": "new-1173-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1186",
+          "newText": "new-1186-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 15,
+          "col": 7,
+          "oldText": "old-1199",
+          "newText": "new-1199-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1212",
+          "newText": "new-1212-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1225",
+          "newText": "new-1225-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2019/0164.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1238",
+          "newText": "new-1238-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001161",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/고시/2019/0165.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 165,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1161",
+          "newText": "new-1161-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1174",
+          "newText": "new-1174-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1187",
+          "newText": "new-1187-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1200",
+          "newText": "new-1200-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1213",
+          "newText": "new-1213-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1226",
+          "newText": "new-1226-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2019/0165.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1239",
+          "newText": "new-1239-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001162",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 166,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1162",
+          "newText": "new-1162-19",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1175",
+          "newText": "new-1175-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1188",
+          "newText": "new-1188-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1201",
+          "newText": "new-1201-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 6,
+          "col": 4,
+          "oldText": "old-1214",
+          "newText": "new-1214-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1227",
+          "newText": "new-1227-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2019/0166.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1240",
+          "newText": "new-1240-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001163",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 167,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1163",
+          "newText": "new-1163-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1176",
+          "newText": "new-1176-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1189",
+          "newText": "new-1189-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 2,
+          "oldText": "old-1202",
+          "newText": "new-1202-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1215",
+          "newText": "new-1215-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1228",
+          "newText": "new-1228-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1241",
+          "newText": "new-1241-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2019/0167.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1254",
+          "newText": "new-1254-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001164",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/고시/2019/0168.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 168,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1164",
+          "newText": "new-1164-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 8,
+          "col": 1,
+          "oldText": "old-1177",
+          "newText": "new-1177-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1190",
+          "newText": "new-1190-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1203",
+          "newText": "new-1203-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 2,
+          "col": 5,
+          "oldText": "old-1216",
+          "newText": "new-1216-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1229",
+          "newText": "new-1229-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1242",
+          "newText": "new-1242-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2019/0168.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1255",
+          "newText": "new-1255-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001165",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 169,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1165",
+          "newText": "new-1165-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1178",
+          "newText": "new-1178-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1191",
+          "newText": "new-1191-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1204",
+          "newText": "new-1204-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1217",
+          "newText": "new-1217-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1230",
+          "newText": "new-1230-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1243",
+          "newText": "new-1243-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2019/0169.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 18,
+          "col": 1,
+          "oldText": "old-1256",
+          "newText": "new-1256-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001166",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 170,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 15,
+          "col": 1,
+          "oldText": "old-1166",
+          "newText": "new-1166-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1179",
+          "newText": "new-1179-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 1,
+          "col": 2,
+          "oldText": "old-1192",
+          "newText": "new-1192-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 9,
+          "col": 5,
+          "oldText": "old-1205",
+          "newText": "new-1205-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 12,
+          "col": 0,
+          "oldText": "old-1218",
+          "newText": "new-1218-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1231",
+          "newText": "new-1231-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 3,
+          "col": 4,
+          "oldText": "old-1244",
+          "newText": "new-1244-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2019/0170.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1257",
+          "newText": "new-1257-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001167",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 171,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1167",
+          "newText": "new-1167-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 11,
+          "col": 4,
+          "oldText": "old-1180",
+          "newText": "new-1180-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1193",
+          "newText": "new-1193-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 19,
+          "col": 0,
+          "oldText": "old-1206",
+          "newText": "new-1206-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 14,
+          "col": 3,
+          "oldText": "old-1219",
+          "newText": "new-1219-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 1,
+          "col": 2,
+          "oldText": "old-1232",
+          "newText": "new-1232-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 3,
+          "oldText": "old-1245",
+          "newText": "new-1245-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2019/0171.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 5,
+          "oldText": "old-1258",
+          "newText": "new-1258-2",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001168",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 172,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 17,
+          "col": 6,
+          "oldText": "old-1168",
+          "newText": "new-1168-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1181",
+          "newText": "new-1181-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1194",
+          "newText": "new-1194-7",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1207",
+          "newText": "new-1207-9",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1220",
+          "newText": "new-1220-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1233",
+          "newText": "new-1233-3",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 4,
+          "col": 0,
+          "oldText": "old-1246",
+          "newText": "new-1246-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2019/0172.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 7,
+          "col": 3,
+          "oldText": "old-1259",
+          "newText": "new-1259-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001169",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/고시/2019/0173.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 173,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 11,
+          "col": 1,
+          "oldText": "old-1169",
+          "newText": "new-1169-8",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1182",
+          "newText": "new-1182-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1195",
+          "newText": "new-1195-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 3,
+          "oldText": "old-1208",
+          "newText": "new-1208-4",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1221",
+          "newText": "new-1221-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 2,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1234",
+          "newText": "new-1234-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 7,
+          "oldText": "old-1247",
+          "newText": "new-1247-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2019/0173.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 5,
+          "col": 0,
+          "oldText": "old-1260",
+          "newText": "new-1260-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001170",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/고시/2019/0174.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 174,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 11,
+          "col": 0,
+          "oldText": "old-1170",
+          "newText": "new-1170-6",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1183",
+          "newText": "new-1183-5",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1196",
+          "newText": "new-1196-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1209",
+          "newText": "new-1209-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1222",
+          "newText": "new-1222-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1235",
+          "newText": "new-1235-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1248",
+          "newText": "new-1248-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2019/0174.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1261",
+          "newText": "new-1261-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001171",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/고시/2019/0175.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 175,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 17,
+          "col": 3,
+          "oldText": "old-1171",
+          "newText": "new-1171-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 0,
+          "row": 12,
+          "col": 4,
+          "oldText": "old-1184",
+          "newText": "new-1184-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 1,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1197",
+          "newText": "new-1197-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 5,
+          "col": 6,
+          "oldText": "old-1210",
+          "newText": "new-1210-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 14,
+          "col": 7,
+          "oldText": "old-1223",
+          "newText": "new-1223-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1236",
+          "newText": "new-1236-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 4,
+          "col": 1,
+          "oldText": "old-1249",
+          "newText": "new-1249-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2019/0175.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 2,
+          "row": 3,
+          "col": 2,
+          "oldText": "old-1262",
+          "newText": "new-1262-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001172",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/고시/2019/0176.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 176,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "table": 0,
+          "row": 7,
+          "col": 2,
+          "oldText": "old-1172",
+          "newText": "new-1172-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 16,
+          "col": 3,
+          "oldText": "old-1185",
+          "newText": "new-1185-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1198",
+          "newText": "new-1198-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 2,
+          "col": 3,
+          "oldText": "old-1211",
+          "newText": "new-1211-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1224",
+          "newText": "new-1224-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 1,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1237",
+          "newText": "new-1237-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 2,
+          "row": 6,
+          "col": 0,
+          "oldText": "old-1250",
+          "newText": "new-1250-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2019/0176.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 10,
+          "col": 3,
+          "oldText": "old-1263",
+          "newText": "new-1263-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001173",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/고시/2019/0177.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 177,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "table": 1,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1173",
+          "newText": "new-1173-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1186",
+          "newText": "new-1186-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 3,
+          "row": 15,
+          "col": 7,
+          "oldText": "old-1199",
+          "newText": "new-1199-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 0,
+          "row": 3,
+          "col": 0,
+          "oldText": "old-1212",
+          "newText": "new-1212-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 1,
+          "row": 1,
+          "col": 1,
+          "oldText": "old-1225",
+          "newText": "new-1225-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 19,
+          "col": 3,
+          "oldText": "old-1238",
+          "newText": "new-1238-17",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1251",
+          "newText": "new-1251-10",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2019/0177.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 5,
+          "col": 4,
+          "oldText": "old-1264",
+          "newText": "new-1264-11",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001174",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/고시/2019/0178.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 178,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "table": 2,
+          "row": 6,
+          "col": 5,
+          "oldText": "old-1174",
+          "newText": "new-1174-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1187",
+          "newText": "new-1187-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 0,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1200",
+          "newText": "new-1200-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1213",
+          "newText": "new-1213-19",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 3,
+          "col": 1,
+          "oldText": "old-1226",
+          "newText": "new-1226-12",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 1,
+          "col": 3,
+          "oldText": "old-1239",
+          "newText": "new-1239-13",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 12,
+          "col": 6,
+          "oldText": "old-1252",
+          "newText": "new-1252-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2019/0178.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 5,
+          "col": 1,
+          "oldText": "old-1265",
+          "newText": "new-1265-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001175",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 179,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "table": 3,
+          "row": 8,
+          "col": 7,
+          "oldText": "old-1175",
+          "newText": "new-1175-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 13,
+          "col": 0,
+          "oldText": "old-1188",
+          "newText": "new-1188-23",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 1,
+          "oldText": "old-1201",
+          "newText": "new-1201-16",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 6,
+          "col": 4,
+          "oldText": "old-1214",
+          "newText": "new-1214-17",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 4,
+          "col": 3,
+          "oldText": "old-1227",
+          "newText": "new-1227-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 1,
+          "oldText": "old-1240",
+          "newText": "new-1240-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 12,
+          "col": 5,
+          "oldText": "old-1253",
+          "newText": "new-1253-15",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2019/0179.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1266",
+          "newText": "new-1266-14",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001176",
+    "command": "set-cell",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "set-cell",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/고시/2019/0180.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 180,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 7,
+          "col": 0,
+          "oldText": "old-1176",
+          "newText": "new-1176-20",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 2,
+          "col": 1,
+          "oldText": "old-1189",
+          "newText": "new-1189-21",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 15,
+          "col": 2,
+          "oldText": "old-1202",
+          "newText": "new-1202-22",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 3,
+          "row": 12,
+          "col": 3,
+          "oldText": "old-1215",
+          "newText": "new-1215-24",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 0,
+          "row": 9,
+          "col": 3,
+          "oldText": "old-1228",
+          "newText": "new-1228-19",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 1,
+          "row": 6,
+          "col": 1,
+          "oldText": "old-1241",
+          "newText": "new-1241-18",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "table": 2,
+          "row": 1,
+          "col": 0,
+          "oldText": "old-1254",
+          "newText": "new-1254-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2019/0180.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "table": 3,
+          "row": 8,
+          "col": 3,
+          "oldText": "old-1267",
+          "newText": "new-1267-0",
+          "overflow": false,
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001177",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/고시/2019/0181.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 181,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2019/0181.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/산림청/고시/2019/0181.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2019/0181.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/산림청/고시/2019/0181.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001178",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/고시/2019/0182.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 182,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2019/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/고시/2019/0182.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2019/0182.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/고시/2019/0182.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001179",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/고시/2019/0183.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 183,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2019/0183.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/고시/2019/0183.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2019/0183.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/고시/2019/0183.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001180",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/고시/2019/0184.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 184,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2019/0184.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/고시/2019/0184.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2019/0184.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/고시/2019/0184.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001181",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/고시/2019/0185.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 185,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2019/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/문화체육관광부/고시/2019/0185.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2019/0185.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/문화체육관광부/고시/2019/0185.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001182",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/고시/2019/0186.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 186,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2019/0186.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/환경부/고시/2019/0186.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2019/0186.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/환경부/고시/2019/0186.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001183",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/고시/2019/0187.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "고시",
+    "year": 2019,
+    "serial": 187,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2019/0187.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/해양수산부/고시/2019/0187.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2019/0187.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양수산부/고시/2019/0187.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001184",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/훈령/2019/0188.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 188,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2019/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/법제처/훈령/2019/0188.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2019/0188.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/법제처/훈령/2019/0188.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001185",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/훈령/2019/0189.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 189,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2019/0189.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/행정안전부/훈령/2019/0189.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2019/0189.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/행정안전부/훈령/2019/0189.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001186",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/훈령/2019/0190.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 190,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2019/0190.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국세청/훈령/2019/0190.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2019/0190.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국세청/훈령/2019/0190.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001187",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/훈령/2019/0191.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 191,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2019/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/대법원/훈령/2019/0191.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2019/0191.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/대법원/훈령/2019/0191.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001188",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/훈령/2019/0192.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 192,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2019/0192.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/특허청/훈령/2019/0192.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2019/0192.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/특허청/훈령/2019/0192.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001189",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/훈령/2019/0193.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 193,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2019/0193.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/교육부/훈령/2019/0193.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2019/0193.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/교육부/훈령/2019/0193.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001190",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/훈령/2019/0194.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 194,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2019/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/훈령/2019/0194.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2019/0194.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/보건복지부/훈령/2019/0194.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001191",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/훈령/2019/0195.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 195,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2019/0195.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/훈령/2019/0195.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2019/0195.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국토교통부/훈령/2019/0195.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2019/0195.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국토교통부/훈령/2019/0195.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001192",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/훈령/2019/0196.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 196,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2019/0196.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/훈령/2019/0196.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2019/0196.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/고용노동부/훈령/2019/0196.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2019/0196.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/고용노동부/훈령/2019/0196.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001193",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/훈령/2019/0197.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 197,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2019/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/외교부/훈령/2019/0197.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2019/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/외교부/훈령/2019/0197.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2019/0197.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/외교부/훈령/2019/0197.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001194",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/훈령/2019/0198.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 198,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2019/0198.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/훈령/2019/0198.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2019/0198.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/기획재정부/훈령/2019/0198.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2019/0198.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/훈령/2019/0198.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001195",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/훈령/2019/0199.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 199,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2019/0199.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/훈령/2019/0199.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2019/0199.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/공정거래위원회/훈령/2019/0199.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2019/0199.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/훈령/2019/0199.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001196",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/훈령/2019/0200.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 200,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2019/0200.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/훈령/2019/0200.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2019/0200.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/금융위원회/훈령/2019/0200.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2019/0200.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/훈령/2019/0200.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001197",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/훈령/2019/0201.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 201,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2019/0201.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/훈령/2019/0201.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2019/0201.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/방송통신위원회/훈령/2019/0201.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2019/0201.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/훈령/2019/0201.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001198",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/훈령/2019/0202.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 202,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2019/0202.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/훈령/2019/0202.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2019/0202.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/개인정보보호위원회/훈령/2019/0202.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2019/0202.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/훈령/2019/0202.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001199",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/훈령/2019/0203.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 203,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2019/0203.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/훈령/2019/0203.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2019/0203.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국민권익위원회/훈령/2019/0203.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2019/0203.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/훈령/2019/0203.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001200",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/훈령/2019/0204.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 204,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2019/0204.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/훈령/2019/0204.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2019/0204.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국가인권위원회/훈령/2019/0204.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2019/0204.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/훈령/2019/0204.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001201",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/훈령/2019/0205.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 205,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2019/0205.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/훈령/2019/0205.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2019/0205.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/통계청/훈령/2019/0205.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2019/0205.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/통계청/훈령/2019/0205.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001202",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/훈령/2019/0206.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 206,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2019/0206.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기상청/훈령/2019/0206.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2019/0206.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/기상청/훈령/2019/0206.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2019/0206.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기상청/훈령/2019/0206.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001203",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/훈령/2019/0207.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 207,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2019/0207.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/관세청/훈령/2019/0207.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2019/0207.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/관세청/훈령/2019/0207.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2019/0207.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/관세청/훈령/2019/0207.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001204",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/훈령/2019/0208.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 208,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2019/0208.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/훈령/2019/0208.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2019/0208.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/훈령/2019/0208.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2019/0208.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/훈령/2019/0208.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001205",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/훈령/2019/0209.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 209,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2019/0209.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/훈령/2019/0209.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2019/0209.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/훈령/2019/0209.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2019/0209.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/훈령/2019/0209.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2019/0209.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/경찰청/훈령/2019/0209.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001206",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/훈령/2019/0210.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 210,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2019/0210.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/소방청/훈령/2019/0210.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2019/0210.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/소방청/훈령/2019/0210.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2019/0210.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/소방청/훈령/2019/0210.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2019/0210.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/소방청/훈령/2019/0210.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001207",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/훈령/2019/0211.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 211,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2019/0211.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/훈령/2019/0211.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2019/0211.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/훈령/2019/0211.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2019/0211.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/훈령/2019/0211.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2019/0211.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/훈령/2019/0211.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001208",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/훈령/2019/0212.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 212,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2019/0212.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/병무청/훈령/2019/0212.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2019/0212.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/병무청/훈령/2019/0212.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2019/0212.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/병무청/훈령/2019/0212.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2019/0212.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/병무청/훈령/2019/0212.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001209",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/훈령/2019/0213.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 213,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2019/0213.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/산림청/훈령/2019/0213.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2019/0213.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/산림청/훈령/2019/0213.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2019/0213.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/산림청/훈령/2019/0213.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2019/0213.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/산림청/훈령/2019/0213.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001210",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/훈령/2019/0214.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 214,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2019/0214.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/훈령/2019/0214.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2019/0214.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/훈령/2019/0214.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2019/0214.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/훈령/2019/0214.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2019/0214.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/훈령/2019/0214.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001211",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/훈령/2019/0215.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 215,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2019/0215.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/중소벤처기업부/훈령/2019/0215.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2019/0215.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/중소벤처기업부/훈령/2019/0215.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2019/0215.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/중소벤처기업부/훈령/2019/0215.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2019/0215.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/중소벤처기업부/훈령/2019/0215.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001212",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/훈령/2019/0216.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 216,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2019/0216.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/과학기술정보통신부/훈령/2019/0216.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2019/0216.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/과학기술정보통신부/훈령/2019/0216.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2019/0216.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/과학기술정보통신부/훈령/2019/0216.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2019/0216.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/과학기술정보통신부/훈령/2019/0216.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001213",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/훈령/2019/0217.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 217,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2019/0217.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/문화체육관광부/훈령/2019/0217.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2019/0217.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/문화체육관광부/훈령/2019/0217.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2019/0217.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/문화체육관광부/훈령/2019/0217.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2019/0217.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/문화체육관광부/훈령/2019/0217.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001214",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/훈령/2019/0218.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 218,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2019/0218.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/환경부/훈령/2019/0218.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2019/0218.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/환경부/훈령/2019/0218.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2019/0218.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/환경부/훈령/2019/0218.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2019/0218.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/환경부/훈령/2019/0218.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001215",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/훈령/2019/0219.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "훈령",
+    "year": 2019,
+    "serial": 219,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2019/0219.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/해양수산부/훈령/2019/0219.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2019/0219.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양수산부/훈령/2019/0219.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2019/0219.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/해양수산부/훈령/2019/0219.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2019/0219.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양수산부/훈령/2019/0219.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001216",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/예규/2019/0220.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 220,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2019/0220.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/법제처/예규/2019/0220.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2019/0220.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/법제처/예규/2019/0220.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2019/0220.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/법제처/예규/2019/0220.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2019/0220.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/법제처/예규/2019/0220.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0019.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0019.json
@@ -1,0 +1,16295 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001217",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/예규/2019/0221.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 221,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2019/0221.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/행정안전부/예규/2019/0221.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2019/0221.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/행정안전부/예규/2019/0221.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2019/0221.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/예규/2019/0221.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2019/0221.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/행정안전부/예규/2019/0221.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001218",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/예규/2019/0222.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 222,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2019/0222.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국세청/예규/2019/0222.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2019/0222.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국세청/예규/2019/0222.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2019/0222.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국세청/예규/2019/0222.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2019/0222.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 4,
+          "csv": "samples/gov/국세청/예규/2019/0222.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001219",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/예규/2019/0223.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 223,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2019/0223.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/대법원/예규/2019/0223.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2019/0223.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/대법원/예규/2019/0223.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2019/0223.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/대법원/예규/2019/0223.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2019/0223.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/대법원/예규/2019/0223.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2019/0223.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/대법원/예규/2019/0223.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001220",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/예규/2019/0224.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 224,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2019/0224.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/특허청/예규/2019/0224.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2019/0224.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/특허청/예규/2019/0224.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2019/0224.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/특허청/예규/2019/0224.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2019/0224.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/특허청/예규/2019/0224.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2019/0224.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/특허청/예규/2019/0224.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001221",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/예규/2019/0225.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 225,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2019/0225.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/교육부/예규/2019/0225.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2019/0225.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/교육부/예규/2019/0225.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2019/0225.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/교육부/예규/2019/0225.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2019/0225.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/교육부/예규/2019/0225.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2019/0225.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/교육부/예규/2019/0225.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001222",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 226,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/보건복지부/예규/2019/0226.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/보건복지부/예규/2019/0226.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/예규/2019/0226.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/보건복지부/예규/2019/0226.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2019/0226.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/예규/2019/0226.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001223",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 227,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/국토교통부/예규/2019/0227.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국토교통부/예규/2019/0227.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/예규/2019/0227.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국토교통부/예규/2019/0227.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2019/0227.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/예규/2019/0227.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001224",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/예규/2019/0228.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 228,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2019/0228.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/고용노동부/예규/2019/0228.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2019/0228.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/고용노동부/예규/2019/0228.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2019/0228.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/예규/2019/0228.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2019/0228.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/고용노동부/예규/2019/0228.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2019/0228.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/예규/2019/0228.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001225",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/예규/2019/0229.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 229,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2019/0229.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/외교부/예규/2019/0229.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2019/0229.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/외교부/예규/2019/0229.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2019/0229.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/외교부/예규/2019/0229.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2019/0229.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/외교부/예규/2019/0229.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2019/0229.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/외교부/예규/2019/0229.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001226",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 230,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/예규/2019/0230.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/기획재정부/예규/2019/0230.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/예규/2019/0230.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/기획재정부/예규/2019/0230.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2019/0230.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/예규/2019/0230.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001227",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 231,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/예규/2019/0231.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/공정거래위원회/예규/2019/0231.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/예규/2019/0231.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/공정거래위원회/예규/2019/0231.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2019/0231.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/예규/2019/0231.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001228",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 232,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/예규/2019/0232.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/금융위원회/예규/2019/0232.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/예규/2019/0232.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/금융위원회/예규/2019/0232.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2019/0232.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/예규/2019/0232.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001229",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 233,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/예규/2019/0233.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/방송통신위원회/예규/2019/0233.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/예규/2019/0233.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/방송통신위원회/예규/2019/0233.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2019/0233.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/예규/2019/0233.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001230",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 234,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/예규/2019/0234.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/개인정보보호위원회/예규/2019/0234.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/예규/2019/0234.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/개인정보보호위원회/예규/2019/0234.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2019/0234.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/예규/2019/0234.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001231",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 235,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/예규/2019/0235.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국민권익위원회/예규/2019/0235.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/예규/2019/0235.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/예규/2019/0235.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2019/0235.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/예규/2019/0235.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001232",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 236,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/예규/2019/0236.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국가인권위원회/예규/2019/0236.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/예규/2019/0236.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/예규/2019/0236.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2019/0236.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/예규/2019/0236.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001233",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/예규/2019/0237.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 237,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2019/0237.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/통계청/예규/2019/0237.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001234",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/예규/2019/0238.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 238,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2019/0238.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/기상청/예규/2019/0238.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001235",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/예규/2019/0239.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 239,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2019/0239.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/관세청/예규/2019/0239.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001236",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/예규/2019/0240.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 240,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2019/0240.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/예규/2019/0240.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001237",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/예규/2019/0241.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 241,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2019/0241.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/예규/2019/0241.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001238",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/예규/2019/0242.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 242,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2019/0242.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/소방청/예규/2019/0242.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001239",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 243,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2019/0243.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/예규/2019/0243.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001240",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/예규/2019/0244.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 244,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2019/0244.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/병무청/예규/2019/0244.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001241",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/예규/2019/0245.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 245,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2019/0245.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/산림청/예규/2019/0245.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001242",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 246,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2019/0246.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/예규/2019/0246.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001243",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 247,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2019/0247.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/중소벤처기업부/예규/2019/0247.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001244",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 248,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2019/0248.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/과학기술정보통신부/예규/2019/0248.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001245",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 249,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2019/0249.hwp",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/문화체육관광부/예규/2019/0249.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001246",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/예규/2019/0250.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 250,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2019/0250.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/환경부/예규/2019/0250.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001247",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예규",
+    "year": 2019,
+    "serial": 251,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2019/0251.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/해양수산부/예규/2019/0251.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001248",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/공고/2019/0252.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 252,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2019/0252.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/법제처/공고/2019/0252.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001249",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 253,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2019/0253.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/공고/2019/0253.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001250",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/공고/2019/0254.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 254,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2019/0254.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/국세청/공고/2019/0254.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001251",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/공고/2019/0255.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 255,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2019/0255.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/대법원/공고/2019/0255.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001252",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/공고/2019/0256.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 256,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2019/0256.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/특허청/공고/2019/0256.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001253",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/공고/2019/0257.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 257,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2019/0257.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/교육부/공고/2019/0257.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001254",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/공고/2019/0258.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 258,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2019/0258.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/공고/2019/0258.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001255",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 259,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2019/0259.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/공고/2019/0259.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001256",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 260,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2019/0260.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/공고/2019/0260.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001257",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/공고/2019/0261.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 261,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2019/0261.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/외교부/공고/2019/0261.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001258",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 262,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2019/0262.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/공고/2019/0262.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001259",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 263,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2019/0263.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/공고/2019/0263.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001260",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/공고/2019/0264.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 264,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2019/0264.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/공고/2019/0264.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001261",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 265,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2019/0265.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/방송통신위원회/공고/2019/0265.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001262",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 266,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2019/0266.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/개인정보보호위원회/공고/2019/0266.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001263",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 267,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2019/0267.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/공고/2019/0267.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001264",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 268,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2019/0268.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/공고/2019/0268.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001265",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/공고/2019/0269.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 269,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2019/0269.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/통계청/공고/2019/0269.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001266",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/공고/2019/0270.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 270,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 4,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2019/0270.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/기상청/공고/2019/0270.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001267",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/공고/2019/0271.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 271,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2019/0271.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/관세청/공고/2019/0271.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001268",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/공고/2019/0272.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 272,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2019/0272.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/공고/2019/0272.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001269",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/공고/2019/0273.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 273,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2019/0273.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/공고/2019/0273.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001270",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/공고/2019/0274.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 274,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2019/0274.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/소방청/공고/2019/0274.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001271",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 275,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2019/0275.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/공고/2019/0275.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001272",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/공고/2019/0276.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 276,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2019/0276.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/병무청/공고/2019/0276.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001273",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/공고/2019/0277.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 277,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2019/0277.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/산림청/공고/2019/0277.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001274",
+    "command": "csv-to-chart",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 278,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2019/0278.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/공고/2019/0278.chart.csv",
+          "changed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001275",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/공고/2019/0279.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 279,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2019/0279.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/공고/2019/0279.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/공고/2019/0279.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2019/0279.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/공고/2019/0279.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/공고/2019/0279.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001276",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/공고/2019/0280.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 280,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2019/0280.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/공고/2019/0280.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2019/0280.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2019/0280.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/공고/2019/0280.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2019/0280.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001277",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/공고/2019/0281.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 281,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2019/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/문화체육관광부/공고/2019/0281.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2019/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2019/0281.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/문화체육관광부/공고/2019/0281.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2019/0281.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001278",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/공고/2019/0282.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 282,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2019/0282.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/환경부/공고/2019/0282.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/환경부/공고/2019/0282.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2019/0282.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/환경부/공고/2019/0282.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/환경부/공고/2019/0282.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001279",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/공고/2019/0283.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "공고",
+    "year": 2019,
+    "serial": 283,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2019/0283.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/해양수산부/공고/2019/0283.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2019/0283.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2019/0283.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양수산부/공고/2019/0283.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2019/0283.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001280",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/지침/2019/0284.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 284,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2019/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/법제처/지침/2019/0284.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2019/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2019/0284.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/법제처/지침/2019/0284.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2019/0284.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0020.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0020.json
@@ -1,0 +1,15088 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001281",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/지침/2019/0285.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 285,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2019/0285.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/행정안전부/지침/2019/0285.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/지침/2019/0285.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2019/0285.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/행정안전부/지침/2019/0285.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/지침/2019/0285.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001282",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/지침/2019/0286.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 286,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2019/0286.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/국세청/지침/2019/0286.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2019/0286.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2019/0286.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/국세청/지침/2019/0286.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2019/0286.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001283",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/지침/2019/0287.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 287,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2019/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/대법원/지침/2019/0287.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/대법원/지침/2019/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2019/0287.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/대법원/지침/2019/0287.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/대법원/지침/2019/0287.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001284",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/지침/2019/0288.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 288,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2019/0288.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/특허청/지침/2019/0288.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/특허청/지침/2019/0288.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2019/0288.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/특허청/지침/2019/0288.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/특허청/지침/2019/0288.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001285",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/지침/2019/0289.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 289,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2019/0289.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/교육부/지침/2019/0289.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/교육부/지침/2019/0289.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2019/0289.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/교육부/지침/2019/0289.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/지침/2019/0289.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001286",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/지침/2019/0290.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 290,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2019/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/지침/2019/0290.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/지침/2019/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2019/0290.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/보건복지부/지침/2019/0290.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/지침/2019/0290.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001287",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/지침/2019/0291.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 291,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2019/0291.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/지침/2019/0291.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/지침/2019/0291.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2019/0291.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국토교통부/지침/2019/0291.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/지침/2019/0291.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001288",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/지침/2019/0292.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 292,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2019/0292.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/지침/2019/0292.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/고용노동부/지침/2019/0292.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2019/0292.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/고용노동부/지침/2019/0292.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/고용노동부/지침/2019/0292.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001289",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/지침/2019/0293.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 293,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2019/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/외교부/지침/2019/0293.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/지침/2019/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2019/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/외교부/지침/2019/0293.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/외교부/지침/2019/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2019/0293.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/외교부/지침/2019/0293.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/외교부/지침/2019/0293.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001290",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/지침/2019/0294.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 294,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2019/0294.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/지침/2019/0294.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/지침/2019/0294.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2019/0294.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/기획재정부/지침/2019/0294.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/지침/2019/0294.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2019/0294.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/지침/2019/0294.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/지침/2019/0294.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001291",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/지침/2019/0295.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 295,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2019/0295.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/지침/2019/0295.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/공정거래위원회/지침/2019/0295.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2019/0295.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/공정거래위원회/지침/2019/0295.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/공정거래위원회/지침/2019/0295.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2019/0295.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/지침/2019/0295.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/공정거래위원회/지침/2019/0295.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001292",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/지침/2019/0296.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 296,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2019/0296.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/지침/2019/0296.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/지침/2019/0296.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2019/0296.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/금융위원회/지침/2019/0296.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/지침/2019/0296.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2019/0296.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/지침/2019/0296.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/지침/2019/0296.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001293",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/지침/2019/0297.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 297,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2019/0297.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/지침/2019/0297.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2019/0297.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2019/0297.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/방송통신위원회/지침/2019/0297.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2019/0297.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2019/0297.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/지침/2019/0297.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2019/0297.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001294",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/지침/2019/0298.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 298,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2019/0298.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/지침/2019/0298.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/개인정보보호위원회/지침/2019/0298.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2019/0298.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/개인정보보호위원회/지침/2019/0298.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/개인정보보호위원회/지침/2019/0298.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2019/0298.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/지침/2019/0298.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2019/0298.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001295",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/지침/2019/0299.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 299,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2019/0299.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/지침/2019/0299.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2019/0299.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2019/0299.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/국민권익위원회/지침/2019/0299.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2019/0299.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2019/0299.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/지침/2019/0299.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2019/0299.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001296",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/지침/2019/0300.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 300,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2019/0300.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/지침/2019/0300.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2019/0300.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2019/0300.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국가인권위원회/지침/2019/0300.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2019/0300.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2019/0300.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/지침/2019/0300.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2019/0300.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001297",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/지침/2019/0301.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 301,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2019/0301.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/지침/2019/0301.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/통계청/지침/2019/0301.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2019/0301.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/통계청/지침/2019/0301.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/통계청/지침/2019/0301.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2019/0301.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/통계청/지침/2019/0301.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/통계청/지침/2019/0301.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001298",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/지침/2019/0302.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 302,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2019/0302.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/기상청/지침/2019/0302.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/기상청/지침/2019/0302.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2019/0302.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 4,
+          "csv": "samples/gov/기상청/지침/2019/0302.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/지침/2019/0302.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2019/0302.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/기상청/지침/2019/0302.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/지침/2019/0302.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001299",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/지침/2019/0303.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 303,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2019/0303.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/관세청/지침/2019/0303.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/관세청/지침/2019/0303.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2019/0303.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/관세청/지침/2019/0303.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/지침/2019/0303.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2019/0303.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/관세청/지침/2019/0303.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/관세청/지침/2019/0303.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001300",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/지침/2019/0304.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 304,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2019/0304.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/지침/2019/0304.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/지침/2019/0304.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2019/0304.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/지침/2019/0304.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/지침/2019/0304.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2019/0304.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/지침/2019/0304.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/지침/2019/0304.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001301",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/지침/2019/0305.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 305,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2019/0305.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/지침/2019/0305.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/지침/2019/0305.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2019/0305.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/지침/2019/0305.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/지침/2019/0305.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2019/0305.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/지침/2019/0305.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/지침/2019/0305.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001302",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/지침/2019/0306.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 306,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2019/0306.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/소방청/지침/2019/0306.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/소방청/지침/2019/0306.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2019/0306.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/소방청/지침/2019/0306.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/소방청/지침/2019/0306.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2019/0306.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/소방청/지침/2019/0306.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/소방청/지침/2019/0306.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001303",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/지침/2019/0307.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 307,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2019/0307.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/지침/2019/0307.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2019/0307.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2019/0307.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/지침/2019/0307.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2019/0307.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2019/0307.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/지침/2019/0307.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2019/0307.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2019/0307.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/지침/2019/0307.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2019/0307.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001304",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/지침/2019/0308.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 308,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2019/0308.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/병무청/지침/2019/0308.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/지침/2019/0308.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2019/0308.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/병무청/지침/2019/0308.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/지침/2019/0308.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2019/0308.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/병무청/지침/2019/0308.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/지침/2019/0308.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2019/0308.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/병무청/지침/2019/0308.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/지침/2019/0308.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001305",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/지침/2019/0309.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 309,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2019/0309.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/산림청/지침/2019/0309.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/산림청/지침/2019/0309.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2019/0309.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/산림청/지침/2019/0309.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/산림청/지침/2019/0309.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2019/0309.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/산림청/지침/2019/0309.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/산림청/지침/2019/0309.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2019/0309.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/산림청/지침/2019/0309.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/산림청/지침/2019/0309.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001306",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/지침/2019/0310.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 310,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2019/0310.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/지침/2019/0310.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2019/0310.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2019/0310.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/지침/2019/0310.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2019/0310.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2019/0310.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/지침/2019/0310.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2019/0310.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2019/0310.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/지침/2019/0310.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2019/0310.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001307",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/지침/2019/0311.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 311,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2019/0311.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/중소벤처기업부/지침/2019/0311.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/지침/2019/0311.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2019/0311.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/중소벤처기업부/지침/2019/0311.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/지침/2019/0311.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2019/0311.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/중소벤처기업부/지침/2019/0311.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2019/0311.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2019/0311.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/중소벤처기업부/지침/2019/0311.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/지침/2019/0311.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001308",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/지침/2019/0312.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 312,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2019/0312.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/과학기술정보통신부/지침/2019/0312.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2019/0312.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2019/0312.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/과학기술정보통신부/지침/2019/0312.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2019/0312.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2019/0312.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/과학기술정보통신부/지침/2019/0312.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2019/0312.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2019/0312.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 4,
+          "csv": "samples/gov/과학기술정보통신부/지침/2019/0312.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/지침/2019/0312.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001309",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/지침/2019/0313.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 313,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2019/0313.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/문화체육관광부/지침/2019/0313.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2019/0313.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2019/0313.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/문화체육관광부/지침/2019/0313.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2019/0313.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2019/0313.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/문화체육관광부/지침/2019/0313.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2019/0313.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2019/0313.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/문화체육관광부/지침/2019/0313.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/문화체육관광부/지침/2019/0313.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001310",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/지침/2019/0314.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 314,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2019/0314.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/환경부/지침/2019/0314.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/환경부/지침/2019/0314.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2019/0314.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/환경부/지침/2019/0314.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/환경부/지침/2019/0314.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2019/0314.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/환경부/지침/2019/0314.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/환경부/지침/2019/0314.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2019/0314.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/환경부/지침/2019/0314.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/환경부/지침/2019/0314.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001311",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/지침/2019/0315.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "지침",
+    "year": 2019,
+    "serial": 315,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2019/0315.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/해양수산부/지침/2019/0315.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/해양수산부/지침/2019/0315.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2019/0315.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/해양수산부/지침/2019/0315.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/지침/2019/0315.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2019/0315.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/해양수산부/지침/2019/0315.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/지침/2019/0315.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2019/0315.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/해양수산부/지침/2019/0315.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/지침/2019/0315.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001312",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/서식/2019/0316.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 316,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2019/0316.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/법제처/서식/2019/0316.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/법제처/서식/2019/0316.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2019/0316.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/법제처/서식/2019/0316.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/법제처/서식/2019/0316.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2019/0316.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/법제처/서식/2019/0316.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/법제처/서식/2019/0316.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2019/0316.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/법제처/서식/2019/0316.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/법제처/서식/2019/0316.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001313",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/서식/2019/0317.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 317,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2019/0317.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/행정안전부/서식/2019/0317.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/서식/2019/0317.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2019/0317.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/행정안전부/서식/2019/0317.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/서식/2019/0317.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2019/0317.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/서식/2019/0317.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/서식/2019/0317.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2019/0317.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/행정안전부/서식/2019/0317.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/서식/2019/0317.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001314",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/서식/2019/0318.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 318,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2019/0318.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/국세청/서식/2019/0318.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/서식/2019/0318.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2019/0318.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/국세청/서식/2019/0318.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/서식/2019/0318.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2019/0318.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/국세청/서식/2019/0318.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/서식/2019/0318.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2019/0318.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/국세청/서식/2019/0318.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/서식/2019/0318.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001315",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/서식/2019/0319.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 319,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2019/0319.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/대법원/서식/2019/0319.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/대법원/서식/2019/0319.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2019/0319.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/대법원/서식/2019/0319.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/대법원/서식/2019/0319.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2019/0319.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/대법원/서식/2019/0319.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/대법원/서식/2019/0319.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2019/0319.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/대법원/서식/2019/0319.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/대법원/서식/2019/0319.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001316",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/서식/2019/0320.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 320,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2019/0320.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/특허청/서식/2019/0320.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/특허청/서식/2019/0320.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2019/0320.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/특허청/서식/2019/0320.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/특허청/서식/2019/0320.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2019/0320.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/특허청/서식/2019/0320.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/특허청/서식/2019/0320.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2019/0320.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/특허청/서식/2019/0320.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/특허청/서식/2019/0320.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001317",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/서식/2019/0321.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 321,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2019/0321.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/교육부/서식/2019/0321.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/서식/2019/0321.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2019/0321.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/교육부/서식/2019/0321.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/서식/2019/0321.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2019/0321.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/교육부/서식/2019/0321.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/서식/2019/0321.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2019/0321.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/교육부/서식/2019/0321.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/서식/2019/0321.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2019/0321.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/교육부/서식/2019/0321.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/서식/2019/0321.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001318",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 322,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/보건복지부/서식/2019/0322.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/서식/2019/0322.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/보건복지부/서식/2019/0322.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/서식/2019/0322.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/서식/2019/0322.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/서식/2019/0322.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/보건복지부/서식/2019/0322.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/서식/2019/0322.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2019/0322.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/서식/2019/0322.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/서식/2019/0322.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001319",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 323,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국토교통부/서식/2019/0323.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/서식/2019/0323.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국토교통부/서식/2019/0323.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/서식/2019/0323.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/서식/2019/0323.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/서식/2019/0323.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국토교통부/서식/2019/0323.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국토교통부/서식/2019/0323.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2019/0323.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/서식/2019/0323.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국토교통부/서식/2019/0323.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001320",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/서식/2019/0324.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 324,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2019/0324.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/고용노동부/서식/2019/0324.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/고용노동부/서식/2019/0324.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2019/0324.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/고용노동부/서식/2019/0324.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/고용노동부/서식/2019/0324.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2019/0324.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/서식/2019/0324.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/서식/2019/0324.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2019/0324.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/고용노동부/서식/2019/0324.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/고용노동부/서식/2019/0324.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2019/0324.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/서식/2019/0324.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/서식/2019/0324.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001321",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/서식/2019/0325.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 325,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2019/0325.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/외교부/서식/2019/0325.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/외교부/서식/2019/0325.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2019/0325.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/외교부/서식/2019/0325.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/외교부/서식/2019/0325.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2019/0325.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/외교부/서식/2019/0325.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/외교부/서식/2019/0325.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2019/0325.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/외교부/서식/2019/0325.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/서식/2019/0325.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2019/0325.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/외교부/서식/2019/0325.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/서식/2019/0325.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001322",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 326,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/서식/2019/0326.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/서식/2019/0326.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/기획재정부/서식/2019/0326.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/서식/2019/0326.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/서식/2019/0326.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/서식/2019/0326.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/기획재정부/서식/2019/0326.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기획재정부/서식/2019/0326.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2019/0326.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/서식/2019/0326.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/서식/2019/0326.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001323",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 327,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/서식/2019/0327.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2019/0327.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/공정거래위원회/서식/2019/0327.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/공정거래위원회/서식/2019/0327.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/서식/2019/0327.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2019/0327.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/공정거래위원회/서식/2019/0327.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2019/0327.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2019/0327.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/서식/2019/0327.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2019/0327.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001324",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 328,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/서식/2019/0328.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/서식/2019/0328.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/금융위원회/서식/2019/0328.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/서식/2019/0328.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/서식/2019/0328.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/서식/2019/0328.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/금융위원회/서식/2019/0328.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/서식/2019/0328.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2019/0328.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/서식/2019/0328.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/서식/2019/0328.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001325",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 329,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/서식/2019/0329.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2019/0329.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/방송통신위원회/서식/2019/0329.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/방송통신위원회/서식/2019/0329.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/서식/2019/0329.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2019/0329.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/방송통신위원회/서식/2019/0329.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2019/0329.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2019/0329.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/서식/2019/0329.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2019/0329.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001326",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 330,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/서식/2019/0330.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2019/0330.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/개인정보보호위원회/서식/2019/0330.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2019/0330.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/서식/2019/0330.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2019/0330.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/개인정보보호위원회/서식/2019/0330.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2019/0330.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2019/0330.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/서식/2019/0330.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2019/0330.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001327",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 331,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/서식/2019/0331.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/서식/2019/0331.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/국민권익위원회/서식/2019/0331.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/서식/2019/0331.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/서식/2019/0331.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/서식/2019/0331.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/서식/2019/0331.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/서식/2019/0331.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2019/0331.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/서식/2019/0331.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/서식/2019/0331.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001328",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 332,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/서식/2019/0332.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2019/0332.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/국가인권위원회/서식/2019/0332.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2019/0332.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/서식/2019/0332.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2019/0332.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/서식/2019/0332.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2019/0332.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2019/0332.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/서식/2019/0332.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2019/0332.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001329",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/서식/2019/0333.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 333,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2019/0333.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/통계청/서식/2019/0333.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/통계청/서식/2019/0333.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2019/0333.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/통계청/서식/2019/0333.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/통계청/서식/2019/0333.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2019/0333.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/통계청/서식/2019/0333.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/통계청/서식/2019/0333.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2019/0333.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/통계청/서식/2019/0333.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/통계청/서식/2019/0333.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2019/0333.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/서식/2019/0333.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/통계청/서식/2019/0333.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001330",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/서식/2019/0334.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 334,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2019/0334.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/기상청/서식/2019/0334.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/서식/2019/0334.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2019/0334.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/기상청/서식/2019/0334.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/서식/2019/0334.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2019/0334.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/기상청/서식/2019/0334.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/서식/2019/0334.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2019/0334.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/기상청/서식/2019/0334.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/서식/2019/0334.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2019/0334.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기상청/서식/2019/0334.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/기상청/서식/2019/0334.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001331",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/서식/2019/0335.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 335,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2019/0335.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 5,
+          "csv": "samples/gov/관세청/서식/2019/0335.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/서식/2019/0335.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001332",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/서식/2019/0336.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 336,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2019/0336.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/서식/2019/0336.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/검찰청/서식/2019/0336.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001333",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/서식/2019/0337.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 337,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2019/0337.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/서식/2019/0337.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/서식/2019/0337.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001334",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/서식/2019/0338.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 338,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2019/0338.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/소방청/서식/2019/0338.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/서식/2019/0338.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001335",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 339,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2019/0339.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/서식/2019/0339.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2019/0339.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001336",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/서식/2019/0340.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 340,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2019/0340.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/병무청/서식/2019/0340.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/병무청/서식/2019/0340.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001337",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/서식/2019/0341.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 341,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2019/0341.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/산림청/서식/2019/0341.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/서식/2019/0341.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001338",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 342,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2019/0342.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/서식/2019/0342.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2019/0342.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001339",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 343,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2019/0343.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/중소벤처기업부/서식/2019/0343.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2019/0343.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001340",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 344,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2019/0344.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/과학기술정보통신부/서식/2019/0344.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/서식/2019/0344.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001341",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 345,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2019/0345.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 3,
+          "csv": "samples/gov/문화체육관광부/서식/2019/0345.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2019/0345.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001342",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/서식/2019/0346.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 346,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2019/0346.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/환경부/서식/2019/0346.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/환경부/서식/2019/0346.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001343",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "서식",
+    "year": 2019,
+    "serial": 347,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2019/0347.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/해양수산부/서식/2019/0347.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양수산부/서식/2019/0347.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001344",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/질의회신/2019/0348.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 348,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2019/0348.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 6,
+          "csv": "samples/gov/법제처/질의회신/2019/0348.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/법제처/질의회신/2019/0348.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0021.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0021.json
@@ -1,0 +1,14798 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001345",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 349,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/질의회신/2019/0349.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/행정안전부/질의회신/2019/0349.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/행정안전부/질의회신/2019/0349.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001346",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 350,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/질의회신/2019/0350.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국세청/질의회신/2019/0350.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/국세청/질의회신/2019/0350.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001347",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/질의회신/2019/0351.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 351,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/질의회신/2019/0351.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/대법원/질의회신/2019/0351.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/대법원/질의회신/2019/0351.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001348",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 352,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/질의회신/2019/0352.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/특허청/질의회신/2019/0352.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/특허청/질의회신/2019/0352.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001349",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 353,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/질의회신/2019/0353.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/교육부/질의회신/2019/0353.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/교육부/질의회신/2019/0353.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001350",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 354,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/질의회신/2019/0354.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/보건복지부/질의회신/2019/0354.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/보건복지부/질의회신/2019/0354.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001351",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 355,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/질의회신/2019/0355.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/국토교통부/질의회신/2019/0355.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/국토교통부/질의회신/2019/0355.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001352",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 356,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/질의회신/2019/0356.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/고용노동부/질의회신/2019/0356.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/고용노동부/질의회신/2019/0356.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001353",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/질의회신/2019/0357.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 357,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/질의회신/2019/0357.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/외교부/질의회신/2019/0357.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/외교부/질의회신/2019/0357.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001354",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 358,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/질의회신/2019/0358.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/기획재정부/질의회신/2019/0358.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/기획재정부/질의회신/2019/0358.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001355",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 359,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/질의회신/2019/0359.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/공정거래위원회/질의회신/2019/0359.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/질의회신/2019/0359.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001356",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 360,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 13
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 13
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/질의회신/2019/0360.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/금융위원회/질의회신/2019/0360.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/금융위원회/질의회신/2019/0360.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001357",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 361,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/질의회신/2019/0361.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/방송통신위원회/질의회신/2019/0361.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/방송통신위원회/질의회신/2019/0361.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001358",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 362,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/질의회신/2019/0362.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/개인정보보호위원회/질의회신/2019/0362.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/질의회신/2019/0362.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001359",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 363,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/질의회신/2019/0363.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/국민권익위원회/질의회신/2019/0363.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/질의회신/2019/0363.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001360",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 364,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/질의회신/2019/0364.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/국가인권위원회/질의회신/2019/0364.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/국가인권위원회/질의회신/2019/0364.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001361",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 365,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            }
+          ],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/질의회신/2019/0365.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/통계청/질의회신/2019/0365.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            }
+          ],
+          "output": "out/v-bon/통계청/질의회신/2019/0365.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001362",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/질의회신/2019/0366.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 366,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/질의회신/2019/0366.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/기상청/질의회신/2019/0366.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/기상청/질의회신/2019/0366.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001363",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 367,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 2,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 3,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/질의회신/2019/0367.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/관세청/질의회신/2019/0367.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/관세청/질의회신/2019/0367.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001364",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 368,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/질의회신/2019/0368.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 4,
+          "csv": "samples/gov/검찰청/질의회신/2019/0368.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/검찰청/질의회신/2019/0368.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001365",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 369,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/질의회신/2019/0369.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/경찰청/질의회신/2019/0369.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            }
+          ],
+          "output": "out/v-bon/경찰청/질의회신/2019/0369.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001366",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 370,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 1,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/질의회신/2019/0370.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/소방청/질의회신/2019/0370.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/소방청/질의회신/2019/0370.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001367",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 371,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 5,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/질의회신/2019/0371.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 1,
+          "csv": "samples/gov/해양경찰청/질의회신/2019/0371.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/해양경찰청/질의회신/2019/0371.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001368",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/질의회신/2019/0372.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 372,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/질의회신/2019/0372.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/병무청/질의회신/2019/0372.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/병무청/질의회신/2019/0372.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001369",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 373,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "chart": 2,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 12
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 1,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 12
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/질의회신/2019/0373.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/산림청/질의회신/2019/0373.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/산림청/질의회신/2019/0373.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001370",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 374,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 6,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "chart": 1,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "chart": 2,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "chart": 3,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/질의회신/2019/0374.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "chart": 4,
+          "csv": "samples/gov/농촌진흥청/질의회신/2019/0374.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/농촌진흥청/질의회신/2019/0374.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001371",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 375,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 1.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 2.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 3.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 6.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 2,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 4,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/질의회신/2019/0375.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 5,
+          "csv": "samples/gov/중소벤처기업부/질의회신/2019/0375.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/질의회신/2019/0375.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001372",
+    "command": "csv-to-chart",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "csv-to-chart",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 376,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 1,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 23
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "chart": 2,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 23
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 3,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 4.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 5.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 6.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 7.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 8.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 9.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 4,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 2.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 3.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 4.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 5.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 6.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 7.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 5,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 0.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 1.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 2.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 5.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/질의회신/2019/0376.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "chart": 6,
+          "csv": "samples/gov/과학기술정보통신부/질의회신/2019/0376.chart.csv",
+          "changed": [
+            {
+              "series": 1,
+              "point": 0,
+              "from": 0.0,
+              "to": 3.0
+            },
+            {
+              "series": 2,
+              "point": 1,
+              "from": 1.0,
+              "to": 4.0
+            },
+            {
+              "series": 3,
+              "point": 2,
+              "from": 2.0,
+              "to": 5.0
+            },
+            {
+              "series": 1,
+              "point": 3,
+              "from": 3.0,
+              "to": 6.0
+            },
+            {
+              "series": 2,
+              "point": 4,
+              "from": 4.0,
+              "to": 7.0
+            },
+            {
+              "series": 3,
+              "point": 5,
+              "from": 5.0,
+              "to": 8.0
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/질의회신/2019/0376.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001373",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/질의회신/2019/0377.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 377,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2019/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/질의회신/2019/0377.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001374",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/질의회신/2019/0378.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 378,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2019/0378.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/질의회신/2019/0378.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001375",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/질의회신/2019/0379.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "질의회신",
+    "year": 2019,
+    "serial": 379,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2019/0379.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/질의회신/2019/0379.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001376",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/업무계획/2019/0380.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 380,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2019/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/업무계획/2019/0380.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001377",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/업무계획/2019/0381.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 381,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2019/0381.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/업무계획/2019/0381.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001378",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/업무계획/2019/0382.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 382,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2019/0382.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/업무계획/2019/0382.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001379",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/업무계획/2019/0383.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 383,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2019/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/업무계획/2019/0383.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001380",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/업무계획/2019/0384.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 384,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2019/0384.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/업무계획/2019/0384.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001381",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/업무계획/2019/0385.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 385,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2019/0385.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/업무계획/2019/0385.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001382",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/업무계획/2019/0386.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 386,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2019/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/업무계획/2019/0386.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001383",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/업무계획/2019/0387.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 387,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2019/0387.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/업무계획/2019/0387.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001384",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/업무계획/2019/0388.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 388,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2019/0388.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/업무계획/2019/0388.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001385",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/업무계획/2019/0389.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 389,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2019/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/업무계획/2019/0389.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001386",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/업무계획/2019/0390.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 390,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2019/0390.hwp",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/업무계획/2019/0390.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001387",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/업무계획/2019/0391.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 391,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2019/0391.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2019/0391.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/업무계획/2019/0391.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001388",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/업무계획/2019/0392.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 392,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2019/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2019/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/업무계획/2019/0392.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001389",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/업무계획/2019/0393.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 393,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2019/0393.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2019/0393.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/업무계획/2019/0393.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001390",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/업무계획/2019/0394.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 394,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2019/0394.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2019/0394.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/업무계획/2019/0394.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001391",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/업무계획/2019/0395.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 395,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2019/0395.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2019/0395.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/업무계획/2019/0395.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001392",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/업무계획/2019/0396.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 396,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2019/0396.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2019/0396.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/업무계획/2019/0396.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001393",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/업무계획/2019/0397.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 397,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2019/0397.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2019/0397.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/업무계획/2019/0397.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001394",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/업무계획/2019/0398.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 398,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2019/0398.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2019/0398.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/업무계획/2019/0398.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001395",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/업무계획/2019/0399.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 399,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2019/0399.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2019/0399.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/업무계획/2019/0399.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001396",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/업무계획/2019/0400.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 400,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2019/0400.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2019/0400.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/업무계획/2019/0400.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001397",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/업무계획/2019/0401.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 401,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2019/0401.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2019/0401.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/업무계획/2019/0401.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001398",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/업무계획/2019/0402.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 402,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2019/0402.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2019/0402.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/업무계획/2019/0402.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001399",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/업무계획/2019/0403.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 403,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2019/0403.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2019/0403.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/업무계획/2019/0403.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001400",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/업무계획/2019/0404.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 404,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2019/0404.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2019/0404.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/업무계획/2019/0404.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001401",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/업무계획/2019/0405.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 405,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2019/0405.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2019/0405.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2019/0405.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/업무계획/2019/0405.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001402",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/업무계획/2019/0406.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 406,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2019/0406.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2019/0406.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2019/0406.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/업무계획/2019/0406.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001403",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/업무계획/2019/0407.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 407,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2019/0407.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2019/0407.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2019/0407.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/업무계획/2019/0407.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001404",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/업무계획/2019/0408.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 408,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2019/0408.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2019/0408.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2019/0408.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/업무계획/2019/0408.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001405",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/업무계획/2019/0409.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 409,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2019/0409.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2019/0409.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2019/0409.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/업무계획/2019/0409.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001406",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/업무계획/2019/0410.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 410,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2019/0410.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2019/0410.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2019/0410.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/업무계획/2019/0410.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001407",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/업무계획/2019/0411.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "업무계획",
+    "year": 2019,
+    "serial": 411,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2019/0411.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2019/0411.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2019/0411.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/업무계획/2019/0411.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001408",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/예산서/2019/0412.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 412,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2019/0412.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2019/0412.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2019/0412.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예산서/2019/0412.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0022.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0022.json
@@ -1,0 +1,11684 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001409",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/예산서/2019/0413.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 413,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2019/0413.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2019/0413.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2019/0413.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예산서/2019/0413.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001410",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/예산서/2019/0414.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 414,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2019/0414.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2019/0414.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2019/0414.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예산서/2019/0414.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001411",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/예산서/2019/0415.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 415,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2019/0415.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2019/0415.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2019/0415.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예산서/2019/0415.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001412",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/예산서/2019/0416.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 416,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2019/0416.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2019/0416.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2019/0416.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예산서/2019/0416.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001413",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/예산서/2019/0417.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 417,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2019/0417.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2019/0417.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2019/0417.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예산서/2019/0417.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001414",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/예산서/2019/0418.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 418,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2019/0418.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2019/0418.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2019/0418.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예산서/2019/0418.hwpx",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 27,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001415",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 419,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예산서/2019/0419.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001416",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 420,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예산서/2019/0420.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001417",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/예산서/2019/0421.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 421,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2019/0421.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2019/0421.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2019/0421.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2019/0421.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예산서/2019/0421.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001418",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 422,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예산서/2019/0422.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001419",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 423,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예산서/2019/0423.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001420",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 424,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예산서/2019/0424.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001421",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 425,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예산서/2019/0425.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001422",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 426,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예산서/2019/0426.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001423",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 427,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예산서/2019/0427.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001424",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 428,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예산서/2019/0428.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001425",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/예산서/2019/0429.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 429,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2019/0429.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2019/0429.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2019/0429.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2019/0429.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예산서/2019/0429.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001426",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/예산서/2019/0430.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 430,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2019/0430.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2019/0430.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2019/0430.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2019/0430.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예산서/2019/0430.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001427",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/예산서/2019/0431.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 431,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2019/0431.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2019/0431.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2019/0431.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2019/0431.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예산서/2019/0431.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001428",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/예산서/2019/0432.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 432,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2019/0432.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2019/0432.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2019/0432.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2019/0432.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예산서/2019/0432.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001429",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 433,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예산서/2019/0433.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001430",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/예산서/2019/0434.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 434,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예산서/2019/0434.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001431",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 435,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예산서/2019/0435.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001432",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/예산서/2019/0436.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 436,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예산서/2019/0436.hwpx",
+          "dryRun": true,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001433",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/예산서/2019/0437.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 437,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예산서/2019/0437.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001434",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 438,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예산서/2019/0438.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001435",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 439,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예산서/2019/0439.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001436",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 440,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예산서/2019/0440.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001437",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 441,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c5",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예산서/2019/0441.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001438",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/예산서/2019/0442.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 442,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예산서/2019/0442.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001439",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예산서",
+    "year": 2019,
+    "serial": 443,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예산서/2019/0443.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001440",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/회의록/2019/0444.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 444,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/회의록/2019/0444.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001441",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 445,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/회의록/2019/0445.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001442",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/회의록/2019/0446.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 446,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/회의록/2019/0446.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001443",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/회의록/2019/0447.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 447,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/회의록/2019/0447.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001444",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/회의록/2019/0448.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 448,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/회의록/2019/0448.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001445",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/회의록/2019/0449.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 449,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/회의록/2019/0449.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001446",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 450,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/회의록/2019/0450.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001447",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 451,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/회의록/2019/0451.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001448",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 452,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/회의록/2019/0452.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001449",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/회의록/2019/0453.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 453,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/회의록/2019/0453.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001450",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 454,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/회의록/2019/0454.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001451",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 455,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/회의록/2019/0455.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001452",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 456,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/회의록/2019/0456.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001453",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 457,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/회의록/2019/0457.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001454",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 458,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/회의록/2019/0458.hwpx",
+          "dryRun": true,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001455",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 459,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/회의록/2019/0459.hwp",
+          "dryRun": true,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001456",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 460,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/회의록/2019/0460.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001457",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/회의록/2019/0461.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 461,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/회의록/2019/0461.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001458",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/회의록/2019/0462.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 462,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/회의록/2019/0462.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001459",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/회의록/2019/0463.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 463,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/회의록/2019/0463.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001460",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 464,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/회의록/2019/0464.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001461",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/회의록/2019/0465.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 465,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/회의록/2019/0465.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001462",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/회의록/2019/0466.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 466,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/회의록/2019/0466.hwpx",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001463",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 467,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_7",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_exact",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_4",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/회의록/2019/0467.hwpx",
+          "dryRun": true,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001464",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/회의록/2019/0468.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 468,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_exact",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_4",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/회의록/2019/0468.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001465",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/회의록/2019/0469.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 469,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_over_4",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/회의록/2019/0469.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001466",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 470,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/회의록/2019/0470.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001467",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 471,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_zero",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/회의록/2019/0471.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001468",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 472,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c7",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_usage",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 8,
+            "actual": 5
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 8,
+              "actual": 5
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_7",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/회의록/2019/0472.hwpx",
+          "dryRun": true,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001469",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 473,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "문서번호"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "문서번호"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 3,
+            "col": 2
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 3,
+              "col": 2
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_7",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_exact",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/회의록/2019/0473.hwpx",
+          "dryRun": true,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001470",
+    "command": "sanitize",
+    "mode": "dry-run",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--dry-run",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/회의록/2019/0474.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 474,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "dry_invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 0,
+            "col": 4
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 0,
+              "col": 4
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "dry_invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "dry_page",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "dry_over_7",
+        "changedCount": 27,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 27,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 27,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "dry_exact",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "dry_over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "dry_over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "dry_over_4",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/회의록/2019/0474.hwp",
+          "dryRun": true,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001471",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/회의록/2019/0475.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "회의록",
+    "year": 2019,
+    "serial": 475,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2019/0475.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/회의록/2019/0475.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/회의록/2019/0475.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/해양수산부/회의록/2019/0475.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001472",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/계약서/2019/0476.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 476,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2019/0476.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/계약서/2019/0476.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/계약서/2019/0476.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/계약서/2019/0476.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0023.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0023.json
@@ -1,0 +1,9692 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001473",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/계약서/2019/0477.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 477,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2019/0477.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/행정안전부/계약서/2019/0477.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/계약서/2019/0477.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/행정안전부/계약서/2019/0477.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001474",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/계약서/2019/0478.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 478,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2019/0478.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국세청/계약서/2019/0478.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/계약서/2019/0478.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국세청/계약서/2019/0478.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001475",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/계약서/2019/0479.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 479,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2019/0479.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/계약서/2019/0479.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/계약서/2019/0479.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/계약서/2019/0479.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001476",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/계약서/2019/0480.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 480,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2019/0480.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/특허청/계약서/2019/0480.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/계약서/2019/0480.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/특허청/계약서/2019/0480.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001477",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/계약서/2019/0481.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 481,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2019/0481.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/교육부/계약서/2019/0481.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/계약서/2019/0481.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/교육부/계약서/2019/0481.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001478",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/계약서/2019/0482.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 482,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2019/0482.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/계약서/2019/0482.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/계약서/2019/0482.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/계약서/2019/0482.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001479",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/계약서/2019/0483.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 483,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2019/0483.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/계약서/2019/0483.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/계약서/2019/0483.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국토교통부/계약서/2019/0483.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001480",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/계약서/2019/0484.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 484,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2019/0484.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/계약서/2019/0484.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/계약서/2019/0484.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/계약서/2019/0484.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001481",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/계약서/2019/0485.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 485,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2019/0485.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/외교부/계약서/2019/0485.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/계약서/2019/0485.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/계약서/2019/0485.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001482",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/계약서/2019/0486.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 486,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2019/0486.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/계약서/2019/0486.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/계약서/2019/0486.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/계약서/2019/0486.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001483",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/계약서/2019/0487.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 487,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2019/0487.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/공정거래위원회/계약서/2019/0487.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/계약서/2019/0487.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/공정거래위원회/계약서/2019/0487.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001484",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/계약서/2019/0488.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 488,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2019/0488.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/계약서/2019/0488.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/계약서/2019/0488.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/계약서/2019/0488.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001485",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/계약서/2019/0489.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 489,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2019/0489.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/방송통신위원회/계약서/2019/0489.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2019/0489.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/계약서/2019/0489.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/계약서/2019/0489.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/계약서/2019/0489.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001486",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/계약서/2019/0490.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 490,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2019/0490.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/개인정보보호위원회/계약서/2019/0490.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2019/0490.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/개인정보보호위원회/계약서/2019/0490.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/계약서/2019/0490.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/개인정보보호위원회/계약서/2019/0490.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001487",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/계약서/2019/0491.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 491,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2019/0491.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국민권익위원회/계약서/2019/0491.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2019/0491.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/국민권익위원회/계약서/2019/0491.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/계약서/2019/0491.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/국민권익위원회/계약서/2019/0491.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001488",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/계약서/2019/0492.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 492,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2019/0492.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/계약서/2019/0492.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2019/0492.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/계약서/2019/0492.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/계약서/2019/0492.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/국가인권위원회/계약서/2019/0492.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001489",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/계약서/2019/0493.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 493,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2019/0493.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/통계청/계약서/2019/0493.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2019/0493.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/통계청/계약서/2019/0493.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/계약서/2019/0493.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/계약서/2019/0493.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001490",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/계약서/2019/0494.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 494,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2019/0494.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/계약서/2019/0494.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2019/0494.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/계약서/2019/0494.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/계약서/2019/0494.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/계약서/2019/0494.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001491",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/계약서/2019/0495.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 495,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2019/0495.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/계약서/2019/0495.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2019/0495.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/계약서/2019/0495.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/계약서/2019/0495.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/계약서/2019/0495.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001492",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/계약서/2019/0496.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 496,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2019/0496.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/계약서/2019/0496.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2019/0496.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/검찰청/계약서/2019/0496.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/계약서/2019/0496.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/계약서/2019/0496.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001493",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/계약서/2019/0497.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 497,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2019/0497.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/계약서/2019/0497.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2019/0497.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/계약서/2019/0497.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/계약서/2019/0497.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/계약서/2019/0497.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001494",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/계약서/2019/0498.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 498,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2019/0498.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/계약서/2019/0498.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2019/0498.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/계약서/2019/0498.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/계약서/2019/0498.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/계약서/2019/0498.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001495",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/계약서/2019/0499.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 499,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2019/0499.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/계약서/2019/0499.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2019/0499.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/계약서/2019/0499.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/계약서/2019/0499.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/계약서/2019/0499.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001496",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/계약서/2019/0500.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 500,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2019/0500.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/계약서/2019/0500.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2019/0500.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/계약서/2019/0500.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/계약서/2019/0500.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/계약서/2019/0500.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001497",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/계약서/2019/0501.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 501,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2019/0501.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/산림청/계약서/2019/0501.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2019/0501.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/산림청/계약서/2019/0501.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/계약서/2019/0501.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/산림청/계약서/2019/0501.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001498",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/계약서/2019/0502.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 502,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2019/0502.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/계약서/2019/0502.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2019/0502.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/계약서/2019/0502.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/계약서/2019/0502.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 25,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/계약서/2019/0502.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001499",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/계약서/2019/0503.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 503,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2019/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/계약서/2019/0503.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2019/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/계약서/2019/0503.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2019/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/계약서/2019/0503.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/계약서/2019/0503.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/계약서/2019/0503.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001500",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/계약서/2019/0504.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 504,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2019/0504.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/계약서/2019/0504.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2019/0504.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/계약서/2019/0504.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2019/0504.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/계약서/2019/0504.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/계약서/2019/0504.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/계약서/2019/0504.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001501",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/계약서/2019/0505.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 505,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2019/0505.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/계약서/2019/0505.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2019/0505.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/계약서/2019/0505.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2019/0505.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/문화체육관광부/계약서/2019/0505.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/계약서/2019/0505.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/문화체육관광부/계약서/2019/0505.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001502",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/계약서/2019/0506.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 506,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2019/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/환경부/계약서/2019/0506.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2019/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/환경부/계약서/2019/0506.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2019/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/계약서/2019/0506.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/계약서/2019/0506.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/환경부/계약서/2019/0506.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001503",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/계약서/2019/0507.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "계약서",
+    "year": 2019,
+    "serial": 507,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2019/0507.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/계약서/2019/0507.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2019/0507.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/계약서/2019/0507.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2019/0507.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/계약서/2019/0507.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/계약서/2019/0507.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/계약서/2019/0507.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001504",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/점검표/2019/0508.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 508,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2019/0508.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/점검표/2019/0508.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2019/0508.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/점검표/2019/0508.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2019/0508.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/법제처/점검표/2019/0508.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/점검표/2019/0508.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/점검표/2019/0508.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001505",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/행정안전부/점검표/2019/0509.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 509,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2019/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/점검표/2019/0509.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2019/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/행정안전부/점검표/2019/0509.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2019/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/점검표/2019/0509.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/점검표/2019/0509.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/점검표/2019/0509.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001506",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국세청/점검표/2019/0510.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 510,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2019/0510.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국세청/점검표/2019/0510.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2019/0510.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/점검표/2019/0510.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2019/0510.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/점검표/2019/0510.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/점검표/2019/0510.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/점검표/2019/0510.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001507",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/대법원/점검표/2019/0511.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 511,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2019/0511.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/점검표/2019/0511.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2019/0511.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/대법원/점검표/2019/0511.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2019/0511.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/점검표/2019/0511.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/점검표/2019/0511.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/점검표/2019/0511.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001508",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/특허청/점검표/2019/0512.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 512,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2019/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/점검표/2019/0512.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2019/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/점검표/2019/0512.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2019/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/점검표/2019/0512.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/점검표/2019/0512.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/점검표/2019/0512.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001509",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/교육부/점검표/2019/0513.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 513,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2019/0513.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/점검표/2019/0513.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2019/0513.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/점검표/2019/0513.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2019/0513.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/점검표/2019/0513.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/점검표/2019/0513.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/점검표/2019/0513.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001510",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/보건복지부/점검표/2019/0514.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 514,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2019/0514.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/점검표/2019/0514.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2019/0514.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/점검표/2019/0514.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2019/0514.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/점검표/2019/0514.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/점검표/2019/0514.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/점검표/2019/0514.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001511",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국토교통부/점검표/2019/0515.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 515,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2019/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/점검표/2019/0515.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2019/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/점검표/2019/0515.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2019/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/점검표/2019/0515.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/점검표/2019/0515.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/점검표/2019/0515.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001512",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/고용노동부/점검표/2019/0516.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 516,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2019/0516.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/점검표/2019/0516.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2019/0516.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/점검표/2019/0516.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2019/0516.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/점검표/2019/0516.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/점검표/2019/0516.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/점검표/2019/0516.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001513",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/외교부/점검표/2019/0517.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 517,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2019/0517.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/외교부/점검표/2019/0517.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2019/0517.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/점검표/2019/0517.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2019/0517.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/점검표/2019/0517.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2019/0517.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/점검표/2019/0517.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/점검표/2019/0517.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/외교부/점검표/2019/0517.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001514",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 518,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/점검표/2019/0518.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/점검표/2019/0518.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기획재정부/점검표/2019/0518.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기획재정부/점검표/2019/0518.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/점검표/2019/0518.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기획재정부/점검표/2019/0518.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001515",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 519,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/공정거래위원회/점검표/2019/0519.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/공정거래위원회/점검표/2019/0519.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/공정거래위원회/점검표/2019/0519.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/공정거래위원회/점검표/2019/0519.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/점검표/2019/0519.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/공정거래위원회/점검표/2019/0519.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001516",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 520,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/점검표/2019/0520.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/점검표/2019/0520.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/점검표/2019/0520.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/점검표/2019/0520.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/점검표/2019/0520.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/점검표/2019/0520.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001517",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 521,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/점검표/2019/0521.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/방송통신위원회/점검표/2019/0521.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/방송통신위원회/점검표/2019/0521.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/방송통신위원회/점검표/2019/0521.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/점검표/2019/0521.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/점검표/2019/0521.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001518",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 522,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/점검표/2019/0522.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/개인정보보호위원회/점검표/2019/0522.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/점검표/2019/0522.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/점검표/2019/0522.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/점검표/2019/0522.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/점검표/2019/0522.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001519",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 523,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국민권익위원회/점검표/2019/0523.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/점검표/2019/0523.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/점검표/2019/0523.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/점검표/2019/0523.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/점검표/2019/0523.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/점검표/2019/0523.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001520",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 524,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/점검표/2019/0524.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국가인권위원회/점검표/2019/0524.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/점검표/2019/0524.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/점검표/2019/0524.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/점검표/2019/0524.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/점검표/2019/0524.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001521",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/통계청/점검표/2019/0525.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 525,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2019/0525.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/점검표/2019/0525.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2019/0525.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/점검표/2019/0525.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2019/0525.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/점검표/2019/0525.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2019/0525.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/점검표/2019/0525.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/점검표/2019/0525.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/점검표/2019/0525.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001522",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기상청/점검표/2019/0526.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 526,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2019/0526.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/점검표/2019/0526.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2019/0526.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/점검표/2019/0526.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2019/0526.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/점검표/2019/0526.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2019/0526.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/점검표/2019/0526.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/점검표/2019/0526.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/점검표/2019/0526.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001523",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/관세청/점검표/2019/0527.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 527,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2019/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/점검표/2019/0527.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2019/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/점검표/2019/0527.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2019/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/점검표/2019/0527.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2019/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/점검표/2019/0527.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/점검표/2019/0527.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/점검표/2019/0527.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001524",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/검찰청/점검표/2019/0528.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 528,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2019/0528.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/점검표/2019/0528.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2019/0528.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/점검표/2019/0528.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2019/0528.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/점검표/2019/0528.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2019/0528.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/점검표/2019/0528.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/점검표/2019/0528.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/점검표/2019/0528.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001525",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 529,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/점검표/2019/0529.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/점검표/2019/0529.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/점검표/2019/0529.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/점검표/2019/0529.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/점검표/2019/0529.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/점검표/2019/0529.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001526",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/소방청/점검표/2019/0530.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 530,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2019/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 28,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/점검표/2019/0530.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2019/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/점검표/2019/0530.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2019/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/점검표/2019/0530.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2019/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/점검표/2019/0530.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/점검표/2019/0530.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/점검표/2019/0530.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001527",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 531,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/점검표/2019/0531.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양경찰청/점검표/2019/0531.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001528",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/병무청/점검표/2019/0532.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 532,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/점검표/2019/0532.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/병무청/점검표/2019/0532.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001529",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/산림청/점검표/2019/0533.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 533,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/점검표/2019/0533.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/점검표/2019/0533.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001530",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 534,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/점검표/2019/0534.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/점검표/2019/0534.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001531",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 535,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/점검표/2019/0535.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/점검표/2019/0535.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001532",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 536,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/점검표/2019/0536.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/점검표/2019/0536.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001533",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 537,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/점검표/2019/0537.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/점검표/2019/0537.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001534",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/환경부/점검표/2019/0538.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 538,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/점검표/2019/0538.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/점검표/2019/0538.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001535",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "점검표",
+    "year": 2019,
+    "serial": 539,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/점검표/2019/0539.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/점검표/2019/0539.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001536",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/법제처/고시/2020/0540.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 540,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/고시/2020/0540.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/고시/2020/0540.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0024.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0024.json
@@ -1,0 +1,12367 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001537",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 541,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/고시/2020/0541.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/행정안전부/고시/2020/0541.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001538",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국세청/고시/2020/0542.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 542,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 15
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/고시/2020/0542.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국세청/고시/2020/0542.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 15
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001539",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/대법원/고시/2020/0543.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 543,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/고시/2020/0543.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/대법원/고시/2020/0543.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001540",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/특허청/고시/2020/0544.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 544,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 25,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 28,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/고시/2020/0544.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/특허청/고시/2020/0544.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001541",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/교육부/고시/2020/0545.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 545,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/고시/2020/0545.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/교육부/고시/2020/0545.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001542",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/보건복지부/고시/2020/0546.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 546,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/고시/2020/0546.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/보건복지부/고시/2020/0546.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001543",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 547,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/고시/2020/0547.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국토교통부/고시/2020/0547.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001544",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 548,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/고시/2020/0548.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/고용노동부/고시/2020/0548.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001545",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/외교부/고시/2020/0549.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 549,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/고시/2020/0549.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/외교부/고시/2020/0549.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001546",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 550,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/고시/2020/0550.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기획재정부/고시/2020/0550.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001547",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 551,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/고시/2020/0551.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/공정거래위원회/고시/2020/0551.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001548",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/금융위원회/고시/2020/0552.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 552,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/고시/2020/0552.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/금융위원회/고시/2020/0552.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001549",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 553,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/고시/2020/0553.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/방송통신위원회/고시/2020/0553.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001550",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 554,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/고시/2020/0554.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/개인정보보호위원회/고시/2020/0554.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001551",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 555,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/고시/2020/0555.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국민권익위원회/고시/2020/0555.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001552",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 556,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/고시/2020/0556.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/국가인권위원회/고시/2020/0556.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001553",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/통계청/고시/2020/0557.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 557,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 24,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/고시/2020/0557.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/통계청/고시/2020/0557.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001554",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기상청/고시/2020/0558.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 558,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 21
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 21
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 21,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/고시/2020/0558.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 22,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/기상청/고시/2020/0558.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001555",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/관세청/고시/2020/0559.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 559,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/고시/2020/0559.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/관세청/고시/2020/0559.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001556",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/검찰청/고시/2020/0560.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 560,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/고시/2020/0560.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/검찰청/고시/2020/0560.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001557",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/경찰청/고시/2020/0561.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 561,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 2,
+          "removed": [
+            "meta:author",
+            "meta:company"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/고시/2020/0561.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/경찰청/고시/2020/0561.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001558",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/소방청/고시/2020/0562.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 562,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/고시/2020/0562.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/소방청/고시/2020/0562.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001559",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 563,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 1,
+          "removed": [
+            "meta:author"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/고시/2020/0563.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양경찰청/고시/2020/0563.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001560",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/병무청/고시/2020/0564.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 564,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 8,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 4,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/고시/2020/0564.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 3,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/병무청/고시/2020/0564.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001561",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/산림청/고시/2020/0565.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 565,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/고시/2020/0565.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/산림청/고시/2020/0565.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001562",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 566,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 15,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/고시/2020/0566.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/농촌진흥청/고시/2020/0566.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001563",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 567,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 7,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 6,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 5,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/고시/2020/0567.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/중소벤처기업부/고시/2020/0567.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001564",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 568,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/고시/2020/0568.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/과학기술정보통신부/고시/2020/0568.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001565",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 569,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 13,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/고시/2020/0569.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/문화체육관광부/고시/2020/0569.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001566",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/환경부/고시/2020/0570.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 570,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 11,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 10,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 9,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 12,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/고시/2020/0570.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 14,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/환경부/고시/2020/0570.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001567",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "고시",
+    "year": 2020,
+    "serial": 571,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 18
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 18
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 16,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 17,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 18,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/고시/2020/0571.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "removedCount": 19,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/해양수산부/고시/2020/0571.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001568",
+    "command": "sanitize",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "sanitize",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/법제처/훈령/2020/0572.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 572,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 20,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "removedCount": 23,
+          "removed": [
+            "meta:author",
+            "meta:company",
+            "meta:date"
+          ],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/훈령/2020/0572.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "removedCount": 0,
+          "removed": [],
+          "output": "out/v-bon/법제처/훈령/2020/0572.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001569",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/행정안전부/훈령/2020/0573.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 573,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2020/0573.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2020/0573.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/훈령/2020/0573.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/훈령/2020/0573.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001570",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국세청/훈령/2020/0574.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 574,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2020/0574.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/훈령/2020/0574.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/훈령/2020/0574.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/훈령/2020/0574.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001571",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/대법원/훈령/2020/0575.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 575,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2020/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/훈령/2020/0575.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/훈령/2020/0575.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/훈령/2020/0575.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001572",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/특허청/훈령/2020/0576.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 576,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2020/0576.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/훈령/2020/0576.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/훈령/2020/0576.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/훈령/2020/0576.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001573",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/교육부/훈령/2020/0577.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 577,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2020/0577.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/훈령/2020/0577.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/훈령/2020/0577.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/훈령/2020/0577.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001574",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/보건복지부/훈령/2020/0578.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 578,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2020/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2020/0578.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/훈령/2020/0578.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/훈령/2020/0578.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001575",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/국토교통부/훈령/2020/0579.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 579,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2020/0579.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2020/0579.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/훈령/2020/0579.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/훈령/2020/0579.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001576",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/고용노동부/훈령/2020/0580.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 580,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2020/0580.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2020/0580.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/훈령/2020/0580.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/훈령/2020/0580.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001577",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/외교부/훈령/2020/0581.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 581,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2020/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/훈령/2020/0581.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/훈령/2020/0581.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/훈령/2020/0581.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001578",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/기획재정부/훈령/2020/0582.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 582,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2020/0582.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2020/0582.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/훈령/2020/0582.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/훈령/2020/0582.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001579",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/공정거래위원회/훈령/2020/0583.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 583,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2020/0583.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2020/0583.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/훈령/2020/0583.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/훈령/2020/0583.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001580",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/금융위원회/훈령/2020/0584.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 584,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2020/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2020/0584.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/훈령/2020/0584.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/훈령/2020/0584.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001581",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/방송통신위원회/훈령/2020/0585.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 585,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2020/0585.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2020/0585.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/훈령/2020/0585.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/훈령/2020/0585.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001582",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/개인정보보호위원회/훈령/2020/0586.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 586,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2020/0586.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 19,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2020/0586.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/훈령/2020/0586.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 18,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/훈령/2020/0586.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001583",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국민권익위원회/훈령/2020/0587.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 587,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2020/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2020/0587.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2020/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2020/0587.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/훈령/2020/0587.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/훈령/2020/0587.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001584",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/국가인권위원회/훈령/2020/0588.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 588,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2020/0588.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2020/0588.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2020/0588.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2020/0588.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/훈령/2020/0588.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/훈령/2020/0588.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001585",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/통계청/훈령/2020/0589.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 589,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2020/0589.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/훈령/2020/0589.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2020/0589.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/훈령/2020/0589.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/훈령/2020/0589.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/훈령/2020/0589.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001586",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기상청/훈령/2020/0590.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 590,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2020/0590.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/훈령/2020/0590.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2020/0590.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/훈령/2020/0590.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/훈령/2020/0590.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/훈령/2020/0590.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001587",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/관세청/훈령/2020/0591.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 591,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2020/0591.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/훈령/2020/0591.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2020/0591.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/훈령/2020/0591.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/훈령/2020/0591.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/훈령/2020/0591.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001588",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/검찰청/훈령/2020/0592.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 592,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2020/0592.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/훈령/2020/0592.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2020/0592.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/훈령/2020/0592.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/훈령/2020/0592.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/훈령/2020/0592.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001589",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/경찰청/훈령/2020/0593.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 593,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2020/0593.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/훈령/2020/0593.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2020/0593.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/훈령/2020/0593.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/훈령/2020/0593.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/훈령/2020/0593.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001590",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/소방청/훈령/2020/0594.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 594,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2020/0594.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/훈령/2020/0594.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2020/0594.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/훈령/2020/0594.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/훈령/2020/0594.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/훈령/2020/0594.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001591",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/해양경찰청/훈령/2020/0595.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 595,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2020/0595.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2020/0595.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2020/0595.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2020/0595.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/훈령/2020/0595.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/훈령/2020/0595.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001592",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/병무청/훈령/2020/0596.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 596,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2020/0596.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/훈령/2020/0596.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2020/0596.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/훈령/2020/0596.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/훈령/2020/0596.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/훈령/2020/0596.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001593",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/산림청/훈령/2020/0597.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 597,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2020/0597.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/훈령/2020/0597.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2020/0597.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/훈령/2020/0597.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/훈령/2020/0597.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/훈령/2020/0597.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001594",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/농촌진흥청/훈령/2020/0598.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 598,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2020/0598.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2020/0598.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2020/0598.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2020/0598.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/훈령/2020/0598.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/훈령/2020/0598.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001595",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/중소벤처기업부/훈령/2020/0599.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 599,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2020/0599.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 15,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2020/0599.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2020/0599.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 14,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2020/0599.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/훈령/2020/0599.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 13,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/훈령/2020/0599.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001596",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/과학기술정보통신부/훈령/2020/0600.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 600,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2020/0600.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2020/0600.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 21
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2020/0600.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2020/0600.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 21
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/훈령/2020/0600.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/훈령/2020/0600.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001597",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/문화체육관광부/훈령/2020/0601.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 601,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2020/0601.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2020/0601.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2020/0601.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2020/0601.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2020/0601.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2020/0601.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/훈령/2020/0601.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/훈령/2020/0601.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001598",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/환경부/훈령/2020/0602.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 602,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2020/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/훈령/2020/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2020/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/훈령/2020/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2020/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/훈령/2020/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/훈령/2020/0602.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/훈령/2020/0602.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001599",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양수산부/훈령/2020/0603.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "훈령",
+    "year": 2020,
+    "serial": 603,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2020/0603.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2020/0603.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2020/0603.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2020/0603.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2020/0603.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2020/0603.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/훈령/2020/0603.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/훈령/2020/0603.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001600",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/법제처/예규/2020/0604.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 604,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2020/0604.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/예규/2020/0604.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2020/0604.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/예규/2020/0604.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2020/0604.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/예규/2020/0604.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/예규/2020/0604.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/예규/2020/0604.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0025.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0025.json
@@ -1,0 +1,16688 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001601",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/행정안전부/예규/2020/0605.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 605,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2020/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/예규/2020/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2020/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/예규/2020/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2020/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/예규/2020/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/예규/2020/0605.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/예규/2020/0605.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001602",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국세청/예규/2020/0606.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 606,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2020/0606.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/예규/2020/0606.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2020/0606.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/예규/2020/0606.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2020/0606.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/예규/2020/0606.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/예규/2020/0606.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/예규/2020/0606.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001603",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/대법원/예규/2020/0607.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 607,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2020/0607.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/예규/2020/0607.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2020/0607.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/예규/2020/0607.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2020/0607.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/예규/2020/0607.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/예규/2020/0607.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/예규/2020/0607.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001604",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/특허청/예규/2020/0608.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 608,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2020/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/예규/2020/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2020/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/예규/2020/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2020/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/예규/2020/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/예규/2020/0608.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/예규/2020/0608.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001605",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/교육부/예규/2020/0609.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 609,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2020/0609.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/예규/2020/0609.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2020/0609.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/예규/2020/0609.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2020/0609.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/예규/2020/0609.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/예규/2020/0609.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/예규/2020/0609.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001606",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/보건복지부/예규/2020/0610.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 610,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2020/0610.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/예규/2020/0610.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2020/0610.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/예규/2020/0610.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2020/0610.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/예규/2020/0610.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/예규/2020/0610.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/예규/2020/0610.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001607",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/국토교통부/예규/2020/0611.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 611,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2020/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/예규/2020/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2020/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/예규/2020/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2020/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/예규/2020/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/예규/2020/0611.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/예규/2020/0611.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001608",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/고용노동부/예규/2020/0612.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 612,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2020/0612.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 11,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/예규/2020/0612.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2020/0612.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/예규/2020/0612.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2020/0612.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/예규/2020/0612.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/예규/2020/0612.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/예규/2020/0612.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001609",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/외교부/예규/2020/0613.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 613,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2020/0613.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/예규/2020/0613.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 18
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2020/0613.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/예규/2020/0613.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 18
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2020/0613.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/예규/2020/0613.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/예규/2020/0613.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/예규/2020/0613.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001610",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/기획재정부/예규/2020/0614.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 614,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2020/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/예규/2020/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2020/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/예규/2020/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2020/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/예규/2020/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/예규/2020/0614.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/예규/2020/0614.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001611",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 615,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2020/0615.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2020/0615.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2020/0615.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2020/0615.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/예규/2020/0615.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/예규/2020/0615.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001612",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 616,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/예규/2020/0616.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/예규/2020/0616.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/예규/2020/0616.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/예규/2020/0616.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/예규/2020/0616.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/예규/2020/0616.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001613",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 617,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2020/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2020/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2020/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2020/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/예규/2020/0617.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/예규/2020/0617.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001614",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 618,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2020/0618.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2020/0618.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2020/0618.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2020/0618.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/예규/2020/0618.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/예규/2020/0618.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001615",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 619,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2020/0619.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2020/0619.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2020/0619.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2020/0619.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/예규/2020/0619.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/예규/2020/0619.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001616",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 620,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2020/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2020/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2020/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2020/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/예규/2020/0620.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/예규/2020/0620.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001617",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/통계청/예규/2020/0621.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 621,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2020/0621.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/예규/2020/0621.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2020/0621.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/예규/2020/0621.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2020/0621.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/예규/2020/0621.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2020/0621.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/예규/2020/0621.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/예규/2020/0621.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/예규/2020/0621.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001618",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기상청/예규/2020/0622.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 622,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2020/0622.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/예규/2020/0622.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2020/0622.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/예규/2020/0622.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2020/0622.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/예규/2020/0622.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2020/0622.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/예규/2020/0622.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/예규/2020/0622.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/예규/2020/0622.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001619",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/관세청/예규/2020/0623.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 623,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2020/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/예규/2020/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2020/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/예규/2020/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2020/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/예규/2020/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2020/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/예규/2020/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/예규/2020/0623.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/예규/2020/0623.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001620",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/검찰청/예규/2020/0624.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 624,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2020/0624.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/예규/2020/0624.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2020/0624.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/예규/2020/0624.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2020/0624.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/예규/2020/0624.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2020/0624.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/예규/2020/0624.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/예규/2020/0624.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/예규/2020/0624.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001621",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/경찰청/예규/2020/0625.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 625,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2020/0625.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/예규/2020/0625.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2020/0625.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/예규/2020/0625.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2020/0625.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/예규/2020/0625.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2020/0625.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/예규/2020/0625.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/예규/2020/0625.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/예규/2020/0625.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001622",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/소방청/예규/2020/0626.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 626,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2020/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/예규/2020/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 15
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2020/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/예규/2020/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 15
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2020/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/예규/2020/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2020/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/예규/2020/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/예규/2020/0626.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/예규/2020/0626.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001623",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 627,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2020/0627.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2020/0627.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2020/0627.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2020/0627.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/예규/2020/0627.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/예규/2020/0627.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001624",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/병무청/예규/2020/0628.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 628,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2020/0628.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 17,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/예규/2020/0628.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2020/0628.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/예규/2020/0628.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2020/0628.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/예규/2020/0628.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2020/0628.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/예규/2020/0628.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/예규/2020/0628.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/예규/2020/0628.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001625",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/산림청/예규/2020/0629.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 629,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/예규/2020/0629.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/예규/2020/0629.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001626",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 630,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/예규/2020/0630.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/예규/2020/0630.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001627",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 631,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/예규/2020/0631.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/예규/2020/0631.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001628",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 632,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/예규/2020/0632.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/예규/2020/0632.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001629",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 633,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/예규/2020/0633.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/예규/2020/0633.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001630",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/환경부/예규/2020/0634.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 634,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/예규/2020/0634.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/예규/2020/0634.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001631",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "예규",
+    "year": 2020,
+    "serial": 635,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/예규/2020/0635.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/예규/2020/0635.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001632",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/법제처/공고/2020/0636.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 636,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/공고/2020/0636.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/공고/2020/0636.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001633",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 637,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/공고/2020/0637.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/공고/2020/0637.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001634",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국세청/공고/2020/0638.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 638,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/공고/2020/0638.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/공고/2020/0638.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001635",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/대법원/공고/2020/0639.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "대법원",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 639,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/공고/2020/0639.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/대법원/공고/2020/0639.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001636",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/특허청/공고/2020/0640.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 640,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/공고/2020/0640.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/특허청/공고/2020/0640.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001637",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/교육부/공고/2020/0641.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 641,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 13,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/공고/2020/0641.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/교육부/공고/2020/0641.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001638",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/보건복지부/공고/2020/0642.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "보건복지부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 642,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/공고/2020/0642.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/보건복지부/공고/2020/0642.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001639",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 643,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/공고/2020/0643.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국토교통부/공고/2020/0643.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001640",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 644,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/공고/2020/0644.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/고용노동부/공고/2020/0644.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001641",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/외교부/공고/2020/0645.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "외교부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 645,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/공고/2020/0645.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/외교부/공고/2020/0645.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001642",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 646,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/공고/2020/0646.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기획재정부/공고/2020/0646.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001643",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 647,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/공고/2020/0647.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/공정거래위원회/공고/2020/0647.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001644",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/금융위원회/공고/2020/0648.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "금융위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 648,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/공고/2020/0648.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/금융위원회/공고/2020/0648.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001645",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 649,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/공고/2020/0649.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/방송통신위원회/공고/2020/0649.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001646",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 650,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/공고/2020/0650.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/개인정보보호위원회/공고/2020/0650.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001647",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국민권익위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 651,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/공고/2020/0651.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국민권익위원회/공고/2020/0651.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 7
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001648",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 652,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/공고/2020/0652.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국가인권위원회/공고/2020/0652.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001649",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/통계청/공고/2020/0653.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 653,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/공고/2020/0653.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/통계청/공고/2020/0653.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001650",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기상청/공고/2020/0654.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기상청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 654,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/공고/2020/0654.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/기상청/공고/2020/0654.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001651",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/관세청/공고/2020/0655.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 655,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/공고/2020/0655.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 15,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/관세청/공고/2020/0655.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001652",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 7,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/검찰청/공고/2020/0656.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 656,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/공고/2020/0656.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/검찰청/공고/2020/0656.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001653",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/경찰청/공고/2020/0657.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "경찰청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 657,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/공고/2020/0657.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/경찰청/공고/2020/0657.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001654",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/소방청/공고/2020/0658.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 658,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/공고/2020/0658.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/소방청/공고/2020/0658.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001655",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 659,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exact_ok",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/공고/2020/0659.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양경찰청/공고/2020/0659.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001656",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/병무청/공고/2020/0660.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "병무청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 660,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/공고/2020/0660.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/병무청/공고/2020/0660.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001657",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/산림청/공고/2020/0661.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 661,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 3,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 2,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 1,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "verify_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/공고/2020/0661.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/산림청/공고/2020/0661.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001658",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 662,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_2",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_3",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/공고/2020/0662.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/농촌진흥청/공고/2020/0662.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001659",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "중소벤처기업부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 663,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/공고/2020/0663.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/중소벤처기업부/공고/2020/0663.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001660",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 664,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 6,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 5,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 4,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_fail_big",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "exit0_ident_false",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/공고/2020/0664.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/과학기술정보통신부/공고/2020/0664.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001661",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 665,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "over_5",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "over_8",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/공고/2020/0665.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 8,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/문화체육관광부/공고/2020/0665.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001662",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/환경부/공고/2020/0666.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "환경부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 666,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 9,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/공고/2020/0666.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/환경부/공고/2020/0666.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001663",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "공고",
+    "year": 2020,
+    "serial": 667,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 7,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "exit3_ident_true",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "page_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/공고/2020/0667.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/해양수산부/공고/2020/0667.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001664",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/법제처/지침/2020/0668.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 668,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 12,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 8
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "under_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 11,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/지침/2020/0668.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 10,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/법제처/지침/2020/0668.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/corpus/shard_0026.json
+++ b/tools/llm_verifier/best_of_n/corpus/shard_0026.json
@@ -1,0 +1,13281 @@
+[
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001665",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/행정안전부/지침/2020/0669.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "행정안전부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 669,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c6",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "verify_omitted",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 16,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 16
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/지침/2020/0669.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/행정안전부/지침/2020/0669.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 16
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001666",
+    "command": "run",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "run",
+      "--verify",
+      "--json"
+    ],
+    "n": 8,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국세청/지침/2020/0670.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국세청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 670,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c6",
+        "archetype": "page_fail_over",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 4,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 20,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 7
+      },
+      {
+        "candidateId": "c7",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/지침/2020/0670.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "planVersion": "1.0",
+          "assertions": {
+            "verify": true,
+            "notFoundEmpty": true
+          },
+          "steps": [
+            {
+              "action": "fill_fields",
+              "filledCount": 0,
+              "invalid": []
+            }
+          ],
+          "output": "out/v-bon/국세청/지침/2020/0670.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 8
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001667",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/대법원/지침/2020/0671.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 671,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2020/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1667-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 1,
+              "value": "대표자-1667-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/지침/2020/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/지침/2020/0671.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1680-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 1,
+              "value": "신청인-1680-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 2,
+              "value": "신청인-1680-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/지침/2020/0671.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001668",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/특허청/지침/2020/0672.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "특허청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 672,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2020/0672.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당부서"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/지침/2020/0672.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/지침/2020/0672.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/지침/2020/0672.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001669",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/교육부/지침/2020/0673.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "교육부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 673,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2020/0673.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1669-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1669-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-1669-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-1669-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/지침/2020/0673.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/지침/2020/0673.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1682-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1682-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/지침/2020/0673.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001670",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/보건복지부/지침/2020/0674.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 674,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2020/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1670-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1670-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1670-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-1670-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/지침/2020/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/지침/2020/0674.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1683-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1683-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1683-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-1683-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/지침/2020/0674.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001671",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/국토교통부/지침/2020/0675.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국토교통부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 675,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2020/0675.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/지침/2020/0675.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/지침/2020/0675.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/지침/2020/0675.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001672",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/고용노동부/지침/2020/0676.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "고용노동부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 676,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2020/0676.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1672-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1672-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1672-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1672-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/지침/2020/0676.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/지침/2020/0676.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1685-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1685-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1685-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1685-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/지침/2020/0676.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001673",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/외교부/지침/2020/0677.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 677,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2020/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1673-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1673-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1673-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1673-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/지침/2020/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/지침/2020/0677.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1686-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1686-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1686-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1686-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/지침/2020/0677.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001674",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/기획재정부/지침/2020/0678.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "기획재정부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 678,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2020/0678.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1674-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1674-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1674-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1674-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/지침/2020/0678.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/지침/2020/0678.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/지침/2020/0678.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001675",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/공정거래위원회/지침/2020/0679.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "공정거래위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 679,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2020/0679.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1675-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1675-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1675-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1675-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/지침/2020/0679.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/지침/2020/0679.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/지침/2020/0679.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001676",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/금융위원회/지침/2020/0680.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 680,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2020/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1676-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1676-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1676-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1676-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/지침/2020/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/지침/2020/0680.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/지침/2020/0680.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001677",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/방송통신위원회/지침/2020/0681.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "방송통신위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 681,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2020/0681.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1677-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1677-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1677-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1677-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2020/0681.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/지침/2020/0681.hwp",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1690-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1690-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1690-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1690-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/지침/2020/0681.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001678",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/개인정보보호위원회/지침/2020/0682.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "개인정보보호위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 682,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2020/0682.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2020/0682.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/지침/2020/0682.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "시행일자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/지침/2020/0682.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001679",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/국민권익위원회/지침/2020/0683.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 683,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2020/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1679-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1679-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1679-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1679-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2020/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/지침/2020/0683.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1692-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1692-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1692-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1692-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/지침/2020/0683.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001680",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 2,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/국가인권위원회/지침/2020/0684.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국가인권위원회",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 684,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 22,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2020/0684.hwp",
+          "dryRun": false,
+          "changedCount": 22,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 22,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1680-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1680-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1680-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1680-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2020/0684.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 23,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/지침/2020/0684.hwp",
+          "dryRun": false,
+          "changedCount": 23,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 23,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1693-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1693-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1693-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1693-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/지침/2020/0684.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001681",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/통계청/지침/2020/0685.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "통계청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 685,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2020/0685.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "생년월일"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/지침/2020/0685.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2020/0685.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/지침/2020/0685.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/지침/2020/0685.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/지침/2020/0685.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001682",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/기상청/지침/2020/0686.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 686,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2020/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1682-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-1682-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 2,
+              "value": "주소-1682-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 3,
+              "value": "주소-1682-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/지침/2020/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2020/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1695-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/지침/2020/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/지침/2020/0686.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1708-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/지침/2020/0686.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001683",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/관세청/지침/2020/0687.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "관세청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 687,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2020/0687.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1683-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1683-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 1,
+              "value": "연락처-1683-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-1683-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/지침/2020/0687.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2020/0687.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1696-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1696-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-1696-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-1696-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/지침/2020/0687.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/지침/2020/0687.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1709-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/지침/2020/0687.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001684",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/검찰청/지침/2020/0688.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "검찰청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 688,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2020/0688.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/지침/2020/0688.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2020/0688.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/지침/2020/0688.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/지침/2020/0688.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1710-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1710-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1710-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/지침/2020/0688.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001685",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/경찰청/지침/2020/0689.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 689,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2020/0689.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1685-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1685-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1685-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1685-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/지침/2020/0689.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2020/0689.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1698-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1698-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1698-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1698-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/지침/2020/0689.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/지침/2020/0689.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1711-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1711-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1711-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1711-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/지침/2020/0689.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001686",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/소방청/지침/2020/0690.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "소방청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 690,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2020/0690.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1686-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1686-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1686-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1686-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/지침/2020/0690.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2020/0690.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1699-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1699-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1699-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/지침/2020/0690.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/지침/2020/0690.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1712-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1712-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/지침/2020/0690.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001687",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/해양경찰청/지침/2020/0691.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양경찰청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 691,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2020/0691.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1687-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1687-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1687-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1687-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2020/0691.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2020/0691.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2020/0691.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/지침/2020/0691.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1713-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1713-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1713-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1713-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/지침/2020/0691.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001688",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/병무청/지침/2020/0692.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 692,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2020/0692.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1688-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1688-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1688-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1688-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/지침/2020/0692.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2020/0692.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/지침/2020/0692.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/지침/2020/0692.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/지침/2020/0692.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001689",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/산림청/지침/2020/0693.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "산림청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 693,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2020/0693.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1689-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1689-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1689-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1689-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/지침/2020/0693.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2020/0693.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/지침/2020/0693.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/지침/2020/0693.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1715-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1715-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1715-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1715-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/지침/2020/0693.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001690",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/농촌진흥청/지침/2020/0694.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "농촌진흥청",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 694,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2020/0694.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1690-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1690-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1690-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1690-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2020/0694.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2020/0694.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1703-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1703-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1703-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1703-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2020/0694.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/지침/2020/0694.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1716-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1716-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1716-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1716-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/지침/2020/0694.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001691",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/중소벤처기업부/지침/2020/0695.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 695,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2020/0695.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2020/0695.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2020/0695.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "전자우편"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2020/0695.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/지침/2020/0695.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/지침/2020/0695.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001692",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/과학기술정보통신부/지침/2020/0696.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "과학기술정보통신부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 696,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2020/0696.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1692-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1692-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1692-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1692-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2020/0696.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2020/0696.hwp",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1705-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1705-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1705-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1705-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2020/0696.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 10
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/지침/2020/0696.hwp",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1718-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1718-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1718-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1718-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/지침/2020/0696.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 10
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001693",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/문화체육관광부/지침/2020/0697.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "문화체육관광부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 697,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2020/0697.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1693-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1693-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1693-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1693-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2020/0697.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2020/0697.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1706-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1706-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1706-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1706-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2020/0697.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 21,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/지침/2020/0697.hwpx",
+          "dryRun": false,
+          "changedCount": 21,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 21,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1719-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1719-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1719-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1719-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/지침/2020/0697.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001694",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 3,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/환경부/지침/2020/0698.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 698,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2020/0698.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "금액"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/지침/2020/0698.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2020/0698.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/지침/2020/0698.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/지침/2020/0698.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/지침/2020/0698.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001695",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/해양수산부/지침/2020/0699.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양수산부",
+    "docKind": "지침",
+    "year": 2020,
+    "serial": 699,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2020/0699.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1695-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 1,
+              "value": "계좌번호-1695-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 2,
+              "value": "계좌번호-1695-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 3,
+              "value": "계좌번호-1695-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/지침/2020/0699.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2020/0699.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/지침/2020/0699.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2020/0699.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/지침/2020/0699.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/지침/2020/0699.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/지침/2020/0699.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001696",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/법제처/서식/2020/0700.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "법제처",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 700,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2020/0700.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1696-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 1,
+              "value": "주민등록번호-1696-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 2,
+              "value": "주민등록번호-1696-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 3,
+              "value": "주민등록번호-1696-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/서식/2020/0700.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2020/0700.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1709-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-1709-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 2,
+              "value": "담당자-1709-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 3,
+              "value": "담당자-1709-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/서식/2020/0700.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2020/0700.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/서식/2020/0700.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/서식/2020/0700.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/서식/2020/0700.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001697",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/행정안전부/서식/2020/0701.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "행정안전부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 701,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2020/0701.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/서식/2020/0701.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2020/0701.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/행정안전부/서식/2020/0701.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2020/0701.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1723-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1723-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/행정안전부/서식/2020/0701.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/행정안전부/서식/2020/0701.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/행정안전부/서식/2020/0701.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001698",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국세청/서식/2020/0702.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "국세청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 702,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2020/0702.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1698-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1698-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1698-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/서식/2020/0702.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2020/0702.hwp",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1711-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1711-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1711-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국세청/서식/2020/0702.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2020/0702.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1724-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1724-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1724-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 1,
+              "value": "전자우편-1724-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국세청/서식/2020/0702.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국세청/서식/2020/0702.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국세청/서식/2020/0702.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001699",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/대법원/서식/2020/0703.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "대법원",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 703,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2020/0703.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1699-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1699-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1699-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/서식/2020/0703.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2020/0703.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1712-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1712-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/대법원/서식/2020/0703.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2020/0703.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1725-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/대법원/서식/2020/0703.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/대법원/서식/2020/0703.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/대법원/서식/2020/0703.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001700",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/특허청/서식/2020/0704.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "특허청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 704,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2020/0704.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1700-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1700-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1700-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1700-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/서식/2020/0704.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2020/0704.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/특허청/서식/2020/0704.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2020/0704.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1726-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1726-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1726-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1726-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/특허청/서식/2020/0704.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/특허청/서식/2020/0704.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1739-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1739-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1739-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1739-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/특허청/서식/2020/0704.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001701",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/교육부/서식/2020/0705.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "교육부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 705,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2020/0705.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1701-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1701-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1701-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1701-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/서식/2020/0705.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2020/0705.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/교육부/서식/2020/0705.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2020/0705.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/교육부/서식/2020/0705.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/교육부/서식/2020/0705.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/교육부/서식/2020/0705.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001702",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/보건복지부/서식/2020/0706.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "보건복지부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 706,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2020/0706.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1702-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1702-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1702-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1702-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/서식/2020/0706.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2020/0706.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/보건복지부/서식/2020/0706.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2020/0706.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1728-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1728-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1728-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1728-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/보건복지부/서식/2020/0706.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/보건복지부/서식/2020/0706.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1741-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1741-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1741-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1741-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/보건복지부/서식/2020/0706.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001703",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/국토교통부/서식/2020/0707.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국토교통부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 707,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2020/0707.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1703-00"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1703-01"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1703-02"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1703-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/서식/2020/0707.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2020/0707.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1716-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1716-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1716-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1716-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국토교통부/서식/2020/0707.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2020/0707.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1729-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1729-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1729-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1729-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국토교통부/서식/2020/0707.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국토교통부/서식/2020/0707.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1742-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1742-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1742-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1742-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국토교통부/서식/2020/0707.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001704",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/고용노동부/서식/2020/0708.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "고용노동부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 708,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2020/0708.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/서식/2020/0708.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2020/0708.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "면허번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/고용노동부/서식/2020/0708.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2020/0708.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/고용노동부/서식/2020/0708.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/고용노동부/서식/2020/0708.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/고용노동부/서식/2020/0708.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001705",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/외교부/서식/2020/0709.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "외교부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 709,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2020/0709.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1705-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1705-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1705-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1705-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/서식/2020/0709.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2020/0709.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1718-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1718-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1718-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1718-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/외교부/서식/2020/0709.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2020/0709.hwpx",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1731-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1731-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1731-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1731-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/외교부/서식/2020/0709.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/외교부/서식/2020/0709.hwpx",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1744-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1744-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1744-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1744-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/외교부/서식/2020/0709.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001706",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/기획재정부/서식/2020/0710.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기획재정부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 710,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2020/0710.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1706-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1706-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1706-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1706-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/서식/2020/0710.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2020/0710.hwpx",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1719-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1719-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1719-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1719-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기획재정부/서식/2020/0710.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2020/0710.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1732-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1732-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1732-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1732-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기획재정부/서식/2020/0710.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기획재정부/서식/2020/0710.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1745-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1745-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1745-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1745-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기획재정부/서식/2020/0710.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001707",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/공정거래위원회/서식/2020/0711.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "공정거래위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 711,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2020/0711.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "대표자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2020/0711.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2020/0711.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2020/0711.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2020/0711.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2020/0711.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/공정거래위원회/서식/2020/0711.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/공정거래위원회/서식/2020/0711.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001708",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 4,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/금융위원회/서식/2020/0712.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "금융위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 712,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2020/0712.hwpx",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1708-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1708-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1708-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1708-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/서식/2020/0712.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2020/0712.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1721-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1721-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1721-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1721-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/금융위원회/서식/2020/0712.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2020/0712.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1734-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1734-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1734-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1734-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/금융위원회/서식/2020/0712.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 20,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 3
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/금융위원회/서식/2020/0712.hwpx",
+          "dryRun": false,
+          "changedCount": 20,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 20,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1747-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1747-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1747-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1747-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/금융위원회/서식/2020/0712.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 3
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001709",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "방송통신위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 713,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1709-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 1,
+              "value": "담당자-1709-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 2,
+              "value": "담당자-1709-02"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 3,
+              "value": "담당자-1709-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2020/0713.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1722-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 1,
+              "value": "주소-1722-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 2,
+              "value": "주소-1722-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 3,
+              "value": "주소-1722-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2020/0713.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2020/0713.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2020/0713.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/방송통신위원회/서식/2020/0713.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/방송통신위원회/서식/2020/0713.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001710",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "개인정보보호위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 714,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2020/0714.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2020/0714.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1736-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2020/0714.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2020/0714.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/개인정보보호위원회/서식/2020/0714.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1762-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/개인정보보호위원회/서식/2020/0714.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001711",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국민권익위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 715,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1711-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1711-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2020/0715.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1724-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1724-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2020/0715.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1737-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1737-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 1,
+              "value": "면허번호-1737-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-1737-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2020/0715.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2020/0715.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국민권익위원회/서식/2020/0715.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국민권익위원회/서식/2020/0715.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001712",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "국가인권위원회",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 716,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1712-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1712-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2020/0716.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1725-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2020/0716.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2020/0716.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2020/0716.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/국가인권위원회/서식/2020/0716.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1764-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1764-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1764-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/국가인권위원회/서식/2020/0716.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001713",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/통계청/서식/2020/0717.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "통계청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 717,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2020/0717.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1713-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1713-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1713-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1713-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/서식/2020/0717.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2020/0717.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/서식/2020/0717.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2020/0717.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1739-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1739-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1739-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1739-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/통계청/서식/2020/0717.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2020/0717.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1752-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1752-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1752-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1752-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/통계청/서식/2020/0717.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/통계청/서식/2020/0717.hwp",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1765-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1765-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1765-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1765-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/통계청/서식/2020/0717.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001714",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/기상청/서식/2020/0718.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "기상청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 718,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2020/0718.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1714-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1714-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1714-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1714-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/서식/2020/0718.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2020/0718.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/서식/2020/0718.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2020/0718.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/기상청/서식/2020/0718.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2020/0718.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/기상청/서식/2020/0718.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/기상청/서식/2020/0718.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/기상청/서식/2020/0718.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001715",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 6,
+    "sample": "samples/gov/관세청/서식/2020/0719.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "관세청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 719,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2020/0719.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1715-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1715-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1715-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/서식/2020/0719.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2020/0719.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/서식/2020/0719.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2020/0719.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1741-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1741-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1741-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1741-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/관세청/서식/2020/0719.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2020/0719.hwpx",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1754-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1754-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1754-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1754-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/관세청/서식/2020/0719.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 14,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 11
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/관세청/서식/2020/0719.hwpx",
+          "dryRun": false,
+          "changedCount": 14,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 14,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1767-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1767-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1767-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1767-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/관세청/서식/2020/0719.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 11
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001716",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 7,
+    "sample": "samples/gov/검찰청/서식/2020/0720.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "검찰청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 720,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exact_ok",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2020/0720.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1716-00"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1716-01"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1716-02"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1716-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/서식/2020/0720.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_1",
+        "changedCount": 8,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2020/0720.hwp",
+          "dryRun": false,
+          "changedCount": 8,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 8,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1729-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1729-01"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1729-02"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1729-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/서식/2020/0720.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_2",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2020/0720.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1742-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1742-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1742-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1742-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/검찰청/서식/2020/0720.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_3",
+        "changedCount": 10,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2020/0720.hwp",
+          "dryRun": false,
+          "changedCount": 10,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 10,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1755-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1755-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1755-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1755-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/검찰청/서식/2020/0720.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_5",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/검찰청/서식/2020/0720.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1768-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1768-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1768-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1768-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/검찰청/서식/2020/0720.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001717",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 8,
+    "sample": "samples/gov/경찰청/서식/2020/0721.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "경찰청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 721,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2020/0721.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/서식/2020/0721.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2020/0721.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "문서번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/서식/2020/0721.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2020/0721.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/경찰청/서식/2020/0721.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2020/0721.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/경찰청/서식/2020/0721.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/경찰청/서식/2020/0721.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/경찰청/서식/2020/0721.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001718",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 9,
+    "sample": "samples/gov/소방청/서식/2020/0722.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "소방청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 722,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c3",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2020/0722.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1718-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1718-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1718-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1718-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/서식/2020/0722.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "verify_fail_over",
+        "changedCount": 11,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2020/0722.hwpx",
+          "dryRun": false,
+          "changedCount": 11,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 11,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1731-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1731-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1731-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1731-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/서식/2020/0722.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail_big",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2020/0722.hwpx",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1744-00"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1744-01"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1744-02"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1744-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/소방청/서식/2020/0722.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "exit0_ident_false",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2020/0722.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1757-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1757-01"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1757-02"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1757-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/소방청/서식/2020/0722.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exit3_ident_true",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/소방청/서식/2020/0722.hwpx",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1770-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1770-01"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1770-02"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1770-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/소방청/서식/2020/0722.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001719",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 10,
+    "sample": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "해양경찰청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 723,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_2",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1719-00"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1719-01"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1719-02"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1719-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2020/0723.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_3",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1732-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1732-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1732-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1732-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2020/0723.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "over_5",
+        "changedCount": 15,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+          "dryRun": false,
+          "changedCount": 15,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 15,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1745-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1745-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1745-02"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1745-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2020/0723.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_8",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1758-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1758-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1758-02"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1758-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2020/0723.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_1",
+        "changedCount": 9,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양경찰청/서식/2020/0723.hwp",
+          "dryRun": false,
+          "changedCount": 9,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 9,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1771-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1771-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1771-02"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1771-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양경찰청/서식/2020/0723.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001720",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 12,
+    "sample": "samples/gov/병무청/서식/2020/0724.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "병무청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 724,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2020/0724.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "신청인"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/서식/2020/0724.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2020/0724.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "제목"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/서식/2020/0724.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2020/0724.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/병무청/서식/2020/0724.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2020/0724.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/병무청/서식/2020/0724.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_omitted",
+        "changedCount": 12,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/병무청/서식/2020/0724.hwpx",
+          "dryRun": false,
+          "changedCount": 12,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 12,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1772-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1772-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1772-02"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1772-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/병무청/서식/2020/0724.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 1
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001721",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 16,
+    "sample": "samples/gov/산림청/서식/2020/0725.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "산림청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 725,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c1",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_fail_big",
+        "changedCount": 24,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 9
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2020/0725.hwpx",
+          "dryRun": false,
+          "changedCount": 24,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 24,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1721-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1721-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1721-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1721-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/서식/2020/0725.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 9
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "exit0_ident_false",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2020/0725.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1734-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1734-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1734-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1734-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/서식/2020/0725.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exit3_ident_true",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2020/0725.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1747-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1747-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1747-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1747-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/산림청/서식/2020/0725.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "page_fail",
+        "changedCount": 16,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2020/0725.hwpx",
+          "dryRun": false,
+          "changedCount": 16,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 16,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1760-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1760-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1760-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1760-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/산림청/서식/2020/0725.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "page_fail_over",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/산림청/서식/2020/0725.hwpx",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1773-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1773-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1773-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1773-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/산림청/서식/2020/0725.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 5
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001722",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 5,
+    "intendedChangedCount": 20,
+    "sample": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "농촌진흥청",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 726,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "over_5",
+        "changedCount": 25,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+          "dryRun": false,
+          "changedCount": 25,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 25,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1722-00"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1722-01"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1722-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1722-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2020/0726.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "over_8",
+        "changedCount": 28,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+          "dryRun": false,
+          "changedCount": 28,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 28,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1735-00"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1735-01"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1735-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1735-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2020/0726.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_1",
+        "changedCount": 19,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+          "dryRun": false,
+          "changedCount": 19,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 19,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1748-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1748-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1748-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1748-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2020/0726.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_2",
+        "changedCount": 18,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+          "dryRun": false,
+          "changedCount": 18,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 18,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1761-00"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1761-01"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1761-02"
+            },
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1761-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2020/0726.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "under_3",
+        "changedCount": 17,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/농촌진흥청/서식/2020/0726.hwp",
+          "dryRun": false,
+          "changedCount": 17,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 17,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1774-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1774-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1774-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1774-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/농촌진흥청/서식/2020/0726.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001723",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 0,
+    "sample": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "중소벤처기업부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 727,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c4",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "invalid_control",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "controlCharacter",
+            "row": 1,
+            "col": 0
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "controlCharacter",
+              "row": 1,
+              "col": 0
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "연락처"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "invalid_bool",
+        "changedCount": 0,
+        "invalid": true,
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": true,
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "주민등록번호"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_omitted",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "exact_ok",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/중소벤처기업부/서식/2020/0727.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1788-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/중소벤처기업부/서식/2020/0727.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001724",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 1,
+    "sample": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "과학기술정보통신부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 728,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "exit3_ident_true",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "전자우편",
+              "occurrence": 0,
+              "value": "전자우편-1724-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "page_fail",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1737-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "page_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1750-00"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-1750-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 2,
+              "value": "문서번호-1750-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 3,
+              "value": "문서번호-1750-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/과학기술정보통신부/서식/2020/0728.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "담당자"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/과학기술정보통신부/서식/2020/0728.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001725",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 2,
+    "sample": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "문화체육관광부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 729,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_1",
+        "changedCount": 1,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 1,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 1,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1725-00"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_2",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "under_3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1777-00"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1777-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "verify_fail_over",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 4
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/문화체육관광부/서식/2020/0729.hwp",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1790-00"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1790-01"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 1,
+              "value": "문서번호-1790-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 1,
+              "value": "시행일자-1790-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/문화체육관광부/서식/2020/0729.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 4
+          }
+        },
+        "expectedRank": 6
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001726",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 3,
+    "sample": "samples/gov/환경부/서식/2020/0730.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "환경부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 730,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c2",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "verify_omitted",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1726-00"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1726-01"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1726-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "under_zero_exit3",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "exact_ok",
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 3,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 3,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1752-00"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1752-01"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1752-02"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "over_1",
+        "changedCount": 4,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 4,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 4,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "사업자등록번호",
+              "occurrence": 0,
+              "value": "사업자등록번호-1765-00"
+            },
+            {
+              "name": "법인명",
+              "occurrence": 0,
+              "value": "법인명-1765-01"
+            },
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1765-02"
+            },
+            {
+              "name": "사업자등록번호",
+              "occurrence": 1,
+              "value": "사업자등록번호-1765-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "over_2",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시설위치",
+              "occurrence": 0,
+              "value": "시설위치-1778-00"
+            },
+            {
+              "name": "처리기한",
+              "occurrence": 0,
+              "value": "처리기한-1778-01"
+            },
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1778-02"
+            },
+            {
+              "name": "시설위치",
+              "occurrence": 1,
+              "value": "시설위치-1778-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "over_3",
+        "changedCount": 6,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/환경부/서식/2020/0730.hwpx",
+          "dryRun": false,
+          "changedCount": 6,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 6,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "시행일자",
+              "occurrence": 0,
+              "value": "시행일자-1791-00"
+            },
+            {
+              "name": "수신",
+              "occurrence": 0,
+              "value": "수신-1791-01"
+            },
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1791-02"
+            },
+            {
+              "name": "시행일자",
+              "occurrence": 1,
+              "value": "시행일자-1791-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/환경부/서식/2020/0730.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001727",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 4,
+    "sample": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+    "sourceFormat": "hwpx",
+    "agency": "해양수산부",
+    "docKind": "서식",
+    "year": 2020,
+    "serial": 731,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "page_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 6
+        },
+        "exitClass": 4,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 4,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1727-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1727-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1727-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1727-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": {
+            "identical": false,
+            "diffCount": 6
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "io_missing",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 1,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "usage_flag",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 3
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "invalid_dim",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 12,
+            "actual": 9
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "rowCountMismatch",
+              "expected": 12,
+              "actual": 9
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "법인명"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "invalid_field",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "notFound",
+            "name": "신청인"
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "notFound",
+              "name": "신청인"
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "처리기한"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "invalid_covered",
+        "changedCount": 0,
+        "invalid": [
+          {
+            "reason": "coveredCellNotEmpty",
+            "row": 2,
+            "col": 1
+          }
+        ],
+        "verify": null,
+        "exitClass": 2,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/해양수산부/서식/2020/0731.hwpx",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [
+            {
+              "reason": "coveredCellNotEmpty",
+              "row": 2,
+              "col": 1
+            }
+          ],
+          "exitClass": 2,
+          "filledCount": 0,
+          "notFound": [
+            "수신"
+          ],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/해양수산부/서식/2020/0731.out.hwpx",
+          "outputFormat": "hwpx",
+          "verify": null
+        },
+        "expectedRank": 4
+      }
+    ]
+  },
+  {
+    "schemaVersion": "1.0",
+    "claim": "V-bon",
+    "kind": "bestOfNSet",
+    "setId": "v-bon-001728",
+    "command": "fill-fields",
+    "mode": "verify",
+    "argv": [
+      "rhwp",
+      "edit",
+      "fill-fields",
+      "--verify",
+      "--json"
+    ],
+    "n": 6,
+    "intendedChangedCount": 5,
+    "sample": "samples/gov/법제처/질의회신/2020/0732.hwp",
+    "sourceFormat": "hwp5",
+    "agency": "법제처",
+    "docKind": "질의회신",
+    "year": 2020,
+    "serial": 732,
+    "rankFields": [
+      "changedCount",
+      "invalid",
+      "verify.identical",
+      "exitClass"
+    ],
+    "winnerId": "c0",
+    "candidates": [
+      {
+        "candidateId": "c0",
+        "archetype": "under_3",
+        "changedCount": 2,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 2,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 2,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1728-00"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1728-01"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 1
+      },
+      {
+        "candidateId": "c1",
+        "archetype": "zero_change",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": {
+          "identical": true,
+          "diffCount": 0
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 0,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 0,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": true,
+            "diffCount": 0
+          }
+        },
+        "expectedRank": 2
+      },
+      {
+        "candidateId": "c2",
+        "archetype": "verify_fail",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 2
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1754-00"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1754-01"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1754-02"
+            },
+            {
+              "name": "면허번호",
+              "occurrence": 0,
+              "value": "면허번호-1754-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 2
+          }
+        },
+        "expectedRank": 4
+      },
+      {
+        "candidateId": "c3",
+        "archetype": "verify_fail_over",
+        "changedCount": 7,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 5
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 7,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 7,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "대표자",
+              "occurrence": 0,
+              "value": "대표자-1767-00"
+            },
+            {
+              "name": "담당부서",
+              "occurrence": 0,
+              "value": "담당부서-1767-01"
+            },
+            {
+              "name": "담당자",
+              "occurrence": 0,
+              "value": "담당자-1767-02"
+            },
+            {
+              "name": "문서번호",
+              "occurrence": 0,
+              "value": "문서번호-1767-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            0
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 5
+          }
+        },
+        "expectedRank": 5
+      },
+      {
+        "candidateId": "c4",
+        "archetype": "verify_fail_big",
+        "changedCount": 13,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 8
+        },
+        "exitClass": 3,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 13,
+          "invalid": [],
+          "exitClass": 3,
+          "filledCount": 13,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "신청인",
+              "occurrence": 0,
+              "value": "신청인-1780-00"
+            },
+            {
+              "name": "생년월일",
+              "occurrence": 0,
+              "value": "생년월일-1780-01"
+            },
+            {
+              "name": "주소",
+              "occurrence": 0,
+              "value": "주소-1780-02"
+            },
+            {
+              "name": "연락처",
+              "occurrence": 0,
+              "value": "연락처-1780-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            1
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 8
+          }
+        },
+        "expectedRank": 6
+      },
+      {
+        "candidateId": "c5",
+        "archetype": "exit0_ident_false",
+        "changedCount": 5,
+        "invalid": [],
+        "verify": {
+          "identical": false,
+          "diffCount": 1
+        },
+        "exitClass": 0,
+        "envelope": {
+          "schemaVersion": "1.0",
+          "source": "samples/gov/법제처/질의회신/2020/0732.hwp",
+          "dryRun": false,
+          "changedCount": 5,
+          "invalid": [],
+          "exitClass": 0,
+          "filledCount": 5,
+          "notFound": [],
+          "ambiguous": [],
+          "filled": [
+            {
+              "name": "제목",
+              "occurrence": 0,
+              "value": "제목-1793-00"
+            },
+            {
+              "name": "금액",
+              "occurrence": 0,
+              "value": "금액-1793-01"
+            },
+            {
+              "name": "계좌번호",
+              "occurrence": 0,
+              "value": "계좌번호-1793-02"
+            },
+            {
+              "name": "주민등록번호",
+              "occurrence": 0,
+              "value": "주민등록번호-1793-03"
+            }
+          ],
+          "changedPages": [
+            0,
+            2
+          ],
+          "output": "out/v-bon/법제처/질의회신/2020/0732.out.hwp",
+          "outputFormat": "hwp5",
+          "verify": {
+            "identical": false,
+            "diffCount": 1
+          }
+        },
+        "expectedRank": 3
+      }
+    ]
+  }
+]

--- a/tools/llm_verifier/best_of_n/envelopes.py
+++ b/tools/llm_verifier/best_of_n/envelopes.py
@@ -1,0 +1,190 @@
+"""Lift existing rhwp JSON envelopes into the four V-bon rank fields.
+
+Does not run rhwp. Does not invent fields. process_steps is refused.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+try:
+    from .schema import FORBIDDEN_KEYS, CandidateOutcome, invalid_is_set
+except ImportError:
+    from schema import FORBIDDEN_KEYS, CandidateOutcome, invalid_is_set
+
+EXIT_NAME_TO_CODE: dict[str, int] = {
+    "ok": 0,
+    "success": 0,
+    "0": 0,
+    "io": 1,
+    "runtime": 1,
+    "1": 1,
+    "usage": 2,
+    "2": 2,
+    "judgment": 3,
+    "judgement": 3,
+    "3": 3,
+    "page_verify": 4,
+    "pageVerify": 4,
+    "verify_pages": 4,
+    "4": 4,
+}
+
+
+def refuse_process_reward(blob: Mapping[str, Any], *, path: str = "") -> None:
+    for key in FORBIDDEN_KEYS:
+        if key in blob:
+            loc = f"{path}.{key}" if path else key
+            raise ValueError(f"V-bon refuses process/prose field {loc} (see #5490)")
+
+
+def parse_exit_class(raw: Any) -> int:
+    if raw is None:
+        raise ValueError("exitClass is required for outcome ranking")
+    if isinstance(raw, bool):
+        raise ValueError("exitClass must not be a boolean")
+    if isinstance(raw, int):
+        if raw in {0, 1, 2, 3, 4}:
+            return raw
+        raise ValueError(f"unknown rhwp exitClass {raw}; only 0/1/2/3/4")
+    if isinstance(raw, float) and raw.is_integer():
+        return parse_exit_class(int(raw))
+    if isinstance(raw, str):
+        mapped = EXIT_NAME_TO_CODE.get(raw)
+        if mapped is not None:
+            return mapped
+        if raw.isdigit():
+            return parse_exit_class(int(raw))
+        raise ValueError(f"unknown exitClass name {raw!r}")
+    raise ValueError(f"unreadable exitClass {raw!r}")
+
+
+def _as_int(raw: Any, default: int = 0) -> int:
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        raise ValueError("numeric envelope field must not be a boolean")
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float) and raw.is_integer():
+        return int(raw)
+    if isinstance(raw, str) and raw.lstrip("-").isdigit():
+        return int(raw)
+    raise ValueError(f"not an int: {raw!r}")
+
+
+def lift_changed_count(envelope: Mapping[str, Any]) -> int:
+    if "changedCount" in envelope and envelope["changedCount"] is not None:
+        return _as_int(envelope["changedCount"])
+    for key in ("filledCount", "replacedCount", "redactedCount", "removedCount"):
+        if key in envelope and envelope[key] is not None:
+            return _as_int(envelope[key])
+    if "diffCount" in envelope and envelope["diffCount"] is not None:
+        return _as_int(envelope["diffCount"])
+    verify = envelope.get("verify")
+    if isinstance(verify, Mapping) and verify.get("diffCount") is not None:
+        return _as_int(verify["diffCount"])
+    return 0
+
+
+def lift_verify_identical(envelope: Mapping[str, Any]) -> bool | None:
+    verify = envelope.get("verify")
+    if isinstance(verify, Mapping) and "identical" in verify:
+        ident = verify["identical"]
+        if ident is None:
+            return None
+        if isinstance(ident, bool):
+            return ident
+        raise ValueError("verify.identical must be bool or null")
+    if "identical" in envelope:
+        ident = envelope["identical"]
+        if ident is None:
+            return None
+        if isinstance(ident, bool):
+            return ident
+        raise ValueError("identical must be bool or null")
+    return None
+
+
+def lift_invalid(envelope: Mapping[str, Any]) -> Any:
+    if "invalid" in envelope:
+        return envelope["invalid"]
+    return []
+
+
+def lift_envelope(
+    envelope: Mapping[str, Any],
+    *,
+    candidate_id: str,
+    exit_class: Any = None,
+) -> CandidateOutcome:
+    refuse_process_reward(envelope)
+    if exit_class is None:
+        if "exitClass" in envelope:
+            exit_class = envelope["exitClass"]
+        elif "exit" in envelope:
+            exit_class = envelope["exit"]
+        else:
+            raise ValueError("envelope is missing exitClass")
+    return CandidateOutcome(
+        candidate_id=candidate_id,
+        changed_count=lift_changed_count(envelope),
+        invalid=lift_invalid(envelope),
+        verify_identical=lift_verify_identical(envelope),
+        exit_class=parse_exit_class(exit_class),
+        envelope=dict(envelope),
+    )
+
+
+def lift_candidate_record(row: Mapping[str, Any]) -> CandidateOutcome:
+    refuse_process_reward(row)
+    envelope = row.get("envelope")
+    if isinstance(envelope, Mapping):
+        refuse_process_reward(envelope, path="envelope")
+        exit_raw = row.get("exitClass", envelope.get("exitClass", envelope.get("exit")))
+        candidate_id = str(row.get("candidateId") or row.get("id") or "c0")
+        lifted = lift_envelope(envelope, candidate_id=candidate_id, exit_class=exit_raw)
+        # Rank fields on the record override the inner envelope when present.
+        changed = (
+            _as_int(row["changedCount"])
+            if "changedCount" in row and row["changedCount"] is not None
+            else lifted.changed_count
+        )
+        invalid = row["invalid"] if "invalid" in row else lifted.invalid
+        if "verify" in row:
+            verify = row["verify"]
+            ident = (
+                verify.get("identical")
+                if isinstance(verify, Mapping)
+                else (verify if isinstance(verify, bool) else lifted.verify_identical)
+            )
+        else:
+            ident = lifted.verify_identical
+        exit_class = (
+            parse_exit_class(row["exitClass"])
+            if "exitClass" in row
+            else lifted.exit_class
+        )
+        return CandidateOutcome(
+            candidate_id=candidate_id,
+            changed_count=changed,
+            invalid=invalid,
+            verify_identical=ident,
+            exit_class=exit_class,
+            envelope=dict(envelope),
+        )
+    candidate_id = str(row.get("candidateId") or row.get("id") or "c0")
+    return lift_envelope(row, candidate_id=candidate_id)
+
+
+def envelope_looks_inconsistent(outcome: CandidateOutcome) -> bool:
+    """Field-only consistency notes. Does not change the rank key."""
+    if outcome.exit_class == 0 and outcome.verify_identical is False:
+        return True
+    if outcome.exit_class == 3 and outcome.verify_identical is True and not outcome.is_invalid():
+        return True
+    if outcome.exit_class == 0 and invalid_is_set(outcome.invalid):
+        return True
+    if outcome.exit_class in {1, 2} and outcome.verify_identical is True:
+        return True
+    return False

--- a/tools/llm_verifier/best_of_n/fixtures/golden_dry_run.json
+++ b/tools/llm_verifier/best_of_n/fixtures/golden_dry_run.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "V-bon",
+  "kind": "bestOfNSet",
+  "setId": "fixture-csv-dry-run",
+  "command": "csv-to-table",
+  "mode": "dry-run",
+  "argv": ["rhwp", "csv-to-table", "--dry-run", "--json"],
+  "n": 3,
+  "intendedChangedCount": 4,
+  "sample": "samples/gov/행정안전부/서식/2022/0012.hwp",
+  "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+  "candidates": [
+    {
+      "candidateId": "c_over",
+      "expectedRank": 2,
+      "changedCount": 6,
+      "invalid": [],
+      "verify": null,
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/행정안전부/서식/2022/0012.hwp",
+        "csv": "samples/gov/행정안전부/서식/2022/0012.csv",
+        "table": 0,
+        "rowCount": 10,
+        "colCount": 4,
+        "changedCount": 6,
+        "changed": [
+          {"row": 1, "col": 0, "oldText": "a", "newText": "A"},
+          {"row": 1, "col": 1, "oldText": "b", "newText": "B"},
+          {"row": 2, "col": 0, "oldText": "c", "newText": "C"},
+          {"row": 2, "col": 1, "oldText": "d", "newText": "D"},
+          {"row": 3, "col": 0, "oldText": "e", "newText": "E"},
+          {"row": 3, "col": 1, "oldText": "f", "newText": "F"}
+        ],
+        "invalid": [],
+        "dryRun": true,
+        "verify": null,
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_exact",
+      "expectedRank": 1,
+      "changedCount": 4,
+      "invalid": [],
+      "verify": null,
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/행정안전부/서식/2022/0012.hwp",
+        "csv": "samples/gov/행정안전부/서식/2022/0012.csv",
+        "table": 0,
+        "rowCount": 10,
+        "colCount": 4,
+        "changedCount": 4,
+        "changed": [
+          {"row": 1, "col": 0, "oldText": "a", "newText": "A"},
+          {"row": 1, "col": 1, "oldText": "b", "newText": "B"},
+          {"row": 2, "col": 0, "oldText": "c", "newText": "C"},
+          {"row": 2, "col": 1, "oldText": "d", "newText": "D"}
+        ],
+        "invalid": [],
+        "dryRun": true,
+        "verify": null,
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_io",
+      "expectedRank": 3,
+      "changedCount": 0,
+      "invalid": [],
+      "verify": null,
+      "exitClass": 1,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/행정안전부/서식/2022/missing.hwp",
+        "error": "file not found",
+        "changedCount": 0,
+        "invalid": [],
+        "dryRun": true,
+        "verify": null,
+        "exitClass": 1
+      }
+    }
+  ]
+}

--- a/tools/llm_verifier/best_of_n/fixtures/golden_fill_verify.json
+++ b/tools/llm_verifier/best_of_n/fixtures/golden_fill_verify.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "V-bon",
+  "kind": "bestOfNSet",
+  "setId": "fixture-fill-verify",
+  "command": "fill-fields",
+  "mode": "verify",
+  "argv": ["rhwp", "edit", "fill-fields", "--verify", "--json"],
+  "n": 4,
+  "intendedChangedCount": 3,
+  "sample": "samples/gov/법제처/서식/2024/0001.hwpx",
+  "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+  "candidates": [
+    {
+      "candidateId": "c_over",
+      "expectedRank": 2,
+      "changedCount": 5,
+      "invalid": [],
+      "verify": {"identical": true, "diffCount": 0},
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/법제처/서식/2024/0001.hwpx",
+        "output": "out/v-bon/fill-over.hwpx",
+        "dryRun": false,
+        "filledCount": 5,
+        "changedCount": 5,
+        "filled": [
+          {"name": "신청인", "occurrence": 0, "value": "홍길동"},
+          {"name": "주소", "occurrence": 0, "value": "세종"},
+          {"name": "연락처", "occurrence": 0, "value": "010-0000-0000"},
+          {"name": "문서번호", "occurrence": 0, "value": "extra-1"},
+          {"name": "제목", "occurrence": 0, "value": "extra-2"}
+        ],
+        "notFound": [],
+        "invalid": [],
+        "verify": {"identical": true, "diffCount": 0},
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_exact",
+      "expectedRank": 1,
+      "changedCount": 3,
+      "invalid": [],
+      "verify": {"identical": true, "diffCount": 0},
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/법제처/서식/2024/0001.hwpx",
+        "output": "out/v-bon/fill-exact.hwpx",
+        "dryRun": false,
+        "filledCount": 3,
+        "changedCount": 3,
+        "filled": [
+          {"name": "신청인", "occurrence": 0, "value": "홍길동"},
+          {"name": "주소", "occurrence": 0, "value": "세종"},
+          {"name": "연락처", "occurrence": 0, "value": "010-0000-0000"}
+        ],
+        "notFound": [],
+        "invalid": [],
+        "verify": {"identical": true, "diffCount": 0},
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_verify_fail",
+      "expectedRank": 3,
+      "changedCount": 3,
+      "invalid": [],
+      "verify": {"identical": false, "diffCount": 2},
+      "exitClass": 3,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/법제처/서식/2024/0001.hwpx",
+        "output": "out/v-bon/fill-verify-fail.hwpx",
+        "dryRun": false,
+        "filledCount": 3,
+        "changedCount": 3,
+        "invalid": [],
+        "verify": {"identical": false, "diffCount": 2},
+        "exitClass": 3
+      }
+    },
+    {
+      "candidateId": "c_invalid",
+      "expectedRank": 4,
+      "changedCount": 0,
+      "invalid": [{"reason": "notFound", "name": "신청인"}],
+      "verify": null,
+      "exitClass": 2,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/법제처/서식/2024/0001.hwpx",
+        "dryRun": false,
+        "filledCount": 0,
+        "changedCount": 0,
+        "notFound": ["신청인"],
+        "invalid": [{"reason": "notFound", "name": "신청인"}],
+        "verify": null,
+        "exitClass": 2
+      }
+    }
+  ]
+}

--- a/tools/llm_verifier/best_of_n/fixtures/golden_ir_diff.json
+++ b/tools/llm_verifier/best_of_n/fixtures/golden_ir_diff.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "V-bon",
+  "kind": "bestOfNSet",
+  "setId": "fixture-ir-diff",
+  "command": "ir-diff",
+  "mode": "ir-diff",
+  "argv": ["rhwp", "ir-diff", "--json"],
+  "n": 3,
+  "intendedChangedCount": 0,
+  "sample": "samples/gov/국세청/고시/2020/0044.hwpx",
+  "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+  "candidates": [
+    {
+      "candidateId": "c_big",
+      "expectedRank": 3,
+      "changedCount": 8,
+      "invalid": [],
+      "verify": {"identical": false, "diffCount": 8},
+      "exitClass": 3,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "left": "samples/gov/국세청/고시/2020/0044.hwpx",
+        "right": "out/v-bon/ir-big.hwp",
+        "identical": false,
+        "diffCount": 8,
+        "changedCount": 8,
+        "categories": {"cc": 3, "table_cell": 3, "char_offsets": 2},
+        "invalid": [],
+        "verify": {"identical": false, "diffCount": 8},
+        "exitClass": 3
+      }
+    },
+    {
+      "candidateId": "c_identical",
+      "expectedRank": 1,
+      "changedCount": 0,
+      "invalid": [],
+      "verify": {"identical": true, "diffCount": 0},
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "left": "samples/gov/국세청/고시/2020/0044.hwpx",
+        "right": "out/v-bon/ir-same.hwp",
+        "identical": true,
+        "diffCount": 0,
+        "changedCount": 0,
+        "categories": {},
+        "invalid": [],
+        "verify": {"identical": true, "diffCount": 0},
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_small",
+      "expectedRank": 2,
+      "changedCount": 2,
+      "invalid": [],
+      "verify": {"identical": false, "diffCount": 2},
+      "exitClass": 3,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "left": "samples/gov/국세청/고시/2020/0044.hwpx",
+        "right": "out/v-bon/ir-small.hwp",
+        "identical": false,
+        "diffCount": 2,
+        "changedCount": 2,
+        "categories": {"cc": 1, "char_offsets": 1},
+        "invalid": [],
+        "verify": {"identical": false, "diffCount": 2},
+        "exitClass": 3
+      }
+    }
+  ]
+}

--- a/tools/llm_verifier/best_of_n/fixtures/mixed_invalid.json
+++ b/tools/llm_verifier/best_of_n/fixtures/mixed_invalid.json
@@ -1,0 +1,90 @@
+{
+  "schemaVersion": "1.0",
+  "claim": "V-bon",
+  "kind": "bestOfNSet",
+  "setId": "fixture-mixed-invalid",
+  "command": "csv-to-table",
+  "mode": "verify",
+  "argv": ["rhwp", "csv-to-table", "--verify", "--json"],
+  "n": 3,
+  "intendedChangedCount": 9,
+  "sample": "samples/gov/특허청/서식/2019/0088.hwp",
+  "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+  "candidates": [
+    {
+      "candidateId": "c_ok",
+      "expectedRank": 1,
+      "changedCount": 9,
+      "invalid": [],
+      "verify": {"identical": true, "diffCount": 0},
+      "exitClass": 0,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/특허청/서식/2019/0088.hwp",
+        "csv": "samples/gov/특허청/서식/2019/0088.csv",
+        "table": 1,
+        "rowCount": 19,
+        "colCount": 9,
+        "changedCount": 9,
+        "changed": [],
+        "invalid": [],
+        "dryRun": false,
+        "verify": {"identical": true, "diffCount": 0},
+        "exitClass": 0
+      }
+    },
+    {
+      "candidateId": "c_io",
+      "expectedRank": 2,
+      "changedCount": 0,
+      "invalid": [],
+      "verify": null,
+      "exitClass": 1,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/특허청/서식/2019/missing.hwp",
+        "error": "io",
+        "changedCount": 0,
+        "invalid": [],
+        "verify": null,
+        "exitClass": 1
+      }
+    },
+    {
+      "candidateId": "c_invalid",
+      "expectedRank": 3,
+      "changedCount": 0,
+      "invalid": [
+        {
+          "reason": "rowCountMismatch",
+          "expected": 19,
+          "actual": 12,
+          "message": "CSV rows != table rows"
+        }
+      ],
+      "verify": null,
+      "exitClass": 2,
+      "envelope": {
+        "schemaVersion": "1.0",
+        "source": "samples/gov/특허청/서식/2019/0088.hwp",
+        "csv": "samples/gov/특허청/서식/2019/0088-bad.csv",
+        "table": 1,
+        "rowCount": 19,
+        "colCount": 9,
+        "changedCount": 0,
+        "changed": [],
+        "invalid": [
+          {
+            "reason": "rowCountMismatch",
+            "expected": 19,
+            "actual": 12,
+            "message": "CSV rows != table rows"
+          }
+        ],
+        "dryRun": false,
+        "verify": null,
+        "exitClass": 2
+      }
+    }
+  ]
+}

--- a/tools/llm_verifier/best_of_n/generate_corpus.py
+++ b/tools/llm_verifier/best_of_n/generate_corpus.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python3
+"""Emit the V-bon Best-of-N corpus of distinct candidate sets.
+
+Each set is N final-outcome envelopes (dry-run / --verify / ir-diff) plus
+an expectedRank computed by rank.py. process_steps is never written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from envelopes import lift_candidate_record  # noqa: E402
+from rank import CLAIM_ID, SCHEMA_VERSION, rank_candidates  # noqa: E402
+from schema import CommandFamily, Mode, invalid_fingerprint  # noqa: E402
+
+CORPUS = HERE / "corpus"
+DEFAULT_MIN_LINES = 102000
+DEFAULT_MIN_SETS = 1666
+SETS_PER_SHARD = 64
+
+AGENCIES = (
+    "법제처",
+    "행정안전부",
+    "국세청",
+    "대법원",
+    "특허청",
+    "교육부",
+    "보건복지부",
+    "국토교통부",
+    "고용노동부",
+    "외교부",
+    "기획재정부",
+    "공정거래위원회",
+    "금융위원회",
+    "방송통신위원회",
+    "개인정보보호위원회",
+    "국민권익위원회",
+    "국가인권위원회",
+    "통계청",
+    "기상청",
+    "관세청",
+    "검찰청",
+    "경찰청",
+    "소방청",
+    "해양경찰청",
+    "병무청",
+    "산림청",
+    "농촌진흥청",
+    "중소벤처기업부",
+    "과학기술정보통신부",
+    "문화체육관광부",
+    "환경부",
+    "해양수산부",
+)
+
+KINDS = (
+    "고시",
+    "훈령",
+    "예규",
+    "공고",
+    "지침",
+    "서식",
+    "질의회신",
+    "업무계획",
+    "예산서",
+    "회의록",
+    "계약서",
+    "점검표",
+)
+
+YEARS = tuple(range(2016, 2027))
+
+FIELD_NAMES = (
+    "신청인",
+    "생년월일",
+    "주소",
+    "연락처",
+    "전자우편",
+    "사업자등록번호",
+    "법인명",
+    "대표자",
+    "담당부서",
+    "담당자",
+    "문서번호",
+    "시행일자",
+    "수신",
+    "제목",
+    "금액",
+    "계좌번호",
+    "주민등록번호",
+    "면허번호",
+    "시설위치",
+    "처리기한",
+)
+
+CELL_LABELS = (
+    "구분",
+    "성명",
+    "직급",
+    "소속",
+    "연락처",
+    "비고",
+    "수량",
+    "단가",
+    "금액",
+    "일자",
+)
+
+IR_CATEGORIES = (
+    "para_count",
+    "char_offsets",
+    "table_cell",
+    "ctrl_id",
+    "section_def",
+    "cc",
+    "bullet",
+    "header_footer",
+)
+
+
+@dataclass(frozen=True)
+class OutcomeCell:
+    name: str
+    invalid: Any
+    exit_class: int
+    identical: bool | None
+    offset: int
+    absolute: int | None = None
+
+    def changed_count(self, intended: int) -> int:
+        if self.absolute is not None:
+            return self.absolute
+        return max(0, intended + self.offset)
+
+
+def _inv(reason: str, **extra: Any) -> list[dict[str, Any]]:
+    item = {"reason": reason, **extra}
+    return [item]
+
+
+VERIFY_CELLS: tuple[OutcomeCell, ...] = (
+    OutcomeCell("exact_ok", [], 0, True, 0),
+    OutcomeCell("over_1", [], 0, True, 1),
+    OutcomeCell("over_2", [], 0, True, 2),
+    OutcomeCell("over_3", [], 0, True, 3),
+    OutcomeCell("over_5", [], 0, True, 5),
+    OutcomeCell("over_8", [], 0, True, 8),
+    OutcomeCell("under_1", [], 0, True, -1),
+    OutcomeCell("under_2", [], 0, True, -2),
+    OutcomeCell("under_3", [], 0, True, -3),
+    OutcomeCell("zero_change", [], 0, True, 0, 0),
+    OutcomeCell("verify_fail", [], 3, False, 0),
+    OutcomeCell("verify_fail_over", [], 3, False, 2),
+    OutcomeCell("verify_fail_big", [], 3, False, 8),
+    OutcomeCell("exit0_ident_false", [], 0, False, 0),
+    OutcomeCell("exit3_ident_true", [], 3, True, 0),
+    OutcomeCell("page_fail", [], 4, False, 0),
+    OutcomeCell("page_fail_over", [], 4, False, 3),
+    OutcomeCell("io_missing", [], 1, None, 0, 0),
+    OutcomeCell("usage_flag", [], 2, None, 0, 0),
+    OutcomeCell("invalid_dim", _inv("rowCountMismatch", expected=12, actual=9), 2, None, 0, 0),
+    OutcomeCell("invalid_field", _inv("notFound", name="신청인"), 2, None, 0, 0),
+    OutcomeCell("invalid_covered", _inv("coveredCellNotEmpty", row=2, col=1), 2, None, 0, 0),
+    OutcomeCell("invalid_control", _inv("controlCharacter", row=1, col=0), 2, None, 0, 0),
+    OutcomeCell("invalid_bool", True, 2, None, 0, 0),
+    OutcomeCell("verify_omitted", [], 0, None, 0),
+    OutcomeCell("under_zero_exit3", [], 3, False, 0, 0),
+)
+
+DRY_CELLS: tuple[OutcomeCell, ...] = (
+    OutcomeCell("dry_exact", [], 0, None, 0),
+    OutcomeCell("dry_over_1", [], 0, None, 1),
+    OutcomeCell("dry_over_2", [], 0, None, 2),
+    OutcomeCell("dry_over_4", [], 0, None, 4),
+    OutcomeCell("dry_under_1", [], 0, None, -1),
+    OutcomeCell("dry_under_2", [], 0, None, -2),
+    OutcomeCell("dry_zero", [], 0, None, 0, 0),
+    OutcomeCell("dry_io", [], 1, None, 0, 0),
+    OutcomeCell("dry_usage", [], 2, None, 0, 0),
+    OutcomeCell("dry_invalid_dim", _inv("rowCountMismatch", expected=8, actual=5), 2, None, 0, 0),
+    OutcomeCell("dry_invalid_field", _inv("notFound", name="문서번호"), 2, None, 0, 0),
+    OutcomeCell("dry_invalid_covered", _inv("coveredCellNotEmpty", row=3, col=2), 2, None, 0, 0),
+    OutcomeCell("dry_invalid_control", _inv("controlCharacter", row=0, col=4), 2, None, 0, 0),
+    OutcomeCell("dry_invalid_bool", True, 2, None, 0, 0),
+    OutcomeCell("dry_page", [], 4, None, 0, 0),
+    OutcomeCell("dry_over_7", [], 0, None, 7),
+)
+
+IR_CELLS: tuple[OutcomeCell, ...] = (
+    OutcomeCell("ir_identical", [], 0, True, 0, 0),
+    OutcomeCell("ir_one", [], 3, False, 0, 1),
+    OutcomeCell("ir_two", [], 3, False, 0, 2),
+    OutcomeCell("ir_three", [], 3, False, 0, 3),
+    OutcomeCell("ir_five", [], 3, False, 0, 5),
+    OutcomeCell("ir_eight", [], 3, False, 0, 8),
+    OutcomeCell("ir_twelve", [], 3, False, 0, 12),
+    OutcomeCell("ir_exit0_false", [], 0, False, 0, 2),
+    OutcomeCell("ir_exit3_true", [], 3, True, 0, 0),
+    OutcomeCell("ir_io", [], 1, None, 0, 0),
+    OutcomeCell("ir_usage", [], 2, None, 0, 0),
+    OutcomeCell("ir_page", [], 4, False, 0, 4),
+    OutcomeCell("ir_invalid", _inv("leftUnreadable"), 1, None, 0, 0),
+    OutcomeCell("ir_omitted", [], 0, None, 0, 0),
+)
+
+COMMAND_MODES: tuple[tuple[CommandFamily, Mode], ...] = (
+    (CommandFamily.FILL_FIELDS, Mode.VERIFY),
+    (CommandFamily.FILL_FIELDS, Mode.DRY_RUN),
+    (CommandFamily.CSV_TO_TABLE, Mode.VERIFY),
+    (CommandFamily.CSV_TO_TABLE, Mode.DRY_RUN),
+    (CommandFamily.IR_DIFF, Mode.IR_DIFF),
+    (CommandFamily.CONVERT, Mode.VERIFY),
+    (CommandFamily.REPLACE_TEXT, Mode.VERIFY),
+    (CommandFamily.REPLACE_TEXT, Mode.DRY_RUN),
+    (CommandFamily.REDACT, Mode.DRY_RUN),
+    (CommandFamily.REDACT, Mode.VERIFY),
+    (CommandFamily.SET_CELL, Mode.VERIFY),
+    (CommandFamily.SET_CELL, Mode.DRY_RUN),
+    (CommandFamily.CSV_TO_CHART, Mode.DRY_RUN),
+    (CommandFamily.CSV_TO_CHART, Mode.VERIFY),
+    (CommandFamily.SANITIZE, Mode.DRY_RUN),
+    (CommandFamily.SANITIZE, Mode.VERIFY),
+    (CommandFamily.RUN, Mode.VERIFY),
+)
+
+N_VALUES = (2, 3, 4, 5, 6, 7, 8)
+INTENDED_VALUES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 16, 20)
+
+
+def cells_for(mode: Mode) -> tuple[OutcomeCell, ...]:
+    if mode is Mode.DRY_RUN:
+        return DRY_CELLS
+    if mode is Mode.IR_DIFF:
+        return IR_CELLS
+    return VERIFY_CELLS
+
+
+def pick_cells(mode: Mode, n: int, salt: int) -> list[OutcomeCell]:
+    pool = cells_for(mode)
+    start = salt % len(pool)
+    picked: list[OutcomeCell] = []
+    for i in range(n):
+        picked.append(pool[(start + i * (1 + salt % 3)) % len(pool)])
+    # Guarantee distinct cell names in a set; walk forward on collision.
+    names = set()
+    unique: list[OutcomeCell] = []
+    cursor = start
+    guard = 0
+    for cell in picked:
+        current = cell
+        while current.name in names:
+            cursor = (cursor + 1) % len(pool)
+            current = pool[cursor]
+            guard += 1
+            if guard > len(pool) * 3:
+                raise RuntimeError("cannot pick distinct outcome cells")
+        names.add(current.name)
+        unique.append(current)
+    return unique
+
+
+def sample_identity(index: int) -> dict[str, Any]:
+    agency = AGENCIES[index % len(AGENCIES)]
+    kind = KINDS[(index // len(AGENCIES)) % len(KINDS)]
+    year = YEARS[(index // (len(AGENCIES) * len(KINDS))) % len(YEARS)]
+    serial = 1 + (index % 997)
+    ext = "hwpx" if index % 3 else "hwp"
+    rel = f"samples/gov/{agency}/{kind}/{year}/{serial:04d}.{ext}"
+    return {
+        "agency": agency,
+        "docKind": kind,
+        "year": year,
+        "serial": serial,
+        "sample": rel,
+        "sourceFormat": "hwpx" if ext == "hwpx" else "hwp5",
+        "output": f"out/v-bon/{agency}/{kind}/{year}/{serial:04d}.out.{ext}",
+    }
+
+
+def field_plan(intended: int, salt: int) -> list[str]:
+    n = max(1, intended)
+    return [FIELD_NAMES[(salt + i) % len(FIELD_NAMES)] for i in range(n)]
+
+
+def filled_items(plan: list[str], count: int, salt: int) -> list[dict[str, Any]]:
+    items = []
+    listed = min(count, 4)
+    for i in range(listed):
+        name = plan[i % len(plan)] if plan else FIELD_NAMES[i % len(FIELD_NAMES)]
+        items.append(
+            {
+                "name": name,
+                "occurrence": i // max(1, len(plan)),
+                "value": f"{name}-{salt:04d}-{i:02d}",
+            }
+        )
+    return items
+
+
+def changed_cells(count: int, salt: int, rows: int, cols: int) -> list[dict[str, Any]]:
+    items = []
+    for i in range(count):
+        row = 1 + ((salt + i) % max(1, rows - 1))
+        col = (salt + i * 3) % cols
+        items.append(
+            {
+                "row": row,
+                "col": col,
+                "oldText": f"old-{salt}-{row}-{col}",
+                "newText": f"new-{salt}-{row}-{col}-{i}",
+            }
+        )
+        if len(items) >= 4:
+            break
+    return items
+
+
+def ir_categories(diff_count: int, salt: int) -> dict[str, int]:
+    if diff_count <= 0:
+        return {}
+    cats: dict[str, int] = {}
+    remaining = diff_count
+    idx = 0
+    while remaining > 0:
+        name = IR_CATEGORIES[(salt + idx) % len(IR_CATEGORIES)]
+        take = 1 + ((salt + idx) % 3)
+        take = min(take, remaining)
+        cats[name] = cats.get(name, 0) + take
+        remaining -= take
+        idx += 1
+    return cats
+
+
+def build_envelope(
+    command: CommandFamily,
+    mode: Mode,
+    ident: dict[str, Any],
+    cell: OutcomeCell,
+    intended: int,
+    salt: int,
+) -> dict[str, Any]:
+    changed = cell.changed_count(intended)
+    dry = mode is Mode.DRY_RUN
+    verify: dict[str, Any] | None
+    if cell.identical is None:
+        verify = None
+    else:
+        verify = {
+            "identical": cell.identical,
+            "diffCount": 0 if cell.identical else max(1, abs(changed - intended) + (salt % 4)),
+        }
+    plan = field_plan(max(intended, 1), salt)
+    rows = 6 + (salt % 17)
+    cols = 3 + (salt % 6)
+    env: dict[str, Any] = {
+        "schemaVersion": "1.0",
+        "source": ident["sample"],
+        "dryRun": dry,
+        "changedCount": changed,
+        "invalid": cell.invalid,
+        "exitClass": cell.exit_class,
+    }
+    if command is CommandFamily.FILL_FIELDS:
+        env.update(
+            {
+                "filledCount": changed,
+                "notFound": [] if not cell.invalid else [plan[0]],
+                "ambiguous": [],
+                "filled": filled_items(plan, changed, salt),
+                "changedPages": None if dry else [0, salt % 3],
+            }
+        )
+    elif command is CommandFamily.CSV_TO_TABLE:
+        env.update(
+            {
+                "csv": ident["sample"].replace(".hwp", ".csv").replace(".hwpx", ".csv"),
+                "table": salt % 5,
+                "rowCount": rows,
+                "colCount": cols,
+                "changed": changed_cells(min(changed, 8), salt, rows, cols),
+                "changedPages": None if dry else [0],
+            }
+        )
+    elif command is CommandFamily.IR_DIFF:
+        env.pop("dryRun", None)
+        env.update(
+            {
+                "left": ident["sample"],
+                "right": ident["output"],
+                "identical": bool(cell.identical) if cell.identical is not None else False,
+                "diffCount": changed,
+                "categories": ir_categories(changed, salt),
+            }
+        )
+        if cell.identical is None:
+            env["identical"] = None
+    elif command is CommandFamily.CONVERT:
+        env.update(
+            {
+                "outputFormat": "hwp5",
+                "wasDistribution": bool(salt % 2),
+                "bytes": 40_000 + salt * 17 + changed * 64,
+            }
+        )
+    elif command is CommandFamily.REPLACE_TEXT:
+        env.update(
+            {
+                "replacedCount": changed,
+                "find": CELL_LABELS[salt % len(CELL_LABELS)],
+                "replace": f"치환-{salt}",
+                "occurrence": None if changed != 1 else 1 + (salt % 4),
+            }
+        )
+    elif command is CommandFamily.REDACT:
+        env.update(
+            {
+                "findingCount": max(changed, 1 if cell.exit_class == 0 else 0),
+                "redactedCount": 0 if dry else changed,
+                "kinds": ["rrn", "phone", "email"][ : 1 + (salt % 3)],
+            }
+        )
+    elif command is CommandFamily.SET_CELL:
+        env.update(
+            {
+                "table": salt % 4,
+                "row": 1 + (salt % rows),
+                "col": salt % cols,
+                "oldText": f"old-{salt}",
+                "newText": f"new-{salt}-{changed}",
+                "overflow": False,
+            }
+        )
+    elif command is CommandFamily.CSV_TO_CHART:
+        env.update(
+            {
+                "chart": 1 + (salt % 6),
+                "csv": ident["sample"].rsplit(".", 1)[0] + ".chart.csv",
+                "changed": [
+                    {"series": 1 + (i % 3), "point": i, "from": float(i), "to": float(i + salt % 5)}
+                    for i in range(min(changed, 6))
+                ],
+            }
+        )
+    elif command is CommandFamily.SANITIZE:
+        env.update(
+            {
+                "removedCount": changed,
+                "removed": [f"meta:{k}" for k in ("author", "company", "date")[: max(0, min(3, changed))]],
+            }
+        )
+    elif command is CommandFamily.RUN:
+        env.update(
+            {
+                "planVersion": "1.0",
+                "assertions": {"verify": mode is Mode.VERIFY, "notFoundEmpty": True},
+                "steps": [
+                    {"action": "fill_fields", "filledCount": min(changed, intended), "invalid": []}
+                ],
+            }
+        )
+    if not dry and command is not CommandFamily.IR_DIFF:
+        env["output"] = ident["output"]
+        env["outputFormat"] = ident["sourceFormat"]
+    if command is CommandFamily.IR_DIFF:
+        if cell.identical is not None:
+            env["verify"] = {"identical": cell.identical, "diffCount": changed}
+        else:
+            env["verify"] = None
+    else:
+        env["verify"] = verify
+    return env
+
+
+def argv_for(command: CommandFamily, mode: Mode) -> list[str]:
+    flags = list(mode.argv_flag())
+    return ["rhwp", *command.argv_head, *flags]
+
+
+def make_set(
+    serial: int,
+    command: CommandFamily,
+    mode: Mode,
+    n: int,
+    intended: int,
+    ident_index: int,
+) -> dict[str, Any]:
+    ident = sample_identity(ident_index)
+    cells = pick_cells(mode, n, serial * 17 + ident_index)
+    raw_candidates: list[dict[str, Any]] = []
+    outcomes = []
+    for idx, cell in enumerate(cells):
+        cid = f"c{idx}"
+        env = build_envelope(command, mode, ident, cell, intended, serial + idx * 13)
+        rec = {
+            "candidateId": cid,
+            "archetype": cell.name,
+            "changedCount": cell.changed_count(intended),
+            "invalid": cell.invalid,
+            "verify": env.get("verify"),
+            "exitClass": cell.exit_class,
+            "envelope": env,
+        }
+        raw_candidates.append(rec)
+        outcomes.append(lift_candidate_record(rec))
+    ranked = rank_candidates(
+        outcomes,
+        intended_changed_count=intended,
+        set_id=f"v-bon-{serial:06d}",
+        command=command.value,
+        mode=mode.value,
+    )
+    by_id = {row.candidate.candidate_id: row.expected_rank for row in ranked.ranking}
+    for rec in raw_candidates:
+        rec["expectedRank"] = by_id[rec["candidateId"]]
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "claim": CLAIM_ID,
+        "kind": "bestOfNSet",
+        "setId": f"v-bon-{serial:06d}",
+        "command": command.value,
+        "mode": mode.value,
+        "argv": argv_for(command, mode),
+        "n": n,
+        "intendedChangedCount": intended,
+        "sample": ident["sample"],
+        "sourceFormat": ident["sourceFormat"],
+        "agency": ident["agency"],
+        "docKind": ident["docKind"],
+        "year": ident["year"],
+        "serial": ident["serial"],
+        "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+        "winnerId": ranked.winner_id,
+        "candidates": raw_candidates,
+    }
+
+
+def identity_key(blob: dict[str, Any]) -> tuple[Any, ...]:
+    cands = tuple(
+        (
+            rec["candidateId"],
+            rec["archetype"],
+            rec["changedCount"],
+            invalid_fingerprint(rec["invalid"]),
+            None
+            if rec["verify"] is None
+            else rec["verify"].get("identical")
+            if isinstance(rec["verify"], dict)
+            else rec["verify"],
+            rec["exitClass"],
+            rec["expectedRank"],
+        )
+        for rec in blob["candidates"]
+    )
+    return (
+        blob["command"],
+        blob["mode"],
+        blob["sample"],
+        blob["intendedChangedCount"],
+        blob["n"],
+        cands,
+    )
+
+
+def axis_iter():
+    serial = 0
+    ident_index = 0
+    while True:
+        for command, mode in COMMAND_MODES:
+            for n in N_VALUES:
+                for intended in INTENDED_VALUES:
+                    serial += 1
+                    ident_index += 1
+                    yield serial, command, mode, n, intended, ident_index
+
+
+def dump_json(path: Path, payload: Any) -> int:
+    text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+    path.write_text(text, encoding="utf-8", newline="\n")
+    return text.count("\n")
+
+
+def generate(
+    min_lines: int,
+    sets_per_shard: int,
+    out_dir: Path,
+    min_sets: int = DEFAULT_MIN_SETS,
+) -> dict[str, Any]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for stale in out_dir.glob("shard_*.json"):
+        stale.unlink()
+    sets: list[dict[str, Any]] = []
+    keys: set[tuple[Any, ...]] = set()
+    # Generate in memory per shard to keep peak memory bounded.
+    shards: list[dict[str, Any]] = []
+    shard_buf: list[dict[str, Any]] = []
+    total_lines = 0
+    for serial, command, mode, n, intended, ident_index in axis_iter():
+        blob = make_set(serial, command, mode, n, intended, ident_index)
+        key = identity_key(blob)
+        if key in keys:
+            raise RuntimeError(f"duplicate identity at {blob['setId']}")
+        keys.add(key)
+        sets.append(blob)
+        shard_buf.append(blob)
+        if len(shard_buf) >= sets_per_shard:
+            name = f"shard_{len(shards):04d}.json"
+            written = dump_json(out_dir / name, shard_buf)
+            total_lines += written
+            shards.append(
+                {
+                    "path": f"corpus/{name}",
+                    "sets": len(shard_buf),
+                    "lines": written,
+                    "first": shard_buf[0]["setId"],
+                    "last": shard_buf[-1]["setId"],
+                }
+            )
+            shard_buf = []
+            if total_lines >= min_lines and len(sets) >= min_sets:
+                break
+        if serial > 30000:
+            raise RuntimeError("failed to reach min_lines/min_sets before safety cap")
+    if shard_buf and (total_lines < min_lines or len(sets) < min_sets):
+        name = f"shard_{len(shards):04d}.json"
+        written = dump_json(out_dir / name, shard_buf)
+        total_lines += written
+        shards.append(
+            {
+                "path": f"corpus/{name}",
+                "sets": len(shard_buf),
+                "lines": written,
+                "first": shard_buf[0]["setId"],
+                "last": shard_buf[-1]["setId"],
+            }
+        )
+    elif shard_buf:
+        # Flush remainder even after the line gate so the last sets are kept.
+        name = f"shard_{len(shards):04d}.json"
+        written = dump_json(out_dir / name, shard_buf)
+        total_lines += written
+        shards.append(
+            {
+                "path": f"corpus/{name}",
+                "sets": len(shard_buf),
+                "lines": written,
+                "first": shard_buf[0]["setId"],
+                "last": shard_buf[-1]["setId"],
+            }
+        )
+
+    by_command: dict[str, int] = {}
+    by_mode: dict[str, int] = {}
+    for blob in sets:
+        by_command[blob["command"]] = by_command.get(blob["command"], 0) + 1
+        by_mode[blob["mode"]] = by_mode.get(blob["mode"], 0) + 1
+
+    manifest = {
+        "schemaVersion": SCHEMA_VERSION,
+        "claim": CLAIM_ID,
+        "kind": "bestOfNCorpus",
+        "setCount": len(sets),
+        "shardCount": len(shards),
+        "lineCount": total_lines,
+        "minLines": min_lines,
+        "minSets": min_sets,
+        "setsPerShard": sets_per_shard,
+        "rankFields": ["changedCount", "invalid", "verify.identical", "exitClass"],
+        "forbidden": ["process_steps", "processSteps", "proseScore", "llmScore"],
+        "byCommand": dict(sorted(by_command.items())),
+        "byMode": dict(sorted(by_mode.items())),
+        "shards": shards,
+        "notes": [
+            "Each record is a distinct N-candidate outcome set, not comment padding.",
+            "expectedRank is rank.py of changedCount/invalid/verify.identical/exitClass.",
+            "V-step process_steps is out of scope (#5490).",
+        ],
+    }
+    dump_json(out_dir / "manifest.json", manifest)
+    if total_lines < min_lines:
+        raise RuntimeError(f"lineCount {total_lines} < min_lines {min_lines}")
+    # `sets` after the break may omit a flushed remainder already counted; recount.
+    recounted = 0
+    for shard in shards:
+        recounted += shard["sets"]
+    manifest["setCount"] = recounted
+    dump_json(out_dir / "manifest.json", manifest)
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--min-lines", type=int, default=DEFAULT_MIN_LINES)
+    parser.add_argument("--min-sets", type=int, default=DEFAULT_MIN_SETS)
+    parser.add_argument("--sets-per-shard", type=int, default=SETS_PER_SHARD)
+    parser.add_argument("--out-dir", type=Path, default=CORPUS)
+    args = parser.parse_args(argv)
+    manifest = generate(
+        args.min_lines, args.sets_per_shard, args.out_dir, min_sets=args.min_sets
+    )
+    json.dump(
+        {
+            "setCount": manifest["setCount"],
+            "lineCount": manifest["lineCount"],
+            "shards": manifest["shardCount"],
+        },
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/llm_verifier/best_of_n/rank.py
+++ b/tools/llm_verifier/best_of_n/rank.py
@@ -1,0 +1,270 @@
+"""Best-of-N outcome ranker.
+
+Order is a closed lexicographic key of existing envelope fields:
+
+    (invalid, exitClass, verify.identical, |changedCount-intended|, changedCount, id)
+
+Lower is better. There is no prose score and no per-step process reward.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+try:
+    from .envelopes import envelope_looks_inconsistent, lift_candidate_record
+    from .schema import (
+        FORBIDDEN_KEYS,
+        RANK_FIELDS,
+        CandidateOutcome,
+        CandidateSet,
+        CommandFamily,
+        Mode,
+        invalid_is_set,
+    )
+except ImportError:
+    from envelopes import envelope_looks_inconsistent, lift_candidate_record
+    from schema import (
+        FORBIDDEN_KEYS,
+        RANK_FIELDS,
+        CandidateOutcome,
+        CandidateSet,
+        CommandFamily,
+        Mode,
+        invalid_is_set,
+    )
+
+CLAIM_ID = "V-bon"
+SCHEMA_VERSION = "1.0"
+KIND = "bestOfNRanking"
+
+# Smaller is better. 0 = rhwp success, 3 = judgment (tool ran), 4/1/2 worse.
+EXIT_RANK: dict[int, int] = {
+    0: 0,
+    3: 1,
+    4: 2,
+    1: 3,
+    2: 4,
+}
+
+
+@dataclass(frozen=True)
+class OutcomeKey:
+    invalid_rank: int
+    exit_rank: int
+    identical_rank: int
+    change_delta: int
+    changed_count: int
+    candidate_id: str
+
+    def as_tuple(self) -> tuple[int, int, int, int, int, str]:
+        return (
+            self.invalid_rank,
+            self.exit_rank,
+            self.identical_rank,
+            self.change_delta,
+            self.changed_count,
+            self.candidate_id,
+        )
+
+    def to_json(self) -> dict[str, int | str]:
+        return {
+            "invalidRank": self.invalid_rank,
+            "exitRank": self.exit_rank,
+            "identicalRank": self.identical_rank,
+            "changeDelta": self.change_delta,
+            "changedCount": self.changed_count,
+            "candidateId": self.candidate_id,
+        }
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    candidate: CandidateOutcome
+    key: OutcomeKey
+    expected_rank: int
+    inconsistent: bool
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "candidateId": self.candidate.candidate_id,
+            "expectedRank": self.expected_rank,
+            "changedCount": self.candidate.changed_count,
+            "invalid": self.candidate.invalid,
+            "verify": (
+                None
+                if self.candidate.verify_identical is None
+                else {"identical": self.candidate.verify_identical}
+            ),
+            "exitClass": self.candidate.exit_class,
+            "inconsistent": self.inconsistent,
+            "key": self.key.to_json(),
+        }
+
+
+@dataclass(frozen=True)
+class RankedSet:
+    set_id: str
+    command: str
+    mode: str
+    n: int
+    intended_changed_count: int
+    ranking: tuple[RankedCandidate, ...]
+    winner_id: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "claim": CLAIM_ID,
+            "kind": KIND,
+            "setId": self.set_id,
+            "command": self.command,
+            "mode": self.mode,
+            "n": self.n,
+            "intendedChangedCount": self.intended_changed_count,
+            "winnerId": self.winner_id,
+            "rankFields": list(RANK_FIELDS),
+            "ranking": [row.to_json() for row in self.ranking],
+        }
+
+
+def identical_rank(value: bool | None) -> int:
+    if value is True:
+        return 0
+    if value is None:
+        return 1
+    return 2
+
+
+def outcome_key(candidate: CandidateOutcome, intended_changed_count: int) -> OutcomeKey:
+    changed = candidate.changed_count
+    if changed < 0:
+        raise ValueError(f"changedCount must be >= 0, got {changed}")
+    return OutcomeKey(
+        invalid_rank=1 if invalid_is_set(candidate.invalid) else 0,
+        exit_rank=EXIT_RANK.get(candidate.exit_class, 5),
+        identical_rank=identical_rank(candidate.verify_identical),
+        change_delta=abs(changed - intended_changed_count),
+        changed_count=changed,
+        candidate_id=candidate.candidate_id,
+    )
+
+
+def rank_candidates(
+    candidates: Sequence[CandidateOutcome],
+    *,
+    intended_changed_count: int,
+    set_id: str = "",
+    command: str = "",
+    mode: str = "",
+) -> RankedSet:
+    if not candidates:
+        raise ValueError("Best-of-N requires at least one candidate")
+    if intended_changed_count < 0:
+        raise ValueError("intendedChangedCount must be >= 0")
+    ids = [c.candidate_id for c in candidates]
+    if len(ids) != len(set(ids)):
+        raise ValueError(f"duplicate candidateId in set {set_id or ids}")
+
+    keyed = [(outcome_key(c, intended_changed_count), c) for c in candidates]
+    keyed.sort(key=lambda item: item[0].as_tuple())
+
+    ranked: list[RankedCandidate] = []
+    prev_cmp: tuple[int, int, int, int, int] | None = None
+    rank = 0
+    for index, (key, cand) in enumerate(keyed, start=1):
+        cmp = (
+            key.invalid_rank,
+            key.exit_rank,
+            key.identical_rank,
+            key.change_delta,
+            key.changed_count,
+        )
+        if prev_cmp != cmp:
+            rank = index
+            prev_cmp = cmp
+        ranked.append(
+            RankedCandidate(
+                candidate=cand,
+                key=key,
+                expected_rank=rank,
+                inconsistent=envelope_looks_inconsistent(cand),
+            )
+        )
+    return RankedSet(
+        set_id=set_id,
+        command=command,
+        mode=mode,
+        n=len(ranked),
+        intended_changed_count=intended_changed_count,
+        ranking=tuple(ranked),
+        winner_id=ranked[0].candidate.candidate_id,
+    )
+
+
+def rank_set(candidate_set: CandidateSet) -> RankedSet:
+    return rank_candidates(
+        candidate_set.candidates,
+        intended_changed_count=candidate_set.intended_changed_count,
+        set_id=candidate_set.set_id,
+        command=candidate_set.command.value,
+        mode=candidate_set.mode.value,
+    )
+
+
+def rank_mapping(blob: Mapping[str, Any]) -> RankedSet:
+    for key in FORBIDDEN_KEYS:
+        if key in blob:
+            raise ValueError(f"V-bon refuses process/prose field {key} (see #5490)")
+    raw_candidates = blob.get("candidates")
+    if not isinstance(raw_candidates, Iterable) or isinstance(raw_candidates, (str, bytes)):
+        raise ValueError("candidates must be a list")
+    candidates = [lift_candidate_record(row) for row in raw_candidates]
+    command = str(blob.get("command") or "")
+    mode = str(blob.get("mode") or "")
+    intended = blob.get("intendedChangedCount", 0)
+    if not isinstance(intended, int) or isinstance(intended, bool):
+        raise ValueError("intendedChangedCount must be an int")
+    return rank_candidates(
+        candidates,
+        intended_changed_count=intended,
+        set_id=str(blob.get("setId") or blob.get("id") or ""),
+        command=command,
+        mode=mode,
+    )
+
+
+def expected_ranks_match(blob: Mapping[str, Any]) -> list[str]:
+    """Return mismatches of recorded expectedRank vs the ranker."""
+    computed = rank_mapping(blob)
+    by_id = {row.candidate.candidate_id: row.expected_rank for row in computed.ranking}
+    errors: list[str] = []
+    for row in blob.get("candidates") or ():
+        cid = str(row.get("candidateId") or row.get("id") or "")
+        if "expectedRank" not in row:
+            errors.append(f"{cid}: missing expectedRank")
+            continue
+        got = int(row["expectedRank"])
+        want = by_id[cid]
+        if got != want:
+            errors.append(f"{cid}: expectedRank={got} ranker={want}")
+    return errors
+
+
+def command_mode_ok(command: str, mode: str) -> bool:
+    try:
+        fam = CommandFamily(command)
+    except ValueError:
+        return False
+    try:
+        md = Mode(mode)
+    except ValueError:
+        return False
+    if md is Mode.IR_DIFF:
+        return fam is CommandFamily.IR_DIFF
+    if md is Mode.DRY_RUN:
+        return fam.has_dry_run
+    if md is Mode.VERIFY:
+        return fam.has_verify
+    return False

--- a/tools/llm_verifier/best_of_n/schema.py
+++ b/tools/llm_verifier/best_of_n/schema.py
@@ -1,0 +1,154 @@
+"""Closed types for V-bon outcome ranking.
+
+Field names follow existing rhwp JSON envelopes (knowledge map §2-2).
+This module does not invent a CLI or a process-step reward.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class CommandFamily(str, Enum):
+    FILL_FIELDS = "fill-fields"
+    CSV_TO_TABLE = "csv-to-table"
+    IR_DIFF = "ir-diff"
+    CONVERT = "convert"
+    REPLACE_TEXT = "replace-text"
+    REDACT = "redact"
+    SET_CELL = "set-cell"
+    CSV_TO_CHART = "csv-to-chart"
+    SANITIZE = "sanitize"
+    RUN = "run"
+
+    @property
+    def argv_head(self) -> tuple[str, ...]:
+        return {
+            CommandFamily.FILL_FIELDS: ("edit", "fill-fields"),
+            CommandFamily.CSV_TO_TABLE: ("csv-to-table",),
+            CommandFamily.IR_DIFF: ("ir-diff",),
+            CommandFamily.CONVERT: ("convert",),
+            CommandFamily.REPLACE_TEXT: ("edit", "replace-text"),
+            CommandFamily.REDACT: ("edit", "redact"),
+            CommandFamily.SET_CELL: ("edit", "set-cell"),
+            CommandFamily.CSV_TO_CHART: ("csv-to-chart",),
+            CommandFamily.SANITIZE: ("edit", "sanitize"),
+            CommandFamily.RUN: ("run",),
+        }[self]
+
+    @property
+    def has_dry_run(self) -> bool:
+        return self is not CommandFamily.IR_DIFF
+
+    @property
+    def has_verify(self) -> bool:
+        return self is not CommandFamily.IR_DIFF
+
+
+class Mode(str, Enum):
+    DRY_RUN = "dry-run"
+    VERIFY = "verify"
+    IR_DIFF = "ir-diff"
+
+    def argv_flag(self) -> tuple[str, ...]:
+        if self is Mode.DRY_RUN:
+            return ("--dry-run", "--json")
+        if self is Mode.VERIFY:
+            return ("--verify", "--json")
+        return ("--json",)
+
+
+RANK_FIELDS: tuple[str, ...] = (
+    "changedCount",
+    "invalid",
+    "verify.identical",
+    "exitClass",
+)
+
+# process_steps is V-step (#5490). V-bon must not read or emit it.
+FORBIDDEN_KEYS: tuple[str, ...] = (
+    "process_steps",
+    "processSteps",
+    "proseScore",
+    "llmScore",
+    "rubricScore",
+    "stepReward",
+)
+
+
+def invalid_is_set(invalid: Any) -> bool:
+    """True when the existing envelope says the candidate is invalid."""
+    if invalid is True:
+        return True
+    if invalid is False or invalid is None:
+        return False
+    if isinstance(invalid, (list, tuple)):
+        return len(invalid) > 0
+    if isinstance(invalid, dict):
+        return True
+    if isinstance(invalid, str):
+        return bool(invalid)
+    return bool(invalid)
+
+
+def invalid_fingerprint(invalid: Any) -> str:
+    if not invalid_is_set(invalid):
+        return "clean"
+    if invalid is True:
+        return "bool:true"
+    if isinstance(invalid, (list, tuple)):
+        reasons = []
+        for item in invalid:
+            if isinstance(item, Mapping):
+                reasons.append(str(item.get("reason", item.get("code", "item"))))
+            else:
+                reasons.append(str(item))
+        return "list:" + ",".join(reasons) if reasons else "list"
+    if isinstance(invalid, Mapping):
+        return f"obj:{invalid.get('reason', 'obj')}"
+    return f"other:{invalid!r}"
+
+
+@dataclass(frozen=True)
+class CandidateOutcome:
+    """One final candidate. Ranking reads only the four envelope fields."""
+
+    candidate_id: str
+    changed_count: int
+    invalid: Any
+    verify_identical: bool | None
+    exit_class: int
+    envelope: Mapping[str, Any] = field(default_factory=dict)
+
+    def is_invalid(self) -> bool:
+        return invalid_is_set(self.invalid)
+
+    def rank_tuple_payload(self) -> dict[str, Any]:
+        return {
+            "candidateId": self.candidate_id,
+            "changedCount": self.changed_count,
+            "invalid": self.invalid,
+            "verify": (
+                None
+                if self.verify_identical is None
+                else {"identical": self.verify_identical}
+            ),
+            "exitClass": self.exit_class,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateSet:
+    set_id: str
+    command: CommandFamily
+    mode: Mode
+    intended_changed_count: int
+    candidates: tuple[CandidateOutcome, ...]
+    sample: str = ""
+    source_format: str = "hwpx"
+
+    @property
+    def n(self) -> int:
+        return len(self.candidates)

--- a/tools/llm_verifier/best_of_n/schema/best_of_n_set.schema.json
+++ b/tools/llm_verifier/best_of_n/schema/best_of_n_set.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rhwp.local/schema/best_of_n_set.json",
+  "title": "V-bon Best-of-N candidate set",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "claim",
+    "kind",
+    "setId",
+    "command",
+    "mode",
+    "n",
+    "intendedChangedCount",
+    "rankFields",
+    "candidates"
+  ],
+  "additionalProperties": true,
+  "not": {
+    "anyOf": [
+      { "required": ["process_steps"] },
+      { "required": ["processSteps"] },
+      { "required": ["proseScore"] },
+      { "required": ["llmScore"] }
+    ]
+  },
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "claim": { "const": "V-bon" },
+    "kind": { "const": "bestOfNSet" },
+    "setId": { "type": "string" },
+    "command": {
+      "type": "string",
+      "enum": [
+        "fill-fields",
+        "csv-to-table",
+        "ir-diff",
+        "convert",
+        "replace-text",
+        "redact",
+        "set-cell",
+        "csv-to-chart",
+        "sanitize",
+        "run"
+      ]
+    },
+    "mode": { "type": "string", "enum": ["dry-run", "verify", "ir-diff"] },
+    "n": { "type": "integer", "minimum": 1 },
+    "intendedChangedCount": { "type": "integer", "minimum": 0 },
+    "rankFields": {
+      "type": "array",
+      "const": ["changedCount", "invalid", "verify.identical", "exitClass"]
+    },
+    "candidates": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/candidate" }
+    }
+  },
+  "$defs": {
+    "candidate": {
+      "type": "object",
+      "required": [
+        "candidateId",
+        "changedCount",
+        "invalid",
+        "exitClass",
+        "expectedRank"
+      ],
+      "properties": {
+        "candidateId": { "type": "string" },
+        "changedCount": { "type": "integer", "minimum": 0 },
+        "invalid": {},
+        "verify": {
+          "anyOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "identical": { "type": ["boolean", "null"] },
+                "diffCount": { "type": "integer", "minimum": 0 }
+              }
+            }
+          ]
+        },
+        "exitClass": { "type": "integer", "enum": [0, 1, 2, 3, 4] },
+        "expectedRank": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/tools/llm_verifier/best_of_n/schema/ranking.schema.json
+++ b/tools/llm_verifier/best_of_n/schema/ranking.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://rhwp.local/schema/best_of_n_ranking.json",
+  "title": "V-bon ranking output",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "claim",
+    "kind",
+    "setId",
+    "n",
+    "intendedChangedCount",
+    "winnerId",
+    "rankFields",
+    "ranking"
+  ],
+  "not": {
+    "anyOf": [
+      { "required": ["process_steps"] },
+      { "required": ["processSteps"] },
+      { "required": ["proseScore"] }
+    ]
+  },
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "claim": { "const": "V-bon" },
+    "kind": { "const": "bestOfNRanking" },
+    "rankFields": {
+      "const": ["changedCount", "invalid", "verify.identical", "exitClass"]
+    },
+    "winnerId": { "type": "string" },
+    "ranking": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "candidateId",
+          "expectedRank",
+          "changedCount",
+          "invalid",
+          "exitClass",
+          "key"
+        ]
+      }
+    }
+  }
+}

--- a/tools/llm_verifier/best_of_n/test_corpus.py
+++ b/tools/llm_verifier/best_of_n/test_corpus.py
@@ -1,0 +1,96 @@
+"""Corpus gates: distinct sets, expectedRank matches ranker, no process_steps."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from generate_corpus import identity_key
+from rank import expected_ranks_match
+from schema import FORBIDDEN_KEYS, RANK_FIELDS
+
+CORPUS = HERE / "corpus"
+MIN_LINES = 100000
+
+
+class CorpusTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        manifest_path = CORPUS / "manifest.json"
+        if not manifest_path.is_file():
+            raise unittest.SkipTest("corpus not generated")
+        cls.manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        cls.sets: list[dict] = []
+        for shard in cls.manifest["shards"]:
+            path = HERE / shard["path"]
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            cls.sets.extend(payload)
+
+    def test_line_count_meets_hard_gate(self) -> None:
+        counted = 0
+        for shard in self.manifest["shards"]:
+            text = (HERE / shard["path"]).read_text(encoding="utf-8")
+            counted += text.count("\n")
+        self.assertGreaterEqual(counted, MIN_LINES)
+        self.assertGreaterEqual(self.manifest["lineCount"], MIN_LINES)
+        self.assertEqual(self.manifest["lineCount"], counted)
+
+    def test_set_count_matches_manifest(self) -> None:
+        self.assertEqual(self.manifest["setCount"], len(self.sets))
+        self.assertGreaterEqual(len(self.sets), 1600)
+
+    def test_set_ids_and_identity_keys_are_unique(self) -> None:
+        ids = [blob["setId"] for blob in self.sets]
+        self.assertEqual(len(ids), len(set(ids)))
+        keys = [identity_key(blob) for blob in self.sets]
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_every_set_has_machine_fields_and_expected_rank(self) -> None:
+        for blob in self.sets:
+            self.assertEqual(blob["rankFields"], list(RANK_FIELDS))
+            self.assertGreaterEqual(blob["n"], 2)
+            self.assertEqual(blob["n"], len(blob["candidates"]))
+            self.assertNotIn("process_steps", blob)
+            self.assertNotIn("processSteps", blob)
+            for rec in blob["candidates"]:
+                self.assertIn("changedCount", rec)
+                self.assertIn("invalid", rec)
+                self.assertIn("exitClass", rec)
+                self.assertIn("expectedRank", rec)
+                self.assertIn(rec["exitClass"], (0, 1, 2, 3, 4))
+                for forbidden in FORBIDDEN_KEYS:
+                    self.assertNotIn(forbidden, rec)
+                    if isinstance(rec.get("envelope"), dict):
+                        self.assertNotIn(forbidden, rec["envelope"])
+
+    def test_expected_rank_matches_ranker(self) -> None:
+        for blob in self.sets:
+            mismatches = expected_ranks_match(blob)
+            self.assertEqual(mismatches, [], msg=blob["setId"])
+
+    def test_commands_and_modes_are_populated(self) -> None:
+        commands = {blob["command"] for blob in self.sets}
+        modes = {blob["mode"] for blob in self.sets}
+        self.assertIn("fill-fields", commands)
+        self.assertIn("csv-to-table", commands)
+        self.assertIn("ir-diff", commands)
+        self.assertIn("dry-run", modes)
+        self.assertIn("verify", modes)
+        self.assertIn("ir-diff", modes)
+
+    def test_no_comment_padding_markers(self) -> None:
+        for blob in self.sets:
+            dumped = json.dumps(blob, ensure_ascii=False)
+            self.assertNotIn("TODO", dumped)
+            self.assertNotIn("lorem ipsum", dumped.lower())
+            self.assertNotIn("padding", dumped.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/llm_verifier/best_of_n/test_envelopes.py
+++ b/tools/llm_verifier/best_of_n/test_envelopes.py
@@ -1,0 +1,45 @@
+"""Fixture envelopes must rank by machine fields only."""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from rank import expected_ranks_match, rank_mapping
+
+FIXTURES = HERE / "fixtures"
+
+
+class FixtureTests(unittest.TestCase):
+    def test_all_fixtures_match_ranker(self) -> None:
+        paths = sorted(FIXTURES.glob("*.json"))
+        self.assertGreaterEqual(len(paths), 3)
+        for path in paths:
+            blob = json.loads(path.read_text(encoding="utf-8"))
+            mismatches = expected_ranks_match(blob)
+            self.assertEqual(mismatches, [], msg=path.name)
+            ranked = rank_mapping(blob)
+            self.assertNotIn("process_steps", blob)
+            self.assertNotIn("processSteps", blob)
+            self.assertTrue(ranked.winner_id)
+
+    def test_ir_diff_fixture_prefers_identical(self) -> None:
+        blob = json.loads((FIXTURES / "golden_ir_diff.json").read_text(encoding="utf-8"))
+        ranked = rank_mapping(blob)
+        self.assertEqual(ranked.winner_id, "c_identical")
+
+    def test_invalid_fixture_loses(self) -> None:
+        blob = json.loads((FIXTURES / "mixed_invalid.json").read_text(encoding="utf-8"))
+        ranked = rank_mapping(blob)
+        last = ranked.ranking[-1].candidate
+        self.assertTrue(last.is_invalid())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/llm_verifier/best_of_n/test_rank.py
+++ b/tools/llm_verifier/best_of_n/test_rank.py
@@ -1,0 +1,248 @@
+"""Unit tests for V-bon outcome ranking. No prose scores, no process_steps."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from envelopes import lift_envelope
+from rank import CLAIM_ID, outcome_key, rank_candidates, rank_mapping
+from schema import CandidateOutcome, FORBIDDEN_KEYS
+
+
+def cand(
+    cid: str,
+    *,
+    changed: int,
+    invalid,
+    identical,
+    exit_class: int,
+) -> CandidateOutcome:
+    return CandidateOutcome(
+        candidate_id=cid,
+        changed_count=changed,
+        invalid=invalid,
+        verify_identical=identical,
+        exit_class=exit_class,
+    )
+
+
+class RankOrderTests(unittest.TestCase):
+    def test_exact_verify_beats_over_edit(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("over", changed=5, invalid=[], identical=True, exit_class=0),
+                cand("exact", changed=3, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=3,
+            set_id="t-over",
+            command="fill-fields",
+            mode="verify",
+        )
+        self.assertEqual(ranked.winner_id, "exact")
+        by_id = {row.candidate.candidate_id: row.expected_rank for row in ranked.ranking}
+        self.assertEqual(by_id["exact"], 1)
+        self.assertEqual(by_id["over"], 2)
+
+    def test_identical_true_beats_false_at_same_exit(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("bad", changed=4, invalid=[], identical=False, exit_class=0),
+                cand("good", changed=4, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=4,
+        )
+        self.assertEqual(ranked.winner_id, "good")
+
+    def test_exit0_beats_exit3_even_if_identical_true(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("judging", changed=2, invalid=[], identical=True, exit_class=3),
+                cand("ok", changed=2, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=2,
+        )
+        self.assertEqual(ranked.winner_id, "ok")
+
+    def test_invalid_always_worse_than_clean(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("inv", changed=0, invalid=[{"reason": "rowCountMismatch"}], identical=None, exit_class=2),
+                cand("io", changed=0, invalid=[], identical=None, exit_class=1),
+                cand("ok", changed=2, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=2,
+        )
+        order = [row.candidate.candidate_id for row in ranked.ranking]
+        self.assertEqual(order[0], "ok")
+        self.assertEqual(order[-1], "inv")
+
+    def test_exit_order_is_ok_judgment_page_io_usage(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("usage", changed=0, invalid=[], identical=None, exit_class=2),
+                cand("io", changed=0, invalid=[], identical=None, exit_class=1),
+                cand("page", changed=0, invalid=[], identical=False, exit_class=4),
+                cand("judge", changed=3, invalid=[], identical=False, exit_class=3),
+                cand("ok", changed=3, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=3,
+        )
+        order = [row.candidate.candidate_id for row in ranked.ranking]
+        self.assertEqual(order, ["ok", "judge", "page", "io", "usage"])
+
+    def test_dry_run_null_identical_ranks_by_changed_delta(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("over", changed=6, invalid=[], identical=None, exit_class=0),
+                cand("exact", changed=4, invalid=[], identical=None, exit_class=0),
+                cand("under", changed=3, invalid=[], identical=None, exit_class=0),
+            ],
+            intended_changed_count=4,
+        )
+        order = [row.candidate.candidate_id for row in ranked.ranking]
+        self.assertEqual(order[0], "exact")
+        self.assertEqual(set(order[1:]), {"over", "under"})
+
+    def test_competition_rank_ties_share_rank(self) -> None:
+        ranked = rank_candidates(
+            [
+                cand("a", changed=2, invalid=[], identical=True, exit_class=0),
+                cand("b", changed=2, invalid=[], identical=True, exit_class=0),
+                cand("c", changed=4, invalid=[], identical=True, exit_class=0),
+            ],
+            intended_changed_count=2,
+        )
+        by_id = {row.candidate.candidate_id: row.expected_rank for row in ranked.ranking}
+        self.assertEqual(by_id["a"], 1)
+        self.assertEqual(by_id["b"], 1)
+        self.assertEqual(by_id["c"], 3)
+
+    def test_key_uses_only_four_fields_plus_id(self) -> None:
+        key = outcome_key(
+            cand("x", changed=7, invalid=[], identical=True, exit_class=0),
+            5,
+        )
+        self.assertEqual(key.invalid_rank, 0)
+        self.assertEqual(key.exit_rank, 0)
+        self.assertEqual(key.identical_rank, 0)
+        self.assertEqual(key.change_delta, 2)
+        self.assertEqual(key.changed_count, 7)
+
+    def test_mapping_roundtrip_and_claim(self) -> None:
+        blob = {
+            "setId": "map-1",
+            "command": "csv-to-table",
+            "mode": "verify",
+            "intendedChangedCount": 2,
+            "candidates": [
+                {
+                    "candidateId": "c0",
+                    "changedCount": 2,
+                    "invalid": [],
+                    "verify": {"identical": True, "diffCount": 0},
+                    "exitClass": 0,
+                },
+                {
+                    "candidateId": "c1",
+                    "changedCount": 2,
+                    "invalid": [],
+                    "verify": {"identical": False, "diffCount": 4},
+                    "exitClass": 3,
+                },
+            ],
+        }
+        ranked = rank_mapping(blob)
+        self.assertEqual(ranked.claim if hasattr(ranked, "claim") else CLAIM_ID, CLAIM_ID)
+        self.assertEqual(ranked.winner_id, "c0")
+        self.assertEqual(ranked.to_json()["rankFields"], [
+            "changedCount",
+            "invalid",
+            "verify.identical",
+            "exitClass",
+        ])
+
+    def test_refuses_process_steps(self) -> None:
+        blob = {
+            "setId": "bad",
+            "intendedChangedCount": 1,
+            "process_steps": [{"score": 0.9}],
+            "candidates": [
+                {
+                    "candidateId": "c0",
+                    "changedCount": 1,
+                    "invalid": [],
+                    "verify": {"identical": True},
+                    "exitClass": 0,
+                }
+            ],
+        }
+        with self.assertRaises(ValueError) as ctx:
+            rank_mapping(blob)
+        self.assertIn("5490", str(ctx.exception))
+
+    def test_forbidden_keys_are_closed(self) -> None:
+        self.assertIn("process_steps", FORBIDDEN_KEYS)
+        self.assertIn("proseScore", FORBIDDEN_KEYS)
+
+
+class EnvelopeLiftTests(unittest.TestCase):
+    def test_ir_diff_lifts_top_level_identical(self) -> None:
+        env = {
+            "schemaVersion": "1.0",
+            "identical": False,
+            "diffCount": 3,
+            "categories": {"cc": 3},
+            "exitClass": 3,
+        }
+        out = lift_envelope(env, candidate_id="ir0")
+        self.assertEqual(out.changed_count, 3)
+        self.assertEqual(out.verify_identical, False)
+        self.assertEqual(out.exit_class, 3)
+
+    def test_fill_fields_uses_filled_count_fallback(self) -> None:
+        env = {
+            "filledCount": 4,
+            "invalid": [],
+            "verify": {"identical": True, "diffCount": 0},
+            "exitClass": "ok",
+        }
+        out = lift_envelope(env, candidate_id="f0")
+        self.assertEqual(out.changed_count, 4)
+        self.assertEqual(out.exit_class, 0)
+        self.assertTrue(out.verify_identical)
+
+    def test_invalid_list_and_bool(self) -> None:
+        a = lift_envelope(
+            {"changedCount": 0, "invalid": [{"reason": "notFound"}], "exitClass": 2},
+            candidate_id="a",
+        )
+        b = lift_envelope(
+            {"changedCount": 0, "invalid": True, "exitClass": 2},
+            candidate_id="b",
+        )
+        self.assertTrue(a.is_invalid())
+        self.assertTrue(b.is_invalid())
+
+    def test_exit_name_runtime_maps_to_io(self) -> None:
+        out = lift_envelope(
+            {"changedCount": 0, "invalid": [], "exitClass": "runtime"},
+            candidate_id="io",
+        )
+        self.assertEqual(out.exit_class, 1)
+
+    def test_refuses_prose_score_on_envelope(self) -> None:
+        with self.assertRaises(ValueError):
+            lift_envelope(
+                {"changedCount": 1, "invalid": [], "exitClass": 0, "llmScore": 0.8},
+                candidate_id="x",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

LLM-as-Verifier 축 4(V-bon, #5489). 후보 N개의 **최종 산출**을 기존 `dry-run` / `--verify` / `ir-diff` JSON 봉투 필드만으로 순위 매긴다.

순위 키(작을수록 좋음, 산문 점수 없음):

1. `invalid` 비어 있음/거짓 > 채워짐/참
2. `exitClass` 0 > 3 > 4 > 1 > 2
3. `verify.identical` true > 없음 > false
4. `|changedCount - intendedChangedCount|`, 그다음 `changedCount`

`ir-diff` 최상위 `identical`/`diffCount` 는 기존 봉투에서 끌어올린다. V-step `process_steps`(#5490) 는 읽지도 쓰지도 않는다.

코퍼스는 후보 집합 1,728개(샤드 27)이며 각 집합에 네 필드와 `expectedRank` 가 있다. 주석 패딩이 아니다.

소유권 경로만 변경: `tools/llm_verifier/best_of_n/` · `mydocs/working/llm_verifier_best_of_n.md`. 새 rhwp CLI 와 `gym/` 은 건드리지 않았다.

## 관련 이슈

closes #5489

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과 (이번 파동 범위 밖 — Rust 워크스페이스 멤버를 추가하지 않음)
- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] 관련 테스트 통과: `python tools/llm_verifier/best_of_n/test_rank.py` (16) · `test_envelopes.py` (3) · `test_corpus.py` (7)
- [ ] `cargo clippy -- -D warnings` 통과 (Rust crate 를 워크스페이스에 추가하지 않음)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — 렌더/레이아웃 변경 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음)
- [ ] rhwp-studio 편집·UI 변경 시 e2e (해당 없음)
- [ ] 작업 증빙 `rhwp replay --capsule` (문서 편집 없음 — 봉투 코퍼스만)
- [ ] 스킬/에이전트 카탈로그 변경 (해당 없음)

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (검증기 도구·코퍼스만)
- 재현·측정: 미측정

## 스크린샷

해당 없음 (렌더/레이아웃 변경 없음).
