### PR TITLE
fix(render): 그릴 수 없는 그림 바이트를 한글처럼 그림-없음 표시로 그린다 (#5513)

### DIFF
--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -938,6 +938,30 @@ pub(crate) fn detect_image_mime_type(data: &[u8]) -> &'static str {
     "application/octet-stream"
 }
 
+/// 이 바이트를 백엔드가 실제로 **그릴 수 있는가**.
+///
+/// 변환 사슬(`resolve_image_payload`)을 태워도 남는 형식 — 프리뷰 없는 텍스트 EPS/AI,
+/// 정체불명 바이트 — 은 브라우저도 resvg 도 skia 도 디코드하지 못해 그 자리가 그냥
+/// **빈 공간**이 된다. 한글은 그럴 때 "그림 미지정" 과 똑같이 편집 화면에서 점선 테두리 +
+/// 그림-없음 아이콘을 그린다(인쇄 등가 출력에서는 미출력). 레이아웃이 그 판정을 내리려면
+/// 술어가 mime 판정 옆 한 곳에 있어야 한다 — 사본을 두면 "그리는 쪽"과 "없다고 보는 쪽"이
+/// 조용히 갈라진다.
+///
+/// WMF·EMF·TIFF·PCX 는 변환기가 있으므로 **형식만 보고** 그릴 수 있다고 본다. 변환이
+/// 실패하는 개별 파손 바이트까지 잡으려면 여기서 변환을 한 번 더 돌려야 하는데, 그 비용은
+/// 매 페이지 조판마다 붙는다. 지금 동작(변환 실패 시 원본 그대로 → 빈 공간)은 그대로 두고
+/// 판정만 넓히지 않는다.
+pub(crate) fn is_displayable_image_data(data: &[u8]) -> bool {
+    match detect_image_mime_type(data) {
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/bmp" | "image/svg+xml"
+        | "image/tiff" | "image/x-pcx" | "image/x-wmf" | "image/x-emf" => true,
+        // EPS/AI 는 DOS EPS 바이너리 프리뷰(WMF/TIFF)를 품고 있을 때만 그릴 수 있다 (#4062).
+        // 순수 텍스트 PostScript 는 해석기가 없다.
+        "application/postscript" => dos_eps_preview_bytes(data).is_some(),
+        _ => false,
+    }
+}
+
 fn decode_image_with_format_limited(
     data: &[u8],
     format: image::ImageFormat,

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -11,7 +11,9 @@ use super::super::{
 };
 use super::border_rendering::border_width_to_px;
 use super::text_measurement::{estimate_text_width, resolved_to_text_style};
-use super::utils::{extract_shape_transform, find_bin_data_bytes, picture_display_size_hu};
+use super::utils::{
+    extract_shape_transform, find_bin_data_bytes, picture_data_is_unusable, picture_display_size_hu,
+};
 use super::{footnote_separator_length_px, LayoutEngine};
 use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
@@ -198,7 +200,7 @@ impl LayoutEngine {
         // [Task #2225] 그림 미지정(bin 참조 실패 + 외부 경로 없음): 한컴은 편집기
         // 에서만 점선 테두리+그림-없음 아이콘으로 표시하고 인쇄 등가 출력은
         // 미출력 — 의미 노드(MissingPicture)로 방출해 백엔드별 분기를 일원화.
-        if image_data.as_ref().is_none_or(|d| d.is_empty())
+        if picture_data_is_unusable(image_data.as_deref())
             && picture.image_attr.external_path.is_none()
         {
             let ph_id = tree.next_id();
@@ -515,25 +517,12 @@ impl LayoutEngine {
         let bin_data_id = picture.image_attr.bin_data_id;
         let image_data = find_bin_data_bytes(bin_data_content, bin_data_id);
         // [Task #2225] 그림 미지정 — layout_picture_full 과 동일 분기.
-        if image_data.as_ref().is_none_or(|d| d.is_empty())
-            && picture.image_attr.external_path.is_none()
-        {
-            let ph_id = tree.next_id();
-            parent_node.children.push(RenderNode::new(
-                ph_id,
-                RenderNodeType::Placeholder(
-                    // [Task #2230] 본문 picture — 셀 경로 없음(None).
-                    crate::renderer::render_tree::PlaceholderNode::missing_picture(
-                        Some(section_index),
-                        Some(para_index),
-                        Some(control_index),
-                        None,
-                    ),
-                ),
-                BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),
-            ));
-            return total_height;
-        }
+        //
+        // 여기서 곧장 되돌아가면(early return) 캡션 배치와 흐름 계산을 통째로 건너뛴다 —
+        // 캡션 글자가 사라지고, 반환값도 "후속 y" 가 아니라 "높이" 가 되어 뒤 문단이 그림
+        // 위로 올라탄다. 그래서 **노드만 바꿔 끼우고** 나머지 경로는 그대로 태운다.
+        let picture_missing = picture_data_is_unusable(image_data.as_deref())
+            && picture.image_attr.external_path.is_none();
 
         // 그림 자르기
         let crop = {
@@ -547,10 +536,19 @@ impl LayoutEngine {
 
         let original_size_hu = picture.crop_reference_size();
 
-        // 이미지 노드 생성
+        // 이미지 노드 생성 (그림 미지정이면 같은 자리·같은 bbox 의 placeholder 노드)
         let img_id = tree.next_id();
-        let img_node = RenderNode::new(
-            img_id,
+        let node_type = if picture_missing {
+            RenderNodeType::Placeholder(
+                // [Task #2230] 본문 picture — 셀 경로 없음(None).
+                crate::renderer::render_tree::PlaceholderNode::missing_picture(
+                    Some(section_index),
+                    Some(para_index),
+                    Some(control_index),
+                    None,
+                ),
+            )
+        } else {
             RenderNodeType::Image(ImageNode {
                 section_index: Some(section_index),
                 para_index: Some(para_index),
@@ -565,7 +563,11 @@ impl LayoutEngine {
                 transform: extract_shape_transform(&picture.shape_attr),
                 external_path: picture.image_attr.external_path.clone(),
                 ..ImageNode::new(bin_data_id, image_data)
-            }),
+            })
+        };
+        let img_node = RenderNode::new(
+            img_id,
+            node_type,
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),
         );
 

--- a/src/renderer/layout/utils.rs
+++ b/src/renderer/layout/utils.rs
@@ -61,6 +61,21 @@ pub(crate) fn find_bin_data_bytes(
     })
 }
 
+/// 그림 자리에 **아무것도 그릴 수 없는** 상태인가 — "그림 미지정" 판정.
+///
+/// bin 참조 실패·빈 데이터뿐 아니라 **어느 백엔드도 디코드하지 못하는 바이트**도 같은
+/// 상태로 본다(프리뷰 없는 텍스트 EPS/AI 등). 지금까지 후자는 소리 없이 빈 공간이 됐지만,
+/// 한글은 둘을 구별하지 않고 편집 화면에 점선 테두리 + 그림-없음 아이콘을 그린다
+/// (인쇄 등가 출력에서는 둘 다 미출력). 형식 판정의 단일 권위는 `image_resolver` 다.
+pub(crate) fn picture_data_is_unusable(data: Option<&[u8]>) -> bool {
+    match data {
+        None => true,
+        Some(bytes) => {
+            bytes.is_empty() || !crate::renderer::image_resolver::is_displayable_image_data(bytes)
+        }
+    }
+}
+
 /// Picture의 렌더 표시 크기(HWPUNIT)를 반환한다.
 ///
 /// 일부 HWP5 그림은 `CommonObjAttr.width/height`보다

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -577,6 +577,16 @@ impl SvgRenderer {
                 {
                     return;
                 }
+                // 그림 미지정은 라벨 없는 전용 표시다 — 한글 편집 화면과 같은 점선 테두리 +
+                // 중앙의 그림-없음 아이콘. 차트/OLE 의 "라벨 박스"를 쓰면 빈 라벨만 남아
+                // 한글과 달라진다.
+                if matches!(
+                    ph.kind,
+                    crate::renderer::render_tree::PlaceholderKind::MissingPicture
+                ) {
+                    self.draw_missing_picture_placeholder(&node.bbox);
+                    return;
+                }
                 // Task #195: 차트/OLE placeholder (점선 테두리 + 중앙 라벨)
                 let cx = node.bbox.x + node.bbox.width / 2.0;
                 let cy = node.bbox.y + node.bbox.height / 2.0;
@@ -1519,6 +1529,61 @@ impl SvgRenderer {
     }
 
     /// 이미지 노드를 fill_mode에 따라 렌더링한다.
+    /// 한글 편집 화면의 "그림 없음" 표시 — 개체 영역 점선 테두리 + 중앙의 작은
+    /// 그림-없음 아이콘(사선 그은 그림 픽토그램).
+    ///
+    /// 기하·색은 `web_canvas.rs::render_placeholder` 와 같은 값을 쓴다 — 같은 표시를
+    /// 두 백엔드가 다른 모양으로 그리면 studio 화면과 SVG 내보내기가 갈라진다.
+    /// 인쇄 등가 profile 에서는 호출부(`show_missing_picture_placeholder`)가 막는다.
+    fn draw_missing_picture_placeholder(&mut self, bbox: &super::render_tree::BoundingBox) {
+        self.output.push_str(&format!(
+            "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"none\" stroke=\"#999999\" stroke-width=\"1\" stroke-dasharray=\"2 2\"/>
+",
+            bbox.x, bbox.y, bbox.width, bbox.height,
+        ));
+        let icon = (bbox.width.min(bbox.height) * 0.4).clamp(14.0, 36.0);
+        let ix = bbox.x + (bbox.width - icon) / 2.0;
+        let iy = bbox.y + (bbox.height - icon) / 2.0;
+        // 아이콘 판 + 산 두 개 + 해 + 사선(그림 없음)
+        self.output.push_str(&format!(
+            "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix,
+            iy,
+            icon,
+            icon * 0.75,
+        ));
+        self.output.push_str(&format!(
+            "<polyline points=\"{:.2},{:.2} {:.2},{:.2} {:.2},{:.2} {:.2},{:.2} {:.2},{:.2}\" fill=\"none\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix + icon * 0.08,
+            iy + icon * 0.62,
+            ix + icon * 0.32,
+            iy + icon * 0.30,
+            ix + icon * 0.52,
+            iy + icon * 0.62,
+            ix + icon * 0.68,
+            iy + icon * 0.42,
+            ix + icon * 0.92,
+            iy + icon * 0.62,
+        ));
+        self.output.push_str(&format!(
+            "<circle cx=\"{:.2}\" cy=\"{:.2}\" r=\"{:.2}\" fill=\"none\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix + icon * 0.72,
+            iy + icon * 0.20,
+            icon * 0.07,
+        ));
+        self.output.push_str(&format!(
+            "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#cc4444\" stroke-width=\"1.5\"/>
+",
+            ix,
+            iy + icon * 0.75,
+            ix + icon,
+            iy,
+        ));
+    }
+
     fn render_image_node(&mut self, img: &ImageNode, bbox: &super::render_tree::BoundingBox) {
         // [Task #741] 빈 binary 데이터 (외부 file path 그림 등) 도 placeholder 처리.
         // 한컴 한글 2024 viewer 정합 — 외부 file 못 찾는 경우 점선 사각형 + 깨진 image 아이콘.

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -388,8 +388,10 @@ mod tests {
         let mut print = SvgLayerRenderer::new();
         print.render_page(&print_tree).unwrap();
 
-        assert!(screen.output().contains("stroke-dasharray=\"6 3\""));
-        assert!(!print.output().contains("stroke-dasharray=\"6 3\""));
+        // 점선은 한글 편집 화면 실측(2px on / 2px off)에 맞춘 값이다 — 차트/OLE 의
+        // "6 3" 파선과 구별된다.
+        assert!(screen.output().contains("stroke-dasharray=\"2 2\""));
+        assert!(!print.output().contains("stroke-dasharray=\"2 2\""));
     }
 
     /// [Issue #4379] `editor_only` 표시 판정은 legacy(`SvgRenderer::profile`)와 layer

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -1158,7 +1158,9 @@ impl WebCanvasRenderer {
             if !self.render_profile.shows_editor_visuals() {
                 return;
             }
-            self.set_line_dash(&StrokeDash::Dash);
+            // 한글 편집 화면의 테두리는 굵은 파선이 아니라 잔 점선이다 — 오라클 화면
+            // 실측(2px on / 2px off)에 맞춘다. `svg.rs` 의 stroke-dasharray 와 같은 값.
+            self.set_line_dash(&StrokeDash::Dot);
             self.ctx.set_stroke_style_str("#999999");
             self.ctx.set_line_width(1.0);
             self.ctx


### PR DESCRIPTION
## 무엇을 고치나

프리뷰 없는 **텍스트 EPS/AI** 처럼 어떤 백엔드도 디코드하지 못하는 그림 BinData 가
`data:application/postscript;base64,…` 로 그대로 실려 나가 **그림 자리가 빈칸**이 되던 것을,
한글과 같은 **그림-없음 표시**로 바꾼다. (#5513)

재현: 코퍼스 문서 `148703503_20101119 매일유업 남양유업 부당한 고객유인.hwp` 1쪽 왼쪽 위 셀.
그 셀의 BinData 는 Adobe Illustrator 5.5 텍스트 EPS(76,537 bytes)다.

## 한글 오라클 실측 (한글 2022)

| 경로 | 그 자리 |
|---|---|
| 한글 편집 화면 | 점선 테두리 + 중앙 그림-없음 아이콘 (그림 내용은 한글도 못 그린다) |
| 한글 PDF 내보내기 | 아무것도 없음 |

한글은 "못 그리는 그림"을 **그림 미지정과 같게** 다뤄 편집 화면에만 표시하고 인쇄 등가
출력에서는 뺀다. rhwp 에는 그 규약이 이미 `PlaceholderKind::MissingPicture` (#2225/#2230)
로 있는데, 발동 조건이 "BinData 가 없거나 비었을 때"로만 걸려 있어 이 경우를 못 잡았다.

## 변경

1. **`image_resolver::is_displayable_image_data`** — "그릴 수 있는 바이트인가" 판정을 mime
   판정 옆 한 곳에 둔다. 사본을 만들면 *그리는 쪽*과 *없다고 보는 쪽*이 조용히 갈라진다.
   EPS/AI 는 DOS EPS 바이너리 프리뷰(WMF/TIFF, #4062)가 있을 때만 참이다.
   WMF·EMF·TIFF·PCX 는 변환기가 있으므로 형식만 보고 참으로 둔다 — 개별 파손 바이트까지
   잡으려면 조판마다 변환을 한 번 더 돌려야 하므로 판정을 넓히지 않았다(동작은 종전과 동일).
2. **`MissingPicture` 발동 조건 확대** — `picture_data_is_unusable(...)` 로 두 그림 경로가
   같은 술어를 쓴다.
3. **본문 그림 경로는 early return 대신 노드 교체** — 되돌아가면 캡션 배치를 통째로
   건너뛰고, 반환값도 "후속 y" 가 아니라 "높이" 라서 뒤 문단이 그림 위로 올라탄다.
   같은 bbox 에 placeholder 노드를 끼우고 캡션·테두리·흐름 계산은 그대로 태운다.
4. **SVG 백엔드에 그림-없음 전용 표시 추가** — 차트/OLE 의 라벨 박스를 쓰면 빈 라벨만
   남는다. 기하·색은 studio canvas(`web_canvas.rs`)와 같은 값으로 맞췄고, 점선은 한글
   화면 실측에 맞춰 `2 on / 2 off` 로 통일했다(양쪽 동시 변경).

## 검증

- `cargo test --release --lib` — **3,886 passed / 0 failed** (`-j 4`).
  `missing_picture_placeholder_follows_render_profile` 은 점선 값 변경에 맞춰 기대값 갱신.
- `cargo clippy --all-targets` 통과. 변경 파일 `rustfmt --check` 통과.
- 대상 문서 실측:
  - `export-pdf` (인쇄 등가, 기본): 변경 전후 **3쪽 / 본문 860자 / 벡터 22개로 동일** —
    한글 PDF 와 같은 빈칸.
  - `export-pdf --profile screen` (편집): 같은 자리(bbox 동일)에 점선 테두리 + 아이콘 표시,
    벡터 5개 증가. 디코드 불가 data URI 는 산출에서 사라졌다.
- 코퍼스 범위: HWP5 6,582건 전수 스캔에서 그림 BinData 가 디코드 불가인 문서는 11건 43항목
  (텍스트 EPS 16 · 정체불명 바이트 27). EPS 는 전부 Adobe Illustrator 3.2~8.0 세대다.

## 남는 것

그림 **내용**을 실제로 그리려면 AI 아트워크(PostScript 부분집합) → SVG 변환기가 따로 필요하다.
한글도 그리지 못하는 영역이라 이 PR 범위 밖으로 둔다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
