### PR TITLE
fix(equation): 첨자 앞 Thin 공백(`)의 시각 폭·AST 정보 보존

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -29,3 +29,11 @@ date: 2026-08-19
 - 원 PR 기능 head `75c2af163fcbcf155a3273e61dca19aeab354b3c`의 `CharShape::default()` 장평을 OWPML 기본값 `100`으로 정합화했다.
 - 최신 `devel` 병합 보정과 [PR #5398 검토 기록](../pr/archives/pr_5398_review.md)을 포함한 code/trailing head의 GitHub Full CI·CodeQL·Native Skia·Canvas visual diff는 모두 통과했다.
 - 이 항목만 trailing 문서 commit으로 반영한다. push 후 최신 head의 CI·mergeable 상태를 확인하고, 통과하면 PR #5398 merge 및 #4161 상태·comment·로컬 branch 정리를 수행한다.
+
+## #5548 수식 Thin 공백 첨자 결합과 폭 보존
+
+- PR [#5548](https://github.com/edwardkim/rhwp/pull/5548)는 issue [#5534](https://github.com/edwardkim/rhwp/issues/5534)의 `a`_{2}`·`log`_{2}` Thin 공백 폭 보존을 처리한다.
+- contributor 원 변경 `095ab811b71c2bfa7daf26a6d4f5c892f3909d8d` 뒤에 메인터너 보정 `648cef952`와 포맷 `0a334bd3`을 추가했다. 괄호 base `(a)`의 Thin 공백 뒤 아래·위 첨자도 결합하고 `Space(Thin)` 폭을 보존한다.
+- `cargo fmt --all -- --check`, suite manifest 정책, source-side unit tier 정책과 최신 code candidate의 Full CI·CodeQL·Native Skia·Render Diff는 통과했다.
+- [PR #5548 검토 기록](../pr/archives/pr_5548_review.md)과 이 항목은 CI 성공 뒤 같은 docs-only trailing commit으로 contributor source branch에 push한다.
+- trailing head의 aggregate와 mergeability를 다시 확인한 뒤 승인 절차에 따라 merge하며, `closes #5534`의 auto-close와 후속 comment·branch/worktree 정리를 확인한다.

--- a/mydocs/pr/archives/pr_5548_review.md
+++ b/mydocs/pr/archives/pr_5548_review.md
@@ -1,0 +1,73 @@
+---
+kind: pr-review
+status: in-review
+pr: 5548
+issue: 5534
+base: devel
+code_candidate: 0a334bd3ca3a68f45fbba53d71169a5f2610fe5d
+last_verified: 2026-08-19
+---
+
+# PR #5548 검토: 수식 Thin 공백 첨자 결합과 폭 보존
+
+## 접수
+
+- PR: [#5548](https://github.com/edwardkim/rhwp/pull/5548)
+- 관련 이슈: [#5534](https://github.com/edwardkim/rhwp/issues/5534), PR 본문의 `closes #5534`
+- 작성자: `planet6897`; base: `devel`; 작성 시점 head: `0a334bd3ca3a68f45fbba53d71169a5f2610fe5d`
+- reviewer: `jangster77`
+- base route: `collaborator_external_pr.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `visual_fixture_evidence.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md` 및 위 라우팅 문서
+
+## 변경 범위와 계보
+
+- contributor 원 변경 `095ab811b71c2bfa7daf26a6d4f5c892f3909d8d`는 첨자 앞 Thin 공백을
+  `Row[base, Space(Thin)]`의 base 폭으로 보존하고, 함수명 뒤 첨자 경로가 이를 소비하지 않게 했다.
+- collaborator 보정 `648cef952`는 괄호 그룹도 같은 규칙을 따르도록 했다. `paren_then_script`가
+  닫는 괄호 뒤 Thin 공백 하나를 건너뛰어 `_`와 `^`를 식별하고, 기존 `try_parse_scripts`가 공백을
+  base에 보존한다.
+- 포맷 commit `0a334bd3`은 위 보정의 Rust 포맷만 반영한다.
+- 원 contributor commit은 재작성하지 않았고, 모든 collaborator commit은 원 head 뒤에 추가됐다.
+
+## 검토 결과
+
+- 차단 결함: 없음.
+- 메인터너 보정 전 `(a)`_{2}`와 `(a)`^{2}`는 닫는 괄호와 스크립트 사이 Thin 공백 때문에
+  `Paren` 그룹으로 묶이지 않아 스크립트 결합 경로를 놓칠 수 있었다.
+- 보정은 공백을 삭제하거나 일반 괄호 파싱을 바꾸지 않는다. 스크립트 바로 앞의 Thin 공백 하나에만
+  적용되며, 최종 base의 `Space(Thin)` 폭은 기존 공통 스크립트 처리에 맡긴다.
+- 회귀 계약은 일반 base, 함수 base, 위첨자, 괄호 base의 아래·위 첨자에서 AST 결합과 Thin 공백 보존을
+  확인한다.
+
+## 검증 증적
+
+### 로컬
+
+- `cargo fmt --all -- --check` 통과.
+- `node scripts/rust-test-suite-manifest.mjs --prepare`로 무시되는 파생 suite를 준비한 뒤
+  `node scripts/rust-test-suite-manifest.mjs --check` 통과.
+- `node scripts/rust-unit-test-tiers.mjs --check` 통과.
+- 이번 보정의 focused Rust test와 renderer 시각 검증은 아직 실행하지 않았다.
+
+### 시각·fixture
+
+- 이 변경은 수식 parser AST와 첨자 앵커 폭을 보존하는 구조 보정이다. 독립 HWP/HWPX fixture와 기준
+  PDF는 PR에 첨부되지 않았고, 이슈 #5534의 한컴 비교 이미지는 참고 근거다.
+- `Space(Thin)`가 base의 오른쪽 경계를 넓혀 첨자 위치를 이동시키는 기존 layout 계약을 활용한다.
+  따라서 별도 시각 비교는 참고 자료로 유지하며, parser AST 계약과 최신 CI를 merge 조건으로 삼는다.
+
+### GitHub Actions
+
+- `0a334bd3`의 Full CI aggregate, lint, archive builder, slow/regular shard 4개, Native Skia, CodeQL Rust,
+  Canvas visual diff, Proptest, adapter inter-diff가 모두 성공했다. frontend 및 WASM은 영향 정책에 따라 skipped다.
+- `cancel-stale-runs`의 실패는 이전 run 정리 workflow 기록이며, 최신 code candidate의 Build & Test aggregate와
+  required code 검증 성공을 대체하거나 무효화하지 않는다.
+- contributor source branch의 원격 head가 이 candidate와 같은지 확인한 뒤 review·오늘할일 docs-only trailing
+  commit을 push하고, 그 새 head의 review-only aggregate를 다시 확인한다.
+
+## 다음 게이트
+
+**code candidate 검증 완료.** 이 문서와 오늘할일만 담은 single-parent docs-only commit을 contributor
+source branch에 추가한다. 해당 trailing commit은 review-only fast-pass 조건과 최신 aggregate를 다시 확인한
+뒤 merge 판단으로 진행한다.

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -631,9 +631,11 @@ impl EqParser {
             .copied()
             .unwrap_or(self.tokens.len());
         let next = close + 1;
-        let script = if self.tokens.get(next).is_some_and(|token| {
-            token.ty == TokenType::Whitespace && token.value == "`"
-        }) {
+        let script = if self
+            .tokens
+            .get(next)
+            .is_some_and(|token| token.ty == TokenType::Whitespace && token.value == "`")
+        {
             next + 1
         } else {
             next

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -619,7 +619,8 @@ impl EqParser {
         self.tokens.len()
     }
 
-    /// 현재 LParen 의 매칭 RParen 다음 토큰이 첨자(`^`/`_`)인지 (#1305).
+    /// 현재 LParen 의 매칭 RParen 다음 첨자(`^`/`_`)인지 (#1305).
+    /// RParen 뒤의 Thin 공백(`) 하나는 첨자 결합 전에 보존되는 공백이므로 건너뛴다.
     /// 참이면 `(...)` 를 Paren 그룹으로 묶어 첨자를 결합해야 한다.
     /// 현재 토큰이 LParen 이라는 전제. 사전계산된 `paren_match` 로 O(1) 조회한다
     /// (원래는 매 호출 O(n) 전방 스캔 → 괄호 많은 입력에서 O(n^2) 행 유발).
@@ -629,8 +630,16 @@ impl EqParser {
             .get(self.pos)
             .copied()
             .unwrap_or(self.tokens.len());
+        let next = close + 1;
+        let script = if self.tokens.get(next).is_some_and(|token| {
+            token.ty == TokenType::Whitespace && token.value == "`"
+        }) {
+            next + 1
+        } else {
+            next
+        };
         matches!(
-            self.tokens.get(close + 1).map(|t| t.ty),
+            self.tokens.get(script).map(|t| t.ty),
             Some(TokenType::Subscript) | Some(TokenType::Superscript)
         )
     }

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -509,8 +509,15 @@ impl EqParser {
 
         if is_function(cmd) {
             let func_name = lookup_function(cmd).unwrap_or(cmd).to_string();
+            // 함수명 뒤 Thin 공백은 종전대로 소비하되, 바로 뒤가 첨자면 남겨서
+            // try_parse_scripts 가 폭을 보존하며 결합하게 한다(#5534).
             if self.current_type() == TokenType::Whitespace && self.current_value() == "`" {
-                self.pos += 1;
+                let after_space_is_script = self.tokens.get(self.pos + 1).is_some_and(|t| {
+                    t.ty == TokenType::Subscript || t.ty == TokenType::Superscript
+                });
+                if !after_space_is_script {
+                    self.pos += 1;
+                }
             }
             let node = EqNode::Function(func_name);
             return self.try_parse_scripts(node);
@@ -756,13 +763,20 @@ impl EqParser {
             if self.at_end() {
                 break;
             }
-            // Thin 공백(`) 뒤에 첨자가 바로 오는 경우 공백을 건너뛰기
+            // Thin 공백(`) 뒤에 첨자가 오면 첨자 결합은 유지하되(과거 exam_math
+            // `log`_{2}` 첨자 파싱 실패 수정), 공백의 시각 폭은 base 뒤에 보존한다.
+            // 한컴은 `a_{2}` 와 `` a`_{2} `` 를 다르게 렌더한다 — 공백 토큰을
+            // 삭제만 하면 첨자가 붙는 위치(가로)와 AST 정보가 함께 사라진다(#5534).
+            // Subscript/Superscript 레이아웃은 base box 오른쪽 끝에 첨자를 두므로
+            // base 를 Row[base, Space(Thin)] 로 감싸면 첨자가 1/4 공백만큼
+            // 오른쪽에 놓인다.
             if self.current_type() == TokenType::Whitespace && self.current_value() == "`" {
                 let next_pos = self.pos + 1;
                 if next_pos < self.tokens.len() {
                     let next_ty = self.tokens[next_pos].ty;
                     if next_ty == TokenType::Subscript || next_ty == TokenType::Superscript {
-                        self.pos += 1; // Thin 공백 건너뛰기
+                        self.pos += 1; // Thin 공백 소비 (폭은 아래에서 보존)
+                        result = EqNode::Row(vec![result, EqNode::Space(SpaceKind::Thin)]);
                     }
                 }
             }

--- a/tests/cases/issue_5534_eq_thin_space_scripts.rs
+++ b/tests/cases/issue_5534_eq_thin_space_scripts.rs
@@ -1,0 +1,69 @@
+//! [#5534] 수식 Thin 공백(`) + 첨자 계약.
+//!
+//! 한컴은 `a_{2}` 와 `` a`_{2} `` 를 다르게 렌더한다 — 공백이 있으면 첨자가
+//! 1/4 공백만큼 오른쪽에 놓인다. 종전 파서는 첨자 앞 Thin 공백 토큰을 삭제해
+//! (exam_math `log`_{2}` 첨자 파싱 실패의 과잉 교정) 두 스크립트가 같은 AST 가
+//! 됐다. 수정 후: 첨자 결합은 유지하되 공백 폭을 base 뒤 `Space(Thin)` 으로
+//! 보존한다 — AST 소비자도 두 표기를 구분할 수 있다.
+
+use rhwp::renderer::equation::ast::{EqNode, SpaceKind};
+use rhwp::renderer::equation::parser::parse;
+
+fn base_of(node: &EqNode) -> Option<&EqNode> {
+    match node {
+        EqNode::Subscript { base, .. } => Some(base),
+        EqNode::Superscript { base, .. } => Some(base),
+        _ => None,
+    }
+}
+
+fn base_ends_with_thin_space(node: &EqNode) -> bool {
+    matches!(
+        base_of(node),
+        Some(EqNode::Row(children))
+            if matches!(children.last(), Some(EqNode::Space(SpaceKind::Thin)))
+    )
+}
+
+#[test]
+fn thin_space_before_script_is_preserved_not_collapsed() {
+    // 공백 유무는 다른 AST 다 — 첨자 결합은 양쪽 모두 유지.
+    let tight = parse("a_{2}");
+    let spaced = parse("a`_{2}");
+    assert_ne!(spaced, tight, "Thin 공백의 정보/시각 폭이 사라지면 안 된다");
+    assert!(base_of(&tight).is_some(), "a_{{2}} 는 첨자 결합");
+    assert!(
+        base_ends_with_thin_space(&spaced),
+        "a`_{{2}} 는 base 꼬리에 Space(Thin) 을 보존한 첨자 결합이어야 한다: {spaced:?}"
+    );
+}
+
+#[test]
+fn function_script_keeps_binding_and_space_width() {
+    // exam_math 원 결함(첨자 파싱 실패) 회귀 방지: log`_{2} 는 여전히 첨자 결합.
+    let spaced = parse("log`_{2}");
+    assert_ne!(spaced, parse("log_{2}"));
+    assert!(
+        base_ends_with_thin_space(&spaced),
+        "log`_{{2}} 도 결합 + 공백 폭 보존이어야 한다: {spaced:?}"
+    );
+    // 함수 뒤 공백의 종전 소비(첨자가 아닐 때)는 불변 — Space 노드가 생기지 않는다.
+    fn has_space(node: &EqNode) -> bool {
+        match node {
+            EqNode::Space(_) => true,
+            EqNode::Row(children) => children.iter().any(has_space),
+            _ => false,
+        }
+    }
+    assert!(
+        !has_space(&parse("log`x")),
+        "함수명 직후 Thin 공백(비첨자)은 종전대로 소비된다"
+    );
+}
+
+#[test]
+fn superscript_thin_space_also_preserved() {
+    let spaced = parse("x`^{2}");
+    assert_ne!(spaced, parse("x^{2}"));
+    assert!(base_ends_with_thin_space(&spaced), "{spaced:?}");
+}

--- a/tests/cases/issue_5534_eq_thin_space_scripts.rs
+++ b/tests/cases/issue_5534_eq_thin_space_scripts.rs
@@ -67,3 +67,32 @@ fn superscript_thin_space_also_preserved() {
     assert_ne!(spaced, parse("x^{2}"));
     assert!(base_ends_with_thin_space(&spaced), "{spaced:?}");
 }
+
+#[test]
+fn parenthesized_base_thin_space_before_scripts_stays_in_script_base() {
+    let subscript = parse("(a)`_{2}");
+    assert!(
+        base_ends_with_thin_space(&subscript),
+        "(a)`_{{2}} should keep the Thin space in the subscript base"
+    );
+    assert!(
+        matches!(
+            base_of(&subscript),
+            Some(EqNode::Row(children)) if matches!(children.first(), Some(EqNode::Paren { .. }))
+        ),
+        "(a)`_{{2}} should keep the parenthesized group as the subscript base"
+    );
+
+    let superscript = parse("(a)`^{2}");
+    assert!(
+        base_ends_with_thin_space(&superscript),
+        "(a)`^{{2}} should keep the Thin space in the superscript base"
+    );
+    assert!(
+        matches!(
+            base_of(&superscript),
+            Some(EqNode::Row(children)) if matches!(children.first(), Some(EqNode::Paren { .. }))
+        ),
+        "(a)`^{{2}} should keep the parenthesized group as the superscript base"
+    );
+}


### PR DESCRIPTION
## 변경 요약

수식 파서에서 **첨자(`_`/`^`) 앞 Thin 공백(`` ` ``)의 시각 폭과 AST 정보가 사라지던 문제**를
고칩니다(#5534, jannabiforever 님 분석 그대로입니다 — 감사합니다).

- 종전: `` a`_{2} `` 와 `a_{2}` 가 같은 AST — exam_math ``log`_{2}`` 첨자 파싱 실패를 고치며
  공백 토큰을 삭제한 과잉 교정(모든 base 경로에 적용).
- 수정: **첨자 결합은 유지**하되 base 를 `Row[base, Space(Thin)]` 로 감싸 공백 폭을 보존합니다.
  첨자 레이아웃은 base box 오른쪽 끝을 앵커로 쓰므로 첨자가 1/4 공백만큼 오른쪽에 놓입니다
  (한컴 실렌더와 동일 방향). AST 소비자도 두 표기를 구분할 수 있습니다.
- 함수명 직후 공백 선소비(`is_function` 경로)는 바로 뒤가 첨자일 때만 양보해 같은 보존 경로를
  태우고, 비첨자 케이스(``log`x``)는 종전 소비를 유지합니다.

## 관련 이슈

closes #5534

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test` 통과 — equation 단위 179건·`equation_command_goldens` 5건 전부 그린(옛 동작을
  잠근 테스트 없음), `cargo nextest run --no-fail-fast` 전체 실행(실패는 이 머신의 CRLF 체크아웃
  산물인 스킬 frontmatter 계약군·`wmf_emf_goldens` 텍스트 골든과 issue_2833 플레이크뿐 — #5525
  때와 동일 분류, CI 무관)
- [x] `cargo clippy -- -D warnings` 통과
- [x] 신규 통합 테스트 `tests/cases/issue_5534_eq_thin_space_scripts.rs` 3건 — 공백 유무 AST
  구분(`Space(Thin)` 보존), ``log`_{2}`` 결합 회귀 방지 + 비첨자 소비 불변, 위첨자 동형
- [ ] SVG/WASM/스튜디오 항목 해당 없음

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (파싱 분기 1곳의 노드 래핑)
- 재현: `parse("a\`_{2}") != parse("a_{2}")`, base 꼬리에 `Space(Thin)` — 신규 테스트로 박제.

## 스크린샷

이슈 #5534 의 한컴 실렌더 비교 사진 참조.
