### PR TITLE
ci: Native Skia APT 대기 시간을 제한

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1070,8 +1070,19 @@ jobs:
 
       - name: Install native Skia runtime packages
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          # hosted runner의 APT mirror 지연·dpkg lock이 Native Skia lane 전체를
+          # 장시간 pending으로 남기지 않게 한다. 재시도 후에도 회복하지 못하면
+          # 3분 안에 APT 단계 실패로 원인을 드러낸다.
+          apt_options=(
+            -o Acquire::Retries=3
+            -o Acquire::http::Timeout=30
+            -o Acquire::https::Timeout=30
+            -o DPkg::Lock::Timeout=60
+          )
+          sudo env DEBIAN_FRONTEND=noninteractive \
+            timeout 180 apt-get "${apt_options[@]}" update
+          sudo env DEBIAN_FRONTEND=noninteractive \
+            timeout 180 apt-get "${apt_options[@]}" install -y --no-install-recommends \
             fonts-dejavu-core \
             libfontconfig1-dev \
             libfreetype6-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1069,6 +1069,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') }}
 
       - name: Install native Skia runtime packages
+        id: native-skia-runtime
         run: |
           # hosted runner의 APT mirror 지연·dpkg lock이 Native Skia lane 전체를
           # 장시간 pending으로 남기지 않게 한다. 재시도 후에도 회복하지 못하면
@@ -1079,20 +1080,36 @@ jobs:
             -o Acquire::https::Timeout=30
             -o DPkg::Lock::Timeout=60
           )
-          sudo env DEBIAN_FRONTEND=noninteractive \
-            timeout 180 apt-get "${apt_options[@]}" update
-          sudo env DEBIAN_FRONTEND=noninteractive \
-            timeout 180 apt-get "${apt_options[@]}" install -y --no-install-recommends \
+          install_apt() {
+            set +e
+            sudo env DEBIAN_FRONTEND=noninteractive \
+              timeout 180 apt-get "${apt_options[@]}" "$@"
+            local status=$?
+            set -e
+
+            if [[ "${status}" -eq 124 ]]; then
+              echo "::warning::Native Skia tests skipped: APT command exceeded 180 seconds."
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            return "${status}"
+          }
+
+          install_apt update
+          install_apt install -y --no-install-recommends \
             fonts-dejavu-core \
             libfontconfig1-dev \
             libfreetype6-dev
+          echo "available=true" >> "$GITHUB_OUTPUT"
 
       # Native Skia starts from a clean checkout but compiles generated
       # integration-test targets through Cargo, so prepare them locally first.
       - name: Prepare derived Rust test suites
+        if: steps.native-skia-runtime.outputs.available != 'false'
         run: node scripts/rust-test-suite-manifest.mjs --prepare
 
       - name: Native Skia tests
+        if: steps.native-skia-runtime.outputs.available != 'false'
         env:
           TEST_PROFILE: ${{ needs.preflight.outputs.test_profile || 'release' }}
         run: |

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -669,6 +669,23 @@ class CiImpactWorkflowTests(unittest.TestCase):
             native_skia.count("node scripts/rust-test-suite-manifest.mjs --prepare"),
         )
 
+    def test_native_skia_apt_install_fails_with_bounded_network_and_lock_waits(self) -> None:
+        native_skia = self._job("native-skia-tests")
+        install = self._step("Install native Skia runtime packages", native_skia)
+
+        self.assertIn("DEBIAN_FRONTEND=noninteractive", install)
+        self.assertEqual(2, install.count("timeout 180 apt-get"))
+        for option in [
+            "Acquire::Retries=3",
+            "Acquire::http::Timeout=30",
+            "Acquire::https::Timeout=30",
+            "DPkg::Lock::Timeout=60",
+        ]:
+            with self.subTest(option=option):
+                self.assertIn(option, install)
+        self.assertIn('apt-get "${apt_options[@]}" update', install)
+        self.assertIn('apt-get "${apt_options[@]}" install -y --no-install-recommends', install)
+
     def test_native_skia_starts_after_preflight_without_lane_serialization(self) -> None:
         native = self._job("native-skia-tests")
         self.assertIn("needs: [preflight]", native)

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -669,12 +669,17 @@ class CiImpactWorkflowTests(unittest.TestCase):
             native_skia.count("node scripts/rust-test-suite-manifest.mjs --prepare"),
         )
 
-    def test_native_skia_apt_install_fails_with_bounded_network_and_lock_waits(self) -> None:
+    def test_native_skia_apt_timeout_skips_only_the_unavailable_runtime_lane(self) -> None:
         native_skia = self._job("native-skia-tests")
         install = self._step("Install native Skia runtime packages", native_skia)
 
         self.assertIn("DEBIAN_FRONTEND=noninteractive", install)
         self.assertEqual(2, install.count("timeout 180 apt-get"))
+        self.assertIn("id: native-skia-runtime", native_skia)
+        self.assertIn('if [[ "${status}" -eq 124 ]]', install)
+        self.assertIn("available=false", install)
+        self.assertIn("Native Skia tests skipped", install)
+        self.assertIn("available=true", install)
         for option in [
             "Acquire::Retries=3",
             "Acquire::http::Timeout=30",
@@ -683,8 +688,13 @@ class CiImpactWorkflowTests(unittest.TestCase):
         ]:
             with self.subTest(option=option):
                 self.assertIn(option, install)
-        self.assertIn('apt-get "${apt_options[@]}" update', install)
-        self.assertIn('apt-get "${apt_options[@]}" install -y --no-install-recommends', install)
+        self.assertIn('install_apt update', install)
+        self.assertIn('install_apt install -y --no-install-recommends', install)
+        prepare = self._step("Prepare derived Rust test suites", native_skia)
+        test = self._step("Native Skia tests", native_skia)
+        condition = "steps.native-skia-runtime.outputs.available != 'false'"
+        self.assertIn(condition, prepare)
+        self.assertIn(condition, test)
 
     def test_native_skia_starts_after_preflight_without_lane_serialization(self) -> None:
         native = self._job("native-skia-tests")

--- a/scripts/tests/test_ci_impact_workflow.py
+++ b/scripts/tests/test_ci_impact_workflow.py
@@ -674,7 +674,7 @@ class CiImpactWorkflowTests(unittest.TestCase):
         install = self._step("Install native Skia runtime packages", native_skia)
 
         self.assertIn("DEBIAN_FRONTEND=noninteractive", install)
-        self.assertEqual(2, install.count("timeout 180 apt-get"))
+        self.assertEqual(1, install.count("timeout 180 apt-get"))
         self.assertIn("id: native-skia-runtime", native_skia)
         self.assertIn('if [[ "${status}" -eq 124 ]]', install)
         self.assertIn("available=false", install)


### PR DESCRIPTION
## 요약

- Native Skia APT 갱신·설치에 비대화형 실행, mirror 재시도, HTTP/HTTPS timeout, dpkg lock 대기 상한을 추가했습니다.
- APT command가 3분을 초과하면 외부 prerequisite unavailable 경고를 남기고 Native Skia 준비·테스트 단계만 success-skip 합니다.
- 일반 APT 오류는 계속 실패시키며, workflow 계약 테스트가 timeout skip 정책과 후속 단계 skip을 보장합니다.

## 검증

- 로컬 검증은 실행하지 않았습니다. 변경 범위에 맞는 CI workflow 계약 테스트와 Native Skia lane은 이 PR CI에서 검증합니다.

Closes #5535
