### PR TITLE
review: planet6897 #5483·#5515 검토 통합

### DIFF
--- a/mydocs/pr/archives/pr_5483_review.md
+++ b/mydocs/pr/archives/pr_5483_review.md
@@ -1,0 +1,59 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-18
+---
+
+# PR #5483 검토 - HWP3 개체 자리표시자 슬롯 보정
+
+## 접수 메타데이터
+
+| 항목 | 검토 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#5483](https://github.com/edwardkim/rhwp/pull/5483) / planet6897 |
+| base / contributor head | devel / `e529e59706d43d9aba17595cbfac784031aa760f` |
+| 가시성 branch | `review/planet6897-20260818` |
+| local cherry-pick | `54510eb99` |
+| 원격 상태 | OPEN, 비 draft, MERGEABLE, BLOCKED |
+| 검토 기준 | `upstream/devel@e5ef2620bd469aa2d0118097c4d04f63cfdacdc3` 위에 #5483 후 #5515 누적 |
+
+## 변경 범위
+
+HWP3 파서가 표·그림·도형과 쪽 번호 계열 개체를 본문 글자 `U+FFFC` 하나로만 세어,
+HWP5/HWPX 저장 시 확장 컨트롤의 8유닛 슬롯 판정이 실패하던 문제를 보정했다.
+개체 뒤 슬롯 폭을 파서에서 보존하고, HWP5 직렬화기가 `U+FFFC`를 자리표시자로 인식하도록
+갭 전후를 판정한다. 개요번호와 비가시 컨트롤은 기존 오프셋 계약을 보존하도록 별도 처리했다.
+
+적용된 주요 파일은 `src/parser/hwp3/mod.rs`, `src/serializer/body_text.rs`와
+`tests/cases/issue_3532_trailing_charshape_boundary.rs`,
+`tests/issue_3492_hwp3_outline_marker_leak.rs`,
+`tests/issue_3495_endnote_space_eaten.rs`이다.
+
+## 체리픽 및 충돌
+
+- `upstream/devel`에서 시작한 검토 branch에 #5483의 source head를 먼저 적용했다.
+- #5483 적용 과정에 충돌은 없었다.
+- 뒤이어 #5515를 같은 branch에 적용했으며, #5483 contributor commit은 rewrite하지 않았다.
+- 통합 branch의 변경 범위는 `upstream/devel...review/planet6897-20260818`로 확인했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 실행 후 `--check` 통과
+- `node scripts/rust-unit-test-tiers.mjs --check` 통과
+- `git diff --check upstream/devel...HEAD` 통과
+- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`를 실행해 **7300 passed, 38 skipped, 8 slow**을 확인했다. 전체 실행 시간은 452.801초였고 release-test 빌드 포함 종료 시간은 15분 11초였다.
+
+PR 본문의 HWP3 코퍼스 수치도 변경 범위와 일치했다. HWP5 저장 축의 U+FFFC 유출은
+전 135자/28문서에서 후 0/0으로 줄었다. HWPX 축의 잔여 2자/2문서는 숨은 설명과 머리말의
+비가시 컨트롤 축 배정 문제로 PR 본문에서 범위 밖으로 구분되어 있다.
+
+## 남은 범위와 판정
+
+차단 결함은 발견하지 못했다. 다만 이슈 [#4957](https://github.com/edwardkim/rhwp/issues/4957)은
+아직 OPEN이며, HWPX 축의 숨은 설명·머리말 비가시 컨트롤 2건은 별도 후속 범위로 남아 있다.
+이 잔여 범위는 이번 PR의 HWP5 U+FFFC 유출 수정 판정을 뒤집는 근거로 보지 않았다.
+
+GitHub에서는 이 시점에 두 source branch 모두 required check가 보고되지 않았고 상태가
+BLOCKED였다. 따라서 이 문서는 로컬 통합 검토 기록이며, 원 PR 승인·병합은 수행하지 않았다.

--- a/mydocs/pr/archives/pr_5515_review.md
+++ b/mydocs/pr/archives/pr_5515_review.md
@@ -1,0 +1,73 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-18
+---
+
+# PR #5515 검토 - 디코드 불가 그림의 그림-없음 표시
+
+## 접수 메타데이터
+
+| 항목 | 검토 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#5515](https://github.com/edwardkim/rhwp/pull/5515) / planet6897 |
+| base / contributor head | devel / `4962c0dd8a743170c17f4b4542a7463361cb32ae` |
+| 가시성 branch | `review/planet6897-20260818` |
+| local cherry-pick | `6ae24756a` |
+| 선행 체리픽 | #5483, local `54510eb99` |
+| 원격 상태 | OPEN, 비 draft, MERGEABLE, BLOCKED |
+| 검토 기준 | `upstream/devel@e5ef2620bd469aa2d0118097c4d04f63cfdacdc3` 위에 #5483 후 #5515 누적 |
+
+## 변경 범위
+
+디코드할 수 없는 텍스트 EPS/AI 등 그림 바이트가 SVG에 PostScript data URI로 남아
+브라우저·resvg·Skia에서 빈칸이 되던 경로를 `MissingPicture`로 바꿨다.
+`is_displayable_image_data`와 공통 unusable 판정을 추가하고, 본문 그림 경로에서는 같은
+bbox의 placeholder 노드로 교체해 캡션·테두리·후속 흐름을 보존한다. SVG에는 점선 테두리와
+그림-없음 아이콘을 추가하고 WebCanvas의 점선 표현과 맞췄다.
+
+적용된 주요 파일은 `src/renderer/image_resolver.rs`, `src/renderer/layout/utils.rs`,
+`src/renderer/layout/picture_footnote.rs`, `src/renderer/svg.rs`,
+`src/renderer/svg_layer.rs`, `src/renderer/web_canvas.rs`이다.
+
+## 체리픽 및 충돌
+
+- #5483을 먼저 적용한 동일한 `review/planet6897-20260818` branch에 #5515 source head를 적용했다.
+- #5515 적용 과정에 충돌은 없었다.
+- contributor source history는 rewrite하지 않았고, 통합 결과만 로컬에서 검증했다.
+
+## 검증
+
+- `cargo fmt --all -- --check` 통과
+- `node scripts/rust-test-suite-manifest.mjs --prepare` 실행 후 `--check` 통과
+- `node scripts/rust-unit-test-tiers.mjs --check` 통과
+- `git diff --check upstream/devel...HEAD` 통과
+- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`를 실행해 **7300 passed, 38 skipped, 8 slow**을 확인했다. 전체 실행 시간은 452.801초였고 release-test 빌드 포함 종료 시간은 15분 11초였다.
+
+비공개 기준 HWP fixture를 현재 release-test binary로 직접 렌더링했다.
+
+- screen: `target/pr-review/release-test/rhwp export-svg ... --page 0 --profile screen`
+- print: `target/pr-review/release-test/rhwp export-svg ... --page 0 --profile print`
+- 두 결과 모두 3쪽 문서의 1쪽을 생성했다.
+- screen SVG에는 `stroke-dasharray="2 2"`, 점선 테두리, 그림-없음 표시가 있었고
+  `data:application/postscript`는 남지 않았다.
+- print SVG에는 placeholder 표시가 없었고 `data:application/postscript`도 남지 않았다.
+- 원시 결과는 `/tmp/pr5515-screen-20260818/`와 `/tmp/pr5515-print-20260818/`에 생성했다.
+
+이는 한글 2022의 편집 화면 동작인 점선·아이콘과 인쇄 경로의 빈칸 동작을 각각 확인한
+결과다. 실제 그림 바이트를 복원하지 않고, 디코드 불가 그림의 표시 정책만 검증했다.
+
+## 남은 범위와 판정
+
+차단 결함은 발견하지 못했다. 이슈 [#5513](https://github.com/edwardkim/rhwp/issues/5513)은
+아직 OPEN이며, malformed PNG/JPEG처럼 헤더는 유효하지만 실제 디코드가 실패하는 바이트를
+추가 변환 없이 판정하지 않는 것은 PR 본문에 적힌 성능·범위 제한이다.
+
+또한 `is_displayable_image_data`를 직접 호출하는 단위 테스트와 비공개 텍스트 EPS fixture를
+자동 회귀 fixture로 고정한 테스트는 별도 보완 여지가 있다. 현재 통합 branch의 전체 nextest와
+실제 fixture 렌더링은 통과했으므로 이 항목은 보류 결함이 아니라 테스트 커버리지 후속 범위로
+기록했다.
+
+GitHub에서는 이 시점에 두 source branch 모두 required check가 보고되지 않았고 상태가
+BLOCKED였다. 따라서 이 문서는 로컬 통합 검토 기록이며, 원 PR 승인·병합은 수행하지 않았다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2056,20 +2056,21 @@ fn parse_object_control_char(
         || ch == 16
         || preserve_invisible_anchor_gap
         || (is_control_only_marker && (is_tac_picture_or_shape || is_tac_line));
-    if omit_visible_marker {
-        if preserve_invisible_anchor_gap {
-            utf16_len += 8;
-        }
-    } else {
-        char_offsets.push(utf16_len);
-        // 일반 HWP3의 가시 개체 제어문자는 원본 LineInfo와 CharShape에서 화면
-        // 마커 하나로 좌표가 계산된다. HWP5 저장 시에만 확장 슬롯으로 쓰므로
-        // 여기서 전역으로 8칸을 늘리면 원본 HWP3 도형 문단의 줄 위치가 밀린다.
-        // 실제 암호 HWP3 fixture는 HWP5 변환본의 8-unit control contract를
-        // 사용하므로, 복호화 경로로 한정해 그 슬롯 폭을 보존한다.
-        utf16_len += if *use_password_layout_contract { 8 } else { 1 };
-        text_string.push('\u{FFFC}');
+    if omit_visible_marker && preserve_invisible_anchor_gap {
+        utf16_len += 8;
     }
+    // [#4957] 가시 개체 자리의 슬롯 폭 결정은 **컨트롤이 실제로 생성된 뒤**로 미룬다.
+    //
+    // 종전에는 여기서 `U+FFFC` 를 본문 글자로 밀어 넣고 1유닛만 셌다. 그 문자는 직렬화기
+    // 두 곳(HWP5·HWPX)이 모두 모르는 값이라 리터럴로 기록됐고, 저장본을 한글로 열면 표·
+    // 그림 자리에 원본에 없던 개체 문자가 생겼다. 한글은 같은 HWP3 원본에서 그 자리에
+    // 아무 글자도 내지 않고 8유닛 컨트롤 슬롯만 쓴다(오라클 대조).
+    //
+    // 다만 아래 `controls.push` 는 **조건부**라, 파싱이 개체를 만들지 못한 경로가 있다.
+    // 그때 슬롯만 넓히면 "컨트롤 없는 8유닛 갭"이 생겨 뒤 컨트롤의 슬롯 대응이 밀린다
+    // (미주 표시가 제 오프셋을 잃는다 — #3492 가 지키는 계약).
+    let controls_len_before_object = controls.len();
+    let emit_visible_object_slot = !omit_visible_marker;
 
     if ch == 10 {
         if parsed_is_hypertext {
@@ -2279,6 +2280,31 @@ fn parse_object_control_char(
         ));
     }
     ctrl_data_records.push(None);
+
+    // [#4957] 여기서 슬롯 폭을 확정한다. 위 `controls.push` 가 조건부라, 컨트롤이 실제로
+    // 생겼을 때만 8유닛 슬롯을 세고 가시 글자를 남기지 않는다. 컨트롤이 안 생긴 경로는
+    // 종전 동작(1유닛 + 자리표시 글자)을 그대로 둔다 — 슬롯만 넓히면 "컨트롤 없는 갭" 이
+    // 생겨 뒤 컨트롤의 슬롯 대응이 밀린다(#3492 가 지키는 미주 오프셋 계약).
+    if emit_visible_object_slot {
+        char_offsets.push(utf16_len);
+        // [#4957] 가시 개체는 **자리표시 글자 하나 + 8유닛 슬롯**이다. 암호 HWP3 경로가
+        // 이미 쓰던 계약을 전 경로로 넓힌 것이고, #3504 가 자동번호에 쓴 모양과 같다
+        // (공백 하나 + 8유닛). 글자 인덱스는 그대로라 `char_shapes` 경계가 밀리지 않는다.
+        //
+        // 종전에는 컨트롤이 생겨도 1유닛만 세어, 직렬화기의 자리표시자 판정
+        // (`next_offset >= offset + 8`)이 실패하고 마커가 리터럴로 기록됐다 — 저장본을
+        // 한글로 열면 표·그림 자리에 원본에 없던 개체 문자가 생겼다.
+        //
+        // 컨트롤이 안 생긴 경로는 슬롯을 넓히지 않는다. 넓히면 "컨트롤 없는 8유닛 갭"이
+        // 생겨 뒤 컨트롤의 슬롯 대응이 밀린다(#3492 가 지키는 미주 오프셋 계약).
+        utf16_len += if controls.len() > controls_len_before_object {
+            8
+        } else {
+            1
+        };
+        text_string.push('\u{FFFC}');
+    }
+
     Ok((i, utf16_len, false))
 }
 
@@ -2329,8 +2355,14 @@ fn parse_field_control_char(
                     // 재파싱 때 말미 공백 1칸이 생겼다 (SO-SUEOP 미주 213건).
                     utf16_len += 8;
                 } else {
+                    // [#4957] 새번호(19)·쪽번호 위치(20)·쪽 감추기(21)도 공통 IR 에서는
+                    // **확장 컨트롤 8 코드유닛**이다(직렬화 매핑이 전부 `0x0015`).
+                    // 1 유닛만 세면 자동번호가 겪던 함정이 그대로 재현된다 — 직렬화의
+                    // 자리표시자 판정(`next_offset >= offset + 8`)이 실패해 `U+FFFC` 가
+                    // 리터럴로 기록되고, 저장본을 한글로 열면 원본에 없던 개체 문자가
+                    // 쪽번호 자리에 생긴다(#3504 와 같은 결).
                     text_string.push('\u{FFFC}');
-                    utf16_len += 1;
+                    utf16_len += 8;
                 }
             }
 
@@ -2528,7 +2560,7 @@ fn parse_simple_control_char(
             }
             i += 4;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
             let mut overlap = crate::model::control::CharOverlap::default();
             // 스펙 §10.17 표 58: buf[0..6] = 겹칠 글자 hchar array[3]
@@ -2559,7 +2591,7 @@ fn parse_simple_control_char(
             }
             i += 11;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
             // 스펙 §10.16 표 57: 필드 이름은 파일 오프셋 2..22 (= 추가로 읽은
             // buf 의 [0..20]). 종전 buf[2..22] 는 이름 앞 2바이트를 유실하고
@@ -2586,7 +2618,7 @@ fn parse_simple_control_char(
             }
             i += 122;
             char_offsets.push(utf16_len);
-            utf16_len += 1;
+            utf16_len += 8;
             text_string.push('\u{FFFC}');
 
             let kw1_bytes = &buf[0..120];
@@ -2614,9 +2646,16 @@ fn parse_simple_control_char(
                 }
             }
             i += 31;
-            char_offsets.push(utf16_len);
-            utf16_len += 1;
-            text_string.push('\u{FFFC}');
+            // [#4957] 개요번호 마커는 본문에 **아무 자취도 남기지 않는다.**
+            //
+            // `fixup_hwp3_outline_fields` 가 이 마커를 소비해 번호 정보를 `ParaShape` 로
+            // 옮긴 뒤 공통 IR 에서 컨트롤을 걷어낸다(#3492). 그런데 자리표시 글자는 `text`
+            // 에 남아 있었고, 짝 컨트롤이 없으니 직렬화기가 그걸 리터럴로 기록했다 —
+            // 저장본을 한글로 열면 원본에 없던 개체 문자가 생긴다.
+            //
+            // 8유닛으로 넓히는 것도 답이 아니다. 컨트롤이 걷힌 뒤 "컨트롤 없는 8유닛 갭"이
+            // 남아 미주 오프셋·char_count 규약이 깨진다(실측 확인). 컨트롤도 글자도 남지
+            // 않는 것이 #3492 계약의 완성형이다.
 
             let kind = (&buf[0..2]).read_u16::<LittleEndian>().unwrap_or(0);
             let shape = buf[2];
@@ -2669,7 +2708,7 @@ fn parse_simple_control_char(
             } else {
                 // unrecognized — fall back to placeholder
                 char_offsets.push(utf16_len);
-                utf16_len += 1;
+                utf16_len += 8;
                 text_string.push('\u{FFFC}');
                 controls.push(crate::model::control::Control::Unknown(
                     crate::model::control::UnknownControl { ctrl_id: ch as u32 },

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -938,6 +938,30 @@ pub(crate) fn detect_image_mime_type(data: &[u8]) -> &'static str {
     "application/octet-stream"
 }
 
+/// 이 바이트를 백엔드가 실제로 **그릴 수 있는가**.
+///
+/// 변환 사슬(`resolve_image_payload`)을 태워도 남는 형식 — 프리뷰 없는 텍스트 EPS/AI,
+/// 정체불명 바이트 — 은 브라우저도 resvg 도 skia 도 디코드하지 못해 그 자리가 그냥
+/// **빈 공간**이 된다. 한글은 그럴 때 "그림 미지정" 과 똑같이 편집 화면에서 점선 테두리 +
+/// 그림-없음 아이콘을 그린다(인쇄 등가 출력에서는 미출력). 레이아웃이 그 판정을 내리려면
+/// 술어가 mime 판정 옆 한 곳에 있어야 한다 — 사본을 두면 "그리는 쪽"과 "없다고 보는 쪽"이
+/// 조용히 갈라진다.
+///
+/// WMF·EMF·TIFF·PCX 는 변환기가 있으므로 **형식만 보고** 그릴 수 있다고 본다. 변환이
+/// 실패하는 개별 파손 바이트까지 잡으려면 여기서 변환을 한 번 더 돌려야 하는데, 그 비용은
+/// 매 페이지 조판마다 붙는다. 지금 동작(변환 실패 시 원본 그대로 → 빈 공간)은 그대로 두고
+/// 판정만 넓히지 않는다.
+pub(crate) fn is_displayable_image_data(data: &[u8]) -> bool {
+    match detect_image_mime_type(data) {
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp" | "image/bmp" | "image/svg+xml"
+        | "image/tiff" | "image/x-pcx" | "image/x-wmf" | "image/x-emf" => true,
+        // EPS/AI 는 DOS EPS 바이너리 프리뷰(WMF/TIFF)를 품고 있을 때만 그릴 수 있다 (#4062).
+        // 순수 텍스트 PostScript 는 해석기가 없다.
+        "application/postscript" => dos_eps_preview_bytes(data).is_some(),
+        _ => false,
+    }
+}
+
 fn decode_image_with_format_limited(
     data: &[u8],
     format: image::ImageFormat,

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -11,7 +11,9 @@ use super::super::{
 };
 use super::border_rendering::border_width_to_px;
 use super::text_measurement::{estimate_text_width, resolved_to_text_style};
-use super::utils::{extract_shape_transform, find_bin_data_bytes, picture_display_size_hu};
+use super::utils::{
+    extract_shape_transform, find_bin_data_bytes, picture_data_is_unusable, picture_display_size_hu,
+};
 use super::{footnote_separator_length_px, LayoutEngine};
 use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
@@ -198,7 +200,7 @@ impl LayoutEngine {
         // [Task #2225] 그림 미지정(bin 참조 실패 + 외부 경로 없음): 한컴은 편집기
         // 에서만 점선 테두리+그림-없음 아이콘으로 표시하고 인쇄 등가 출력은
         // 미출력 — 의미 노드(MissingPicture)로 방출해 백엔드별 분기를 일원화.
-        if image_data.as_ref().is_none_or(|d| d.is_empty())
+        if picture_data_is_unusable(image_data.as_deref())
             && picture.image_attr.external_path.is_none()
         {
             let ph_id = tree.next_id();
@@ -515,25 +517,12 @@ impl LayoutEngine {
         let bin_data_id = picture.image_attr.bin_data_id;
         let image_data = find_bin_data_bytes(bin_data_content, bin_data_id);
         // [Task #2225] 그림 미지정 — layout_picture_full 과 동일 분기.
-        if image_data.as_ref().is_none_or(|d| d.is_empty())
-            && picture.image_attr.external_path.is_none()
-        {
-            let ph_id = tree.next_id();
-            parent_node.children.push(RenderNode::new(
-                ph_id,
-                RenderNodeType::Placeholder(
-                    // [Task #2230] 본문 picture — 셀 경로 없음(None).
-                    crate::renderer::render_tree::PlaceholderNode::missing_picture(
-                        Some(section_index),
-                        Some(para_index),
-                        Some(control_index),
-                        None,
-                    ),
-                ),
-                BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),
-            ));
-            return total_height;
-        }
+        //
+        // 여기서 곧장 되돌아가면(early return) 캡션 배치와 흐름 계산을 통째로 건너뛴다 —
+        // 캡션 글자가 사라지고, 반환값도 "후속 y" 가 아니라 "높이" 가 되어 뒤 문단이 그림
+        // 위로 올라탄다. 그래서 **노드만 바꿔 끼우고** 나머지 경로는 그대로 태운다.
+        let picture_missing = picture_data_is_unusable(image_data.as_deref())
+            && picture.image_attr.external_path.is_none();
 
         // 그림 자르기
         let crop = {
@@ -547,10 +536,19 @@ impl LayoutEngine {
 
         let original_size_hu = picture.crop_reference_size();
 
-        // 이미지 노드 생성
+        // 이미지 노드 생성 (그림 미지정이면 같은 자리·같은 bbox 의 placeholder 노드)
         let img_id = tree.next_id();
-        let img_node = RenderNode::new(
-            img_id,
+        let node_type = if picture_missing {
+            RenderNodeType::Placeholder(
+                // [Task #2230] 본문 picture — 셀 경로 없음(None).
+                crate::renderer::render_tree::PlaceholderNode::missing_picture(
+                    Some(section_index),
+                    Some(para_index),
+                    Some(control_index),
+                    None,
+                ),
+            )
+        } else {
             RenderNodeType::Image(ImageNode {
                 section_index: Some(section_index),
                 para_index: Some(para_index),
@@ -565,7 +563,11 @@ impl LayoutEngine {
                 transform: extract_shape_transform(&picture.shape_attr),
                 external_path: picture.image_attr.external_path.clone(),
                 ..ImageNode::new(bin_data_id, image_data)
-            }),
+            })
+        };
+        let img_node = RenderNode::new(
+            img_id,
+            node_type,
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),
         );
 

--- a/src/renderer/layout/utils.rs
+++ b/src/renderer/layout/utils.rs
@@ -61,6 +61,21 @@ pub(crate) fn find_bin_data_bytes(
     })
 }
 
+/// 그림 자리에 **아무것도 그릴 수 없는** 상태인가 — "그림 미지정" 판정.
+///
+/// bin 참조 실패·빈 데이터뿐 아니라 **어느 백엔드도 디코드하지 못하는 바이트**도 같은
+/// 상태로 본다(프리뷰 없는 텍스트 EPS/AI 등). 지금까지 후자는 소리 없이 빈 공간이 됐지만,
+/// 한글은 둘을 구별하지 않고 편집 화면에 점선 테두리 + 그림-없음 아이콘을 그린다
+/// (인쇄 등가 출력에서는 둘 다 미출력). 형식 판정의 단일 권위는 `image_resolver` 다.
+pub(crate) fn picture_data_is_unusable(data: Option<&[u8]>) -> bool {
+    match data {
+        None => true,
+        Some(bytes) => {
+            bytes.is_empty() || !crate::renderer::image_resolver::is_displayable_image_data(bytes)
+        }
+    }
+}
+
 /// Picture의 렌더 표시 크기(HWPUNIT)를 반환한다.
 ///
 /// 일부 HWP5 그림은 `CommonObjAttr.width/height`보다

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -577,6 +577,16 @@ impl SvgRenderer {
                 {
                     return;
                 }
+                // 그림 미지정은 라벨 없는 전용 표시다 — 한글 편집 화면과 같은 점선 테두리 +
+                // 중앙의 그림-없음 아이콘. 차트/OLE 의 "라벨 박스"를 쓰면 빈 라벨만 남아
+                // 한글과 달라진다.
+                if matches!(
+                    ph.kind,
+                    crate::renderer::render_tree::PlaceholderKind::MissingPicture
+                ) {
+                    self.draw_missing_picture_placeholder(&node.bbox);
+                    return;
+                }
                 // Task #195: 차트/OLE placeholder (점선 테두리 + 중앙 라벨)
                 let cx = node.bbox.x + node.bbox.width / 2.0;
                 let cy = node.bbox.y + node.bbox.height / 2.0;
@@ -1519,6 +1529,61 @@ impl SvgRenderer {
     }
 
     /// 이미지 노드를 fill_mode에 따라 렌더링한다.
+    /// 한글 편집 화면의 "그림 없음" 표시 — 개체 영역 점선 테두리 + 중앙의 작은
+    /// 그림-없음 아이콘(사선 그은 그림 픽토그램).
+    ///
+    /// 기하·색은 `web_canvas.rs::render_placeholder` 와 같은 값을 쓴다 — 같은 표시를
+    /// 두 백엔드가 다른 모양으로 그리면 studio 화면과 SVG 내보내기가 갈라진다.
+    /// 인쇄 등가 profile 에서는 호출부(`show_missing_picture_placeholder`)가 막는다.
+    fn draw_missing_picture_placeholder(&mut self, bbox: &super::render_tree::BoundingBox) {
+        self.output.push_str(&format!(
+            "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"none\" stroke=\"#999999\" stroke-width=\"1\" stroke-dasharray=\"2 2\"/>
+",
+            bbox.x, bbox.y, bbox.width, bbox.height,
+        ));
+        let icon = (bbox.width.min(bbox.height) * 0.4).clamp(14.0, 36.0);
+        let ix = bbox.x + (bbox.width - icon) / 2.0;
+        let iy = bbox.y + (bbox.height - icon) / 2.0;
+        // 아이콘 판 + 산 두 개 + 해 + 사선(그림 없음)
+        self.output.push_str(&format!(
+            "<rect x=\"{:.2}\" y=\"{:.2}\" width=\"{:.2}\" height=\"{:.2}\" fill=\"#ffffff\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix,
+            iy,
+            icon,
+            icon * 0.75,
+        ));
+        self.output.push_str(&format!(
+            "<polyline points=\"{:.2},{:.2} {:.2},{:.2} {:.2},{:.2} {:.2},{:.2} {:.2},{:.2}\" fill=\"none\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix + icon * 0.08,
+            iy + icon * 0.62,
+            ix + icon * 0.32,
+            iy + icon * 0.30,
+            ix + icon * 0.52,
+            iy + icon * 0.62,
+            ix + icon * 0.68,
+            iy + icon * 0.42,
+            ix + icon * 0.92,
+            iy + icon * 0.62,
+        ));
+        self.output.push_str(&format!(
+            "<circle cx=\"{:.2}\" cy=\"{:.2}\" r=\"{:.2}\" fill=\"none\" stroke=\"#888888\" stroke-width=\"1\"/>
+",
+            ix + icon * 0.72,
+            iy + icon * 0.20,
+            icon * 0.07,
+        ));
+        self.output.push_str(&format!(
+            "<line x1=\"{:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#cc4444\" stroke-width=\"1.5\"/>
+",
+            ix,
+            iy + icon * 0.75,
+            ix + icon,
+            iy,
+        ));
+    }
+
     fn render_image_node(&mut self, img: &ImageNode, bbox: &super::render_tree::BoundingBox) {
         // [Task #741] 빈 binary 데이터 (외부 file path 그림 등) 도 placeholder 처리.
         // 한컴 한글 2024 viewer 정합 — 외부 file 못 찾는 경우 점선 사각형 + 깨진 image 아이콘.

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -388,8 +388,10 @@ mod tests {
         let mut print = SvgLayerRenderer::new();
         print.render_page(&print_tree).unwrap();
 
-        assert!(screen.output().contains("stroke-dasharray=\"6 3\""));
-        assert!(!print.output().contains("stroke-dasharray=\"6 3\""));
+        // 점선은 한글 편집 화면 실측(2px on / 2px off)에 맞춘 값이다 — 차트/OLE 의
+        // "6 3" 파선과 구별된다.
+        assert!(screen.output().contains("stroke-dasharray=\"2 2\""));
+        assert!(!print.output().contains("stroke-dasharray=\"2 2\""));
     }
 
     /// [Issue #4379] `editor_only` 표시 판정은 legacy(`SvgRenderer::profile`)와 layer

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -1158,7 +1158,9 @@ impl WebCanvasRenderer {
             if !self.render_profile.shows_editor_visuals() {
                 return;
             }
-            self.set_line_dash(&StrokeDash::Dash);
+            // 한글 편집 화면의 테두리는 굵은 파선이 아니라 잔 점선이다 — 오라클 화면
+            // 실측(2px on / 2px off)에 맞춘다. `svg.rs` 의 stroke-dasharray 와 같은 값.
+            self.set_line_dash(&StrokeDash::Dot);
             self.ctx.set_stroke_style_str("#999999");
             self.ctx.set_line_width(1.0);
             self.ctx

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -759,18 +759,47 @@ fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
         // 컨트롤이 자동번호인데 공백이 마지막이면 그 공백이 곧 placeholder 다 — 진짜
         // 공백이었다면 그 뒤에 placeholder 가 하나 더 붙어 마지막이 아니게 된다.
         let is_last_text_char = i + 1 == text_chars.len();
-        let is_autonum_placeholder = *ch == ' '
-            && offset == prev_end
-            && ctrl_idx < para.controls.len()
-            // [#3495] 0x0012(자동번호)만 placeholder 공백을 만든다. 두 파서 모두
-            // 그렇다 — parser/body_text.rs 는 ch == 0x0012 일 때만, HWPX section.rs 는
-            // 0x0012 파트일 때만 text 에 공백을 push 한다. 각주·미주(0x0011)는
-            // placeholder 를 만들지 않으므로, 여기 포함하면 미주 앞의 진짜 공백을
-            // placeholder 로 오인해 컨트롤로 덮어쓴다 (SO-SUEOP.hwp 문단 238:
-            // 공백 12개 -> 11개, 뒤 텍스트가 한 칸 당겨짐).
-            && matches!(control_char_code_and_id(&para.controls[ctrl_idx]).0, 0x0012)
-            && next_offset.map_or(is_last_text_char, |n| n >= offset + 8);
-        if is_autonum_placeholder {
+        // 자리표시자 판정 — 종류별 근거는 아래 `match` 팔에 적는다.
+        //
+        // 판정이 `prev_end`·`ctrl_idx` 에 걸려 있어 **갭을 채우기 전과 후에 각각** 묻는다.
+        // 문단 선두에 예약된 갭(구역·단 정의 자리)이 있으면 첫 물음에서는 `prev_end` 가
+        // 아직 0 이라 판정이 실패한다 — 그 자리를 채운 뒤 다시 물어야 자리표시자를 알아본다
+        // (#4957: `secd`·`cold` 를 앞세운 HWP3 첫 문단).
+        //
+        // 두 번째 물음은 `object_only` 로 **U+FFFC 만** 받는다. 공백 자리표시자는 판별자가
+        // 글자가 아니라 `controls[ctrl_idx]` 의 코드(0x0012)뿐인데, 갭을 채우고 나면
+        // `ctrl_idx` 가 다른 컨트롤을 가리킨다 — 그때 다시 물으면 미주 앞의 **진짜 공백**이
+        // 자동번호로 오인돼 먹힌다(#3495 SO-SUEOP 문단 238). `U+FFFC` 는 글자 자체가
+        // 판별자라 이 위험이 없다.
+        let is_placeholder = |prev_end: u32, ctrl_idx: usize, object_only: bool| -> bool {
+            if offset != prev_end
+                || ctrl_idx >= para.controls.len()
+                || !next_offset.map_or(is_last_text_char, |n| n >= offset + 8)
+            {
+                return false;
+            }
+            match *ch {
+                // [#4957] HWP3 가시 개체의 자리표시자는 `U+FFFC` 다. 파서가 그 자리에
+                // **글자 하나 + 8유닛 슬롯**을 두므로(암호 HWP3 경로가 쓰던 계약을 전
+                // 경로로 넓힘) 자동번호 공백과 같은 모양이다 — 여기서 리터럴 대신 컨트롤을
+                // 써야 저장본에 원본에 없던 개체 문자가 남지 않는다(10k 전수 HWP3 28문서
+                // 56경로). 공백과 달리 컨트롤 종류를 가리지 않는다. `U+FFFC` 는 한컴
+                // 원본이 본문에 한 번도 쓰지 않는 글자라(hwp 0/6,579 · hwpx 0/3,418)
+                // 진짜 본문과 헷갈릴 여지가 없다.
+                '\u{FFFC}' => true,
+                // [#3495] 0x0012(자동번호)만 placeholder 공백을 만든다. 두 파서 모두
+                // 그렇다 — parser/body_text.rs 는 ch == 0x0012 일 때만, HWPX section.rs 는
+                // 0x0012 파트일 때만 text 에 공백을 push 한다. 각주·미주(0x0011)는
+                // placeholder 를 만들지 않으므로, 여기 포함하면 미주 앞의 진짜 공백을
+                // placeholder 로 오인해 컨트롤로 덮어쓴다 (SO-SUEOP.hwp 문단 238:
+                // 공백 12개 -> 11개, 뒤 텍스트가 한 칸 당겨짐).
+                ' ' if !object_only => {
+                    matches!(control_char_code_and_id(&para.controls[ctrl_idx]).0, 0x0012)
+                }
+                _ => false,
+            }
+        };
+        if is_placeholder(prev_end, ctrl_idx, false) {
             let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
             push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
             ctrl_idx += 1;
@@ -826,6 +855,17 @@ fn serialize_para_text(para: &Paragraph) -> ParaTextResult {
                 prev_end += 8;
             }
             ctrl_idx += 1;
+        }
+
+        // ③-b 갭을 채우고 나서 자리표시자를 다시 묻는다 — 위 첫 물음은 선두 예약 갭
+        //     때문에 실패했을 수 있다. 여기서 걸리면 `ctrl_idx` 가 갭을 채운 만큼 앞으로
+        //     가 있어, 자리표시자가 **자기 컨트롤**과 짝지어진다(#4957).
+        if is_placeholder(prev_end, ctrl_idx, true) {
+            let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
+            push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
+            ctrl_idx += 1;
+            prev_end = offset + 8;
+            continue;
         }
 
         // ④ 빈 필드(시작==끝)의 FIELD_END — 자기 BEGIN 직후.

--- a/tests/cases/issue_3532_trailing_charshape_boundary.rs
+++ b/tests/cases/issue_3532_trailing_charshape_boundary.rs
@@ -18,12 +18,23 @@ fn issue3532_trailing_boundary_survives_hwpx_roundtrip() {
     let original = parse_document(&bytes).expect("parse hwp3");
 
     // 샘플 전제: 본문 끝 zero-width 경계 + 말미 컨트롤이 공존하는 문단(26).
+    //
+    // [#4957] 경계 좌표는 **글자 수가 아니라 UTF-16 코드유닛 축**이다. 종전에는 이 문단의
+    // 마커(새번호·쪽번호 위치)가 1유닛만 차지해 두 축이 우연히 같았고, 그래서 글자 수로
+    // 비교해도 통과했다. 마커를 확장 컨트롤 8유닛으로 바로잡자 두 축이 갈라진다
+    // (문단 26: 글자 50 · 축 64). 시험이 지키는 계약은 **왕복 뒤 경계가 밀리지 않는가**
+    // 이므로, 전제는 축 끝으로 표현한다.
     let p26 = &original.sections[0].paragraphs[26];
-    let text_units = p26.text.chars().count() as u32;
+    let text_axis_end = p26
+        .char_offsets
+        .last()
+        .zip(p26.text.chars().last())
+        .map(|(offset, last)| offset + last.len_utf16() as u32)
+        .expect("샘플 전제: 문단 26 은 본문이 있다");
     assert!(
         p26.char_shapes
             .last()
-            .is_some_and(|cs| cs.start_pos == text_units),
+            .is_some_and(|cs| cs.start_pos == text_axis_end),
         "샘플 전제: 마지막 경계가 본문 끝(zero-width)이어야 한다"
     );
     assert!(!p26.controls.is_empty(), "샘플 전제: 말미 컨트롤");

--- a/tests/issue_3492_hwp3_outline_marker_leak.rs
+++ b/tests/issue_3492_hwp3_outline_marker_leak.rs
@@ -102,6 +102,17 @@ fn endnote_marks_keep_their_recorded_offset() {
             else {
                 continue;
             };
+            // [#4957] 선두 갭이 있는 문단은 제외한다. 아래 `gap` 은 **문자 사이** 갭만
+            // 찾으므로(`windows(2)`), 첫 문자 앞에 놓인 8유닛 슬롯을 보지 못한다. 그런
+            // 문단에서는 "첫 내부 갭 = 미주 자리" 라는 가정이 성립하지 않는다 — 미주가
+            // 선두 슬롯이고 내부 갭은 다른 개체 것일 수 있다(SO-SUEOP 의 미주+양식
+            // 문단이 그렇다: controls=[Endnote, Form], 축은 미주 0..8 · Form 19..27).
+            //
+            // 이 시험이 지키는 것은 #3492 의 계약 — 앵커 없는 마커가 앞자리를 가로채
+            // 미주를 밀어내지 않는가 — 이고, 그 판정에는 선두 갭 없는 문단으로 충분하다.
+            if paragraph.char_offsets.first().copied().unwrap_or(0) > 0 {
+                continue;
+            }
             // 오프셋에 공백이 있는 문단만 — 미주가 본문 중간에 앵커된 경우다.
             let gap = paragraph
                 .char_offsets

--- a/tests/issue_3495_endnote_space_eaten.rs
+++ b/tests/issue_3495_endnote_space_eaten.rs
@@ -76,6 +76,18 @@ fn convert_roundtrip() -> std::path::PathBuf {
     out
 }
 
+/// [#4957] HWP3 개체 마커(`U+FFFC`)는 본문 글자가 아니므로 비교 축에서 뺀다.
+///
+/// 파서가 개체 자리에 넣는 자리표시자이고, 저장기는 그 자리에 **확장 컨트롤 8유닛**을 쓴다 —
+/// 리터럴 글자로 쓰면 저장본을 한글로 열 때 원본에 없던 개체 문자가 생긴다. 그래서 왕복 뒤
+/// 텍스트에 이 글자가 없는 것이 정상이고, 종전에 남아 있던 쪽이 결함이었다.
+///
+/// 이 시험이 지키는 계약은 **미주 앞의 진짜 공백이 먹히지 않는가** 다. 마커를 뺀 축으로
+/// 비교해도 그 계약은 그대로 검출된다(실측 표본 문단 147: 마커 양옆 공백 두 개가 모두 남는다).
+fn without_object_markers(text: &str) -> String {
+    text.chars().filter(|c| *c != '\u{FFFC}').collect()
+}
+
 /// 미주가 있는 문단의 텍스트가 저장으로 바뀌지 않는다.
 #[test]
 fn saving_keeps_the_space_before_an_endnote() {
@@ -91,6 +103,10 @@ fn saving_keeps_the_space_before_an_endnote() {
 
     assert_eq!(after.len(), before.len(), "저장 후 미주 문단 수가 달라졌다");
     for (i, ((text_a, _), (text_b, _))) in before.iter().zip(after.iter()).enumerate() {
+        let (text_a, text_b) = (
+            without_object_markers(text_a),
+            without_object_markers(text_b),
+        );
         assert_eq!(
             text_a.chars().count(),
             text_b.chars().count(),


### PR DESCRIPTION
## 변경 내용

planet6897 기여자의 다음 PR을 최신 `upstream/devel` 기준으로 순서대로 체리픽해 통합했습니다.

- #5483: HWP3 개체 자리표시자의 8유닛 컨트롤 슬롯 보존
- #5515: 디코드할 수 없는 그림 바이트의 그림-없음 표시

각 원 PR의 검토 기록은 같은 PR에 archive 문서로 포함했습니다.

- `mydocs/pr/archives/pr_5483_review.md`
- `mydocs/pr/archives/pr_5515_review.md`

## 검증

- 기준선: `upstream/devel@e5ef2620bd469aa2d0118097c4d04f63cfdacdc3`
- 충돌 없음
- `cargo fmt --all -- --check` 통과
- Rust test suite manifest 및 unit test tier check 통과
- `git diff --check` 통과
- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`
  - 7300 passed
  - 38 skipped
  - 8 slow
- #5515 비공개 EPS/AI fixture의 screen·print SVG를 직접 확인했고, screen에는 그림-없음
  표시가, print에는 PostScript data URI와 placeholder가 없는 것을 확인했습니다.

## 판정

로컬 통합 검토에서 차단 결함은 발견하지 못했습니다. #5483의 HWPX 비가시 컨트롤 축 잔여
2건과 #5515의 자동 fixture 보강은 각 archive 검토 문서에 후속 범위로 기록했습니다.

관련 원 PR과 이슈:

- #5483 / #4957
- #5515 / #5513
