### PR TITLE
docs: PR #5500 검증 기록을 보존한다

### DIFF
--- a/mydocs/orders/20260818.md
+++ b/mydocs/orders/20260818.md
@@ -98,3 +98,11 @@ date: 2026-08-18
 - 로컬 format·manifest·tier 검사와 script unit test를 통과했고, CI의 Rust CodeQL(13분 45초), test archive 생성(7분 51초), nextest shard, Native Skia 검증이 모두 성공했다.
 - PR #5473은 `2c639ac0da43adabc792bd0649bbeb7ac1490f08`으로 병합했다. #5463은 종료되었고 기능 브랜치의 로컬·원격 참조를 삭제했다.
 - 병합 기록은 `mydocs/pr/archives/pr_5473_review.md`에 보존하며, 본 오늘할일·검토 기록은 문서 전용 후속 PR로 분리한다.
+
+## #5497 문서 전용 PR의 Proptest fast-pass
+
+- 이슈 [#5497](https://github.com/edwardkim/rhwp/issues/5497), 기능 PR [#5500](https://github.com/edwardkim/rhwp/pull/5500)은 `2f757ad73147e99b0feb4ef7faf5e27750602c32`로 병합됐다.
+- `devel` 대상 PR의 변경 경로가 모두 `mydocs/**`이면 Proptest preflight가 `mydocs-only-devel-pr`을 기록하고, required check 이름을 유지한 `prop roundtrip` worker는 명시적으로 skip한다.
+- 코드·테스트·workflow 변경, `push`, 수동 실행, GitHub API 판정 실패는 fail-closed로 기존 Proptest 실행 경로를 유지한다.
+- 기능 PR 자체는 workflow 변경이므로 fast-pass를 적용하지 않았다. 최신 head `3390f401d57d8d40a9d3d8a02c680dde948593a9`에서 `prop roundtrip`이 2분 11초에 실제 실행되어 통과했고, Build & Test, Native Skia, 세 regular shard, slow shard 및 CodeQL 3개 언어도 모두 통과했다.
+- 검증 기록은 `mydocs/pr/archives/pr_5500_review.md`에 보존한다. 이 후속 docs-only PR에서 Proptest preflight와 `prop roundtrip`의 명시적 skip을 확인한다.

--- a/mydocs/pr/archives/pr_5500_review.md
+++ b/mydocs/pr/archives/pr_5500_review.md
@@ -1,0 +1,28 @@
+---
+kind: pr-review
+pr: 5500
+issue: 5497
+status: merged
+merged_at: 2026-08-18T12:08:25Z
+merge_commit: 2f757ad73147e99b0feb4ef7faf5e27750602c32
+---
+
+# PR #5500 검증 기록 - 문서 전용 Proptest fast-pass
+
+## 범위
+
+- `devel` 대상 pull request의 파일이 모두 `mydocs/**`일 때만 Proptest preflight가 fast-pass를 선택한다.
+- `prop roundtrip` job 이름은 유지하고 worker만 명시적으로 skip하므로 required check가 사라지지 않는다.
+- 코드·테스트·workflow 변경, `push`, `workflow_dispatch`, PR 파일 목록 조회 실패는 full Proptest 실행으로 fail-closed 한다.
+- 권한은 checkout에 필요한 `contents: read`와 PR 파일 목록 조회에 필요한 `pull-requests: read`로 한정했다.
+
+## 검증 근거
+
+- 로컬: `python -m unittest scripts.tests.test_proptest_roundtrip_workflow scripts.tests.test_workflow_contract_wiring` 11건 통과.
+- 로컬: `cargo fmt --all`, `cargo fmt --all -- --check`, `node scripts/rust-test-suite-manifest.mjs --generate`, manifest·unit-tier `--check`, `git diff --check`를 통과했다. 생성 harness는 Git에 포함하지 않았다.
+- 원격: workflow 변경 PR인 최신 head `3390f401d57d8d40a9d3d8a02c680dde948593a9`에서는 fast-pass 없이 `Proptest preflight`와 `prop roundtrip`이 각각 성공했다. `prop roundtrip`은 2분 11초에 실제 실행되어 통과했다.
+- 원격: Build & Test aggregate, Lint, Native Skia, test archive, regular 1/3·2/3·3/3, slow shard, JavaScript·Python·Rust CodeQL이 모두 성공했다. 변경 영향이 없는 WASM Build·frontend unit gate는 명시적으로 skipped됐다.
+
+## 결론 및 후속 처리
+
+PR은 `2f757ad73147e99b0feb4ef7faf5e27750602c32`로 병합됐다. `Closes #5497`에 따른 이슈 종료 상태와, 이 검토 기록만 포함한 docs-only PR의 최신 head에서 `mydocs-only-devel-pr` 및 `prop roundtrip` skip을 확인한다.


### PR DESCRIPTION
## 변경 요약

- 병합된 [#5500](https://github.com/edwardkim/rhwp/pull/5500)의 검증 기록을 archive에 보존합니다.
- 오늘할일에 merge SHA와 Proptest fast-pass의 실행·fail-closed 계약을 기록합니다.

## 검증

- `git diff --check`

## 적용 후 확인

- PR 전체가 `mydocs/**`이므로 Proptest preflight가 `mydocs-only-devel-pr`을 기록하는지 확인합니다.
- required check 이름을 유지한 `prop roundtrip` worker가 명시적으로 skipped되는지 확인합니다.
