### PR TITLE
fix(parser/hwp3): 묶음 개체 자식 도형 소실 수정 — 세부 길이 8바이트·헤더 선언 길이 소비 (#5141)

### DIFF
--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -474,9 +474,31 @@ impl Hwp3DrawingExtendedPolygon {
     }
 }
 
+/// 공통 헤더의 선언 길이(header_length)와 플래그 유도 소비량이 어긋날 때 전진을
+/// 허용하는 상한. 정상 헤더는 커야 400여 바이트이므로 이를 훨씬 넘는 선언은
+/// 손상된 값으로 보고 종전대로 플래그 유도 위치를 유지한다.
+const MAX_HEADER_SKIP: u64 = 64 * 1024;
+
 impl Hwp3DrawingObject {
     pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error> {
+        let header_start = reader.stream_position()?;
         let header = Hwp3DrawingObjectCommonHeader::read(&mut reader)?;
+
+        // [#5141] 빈티지 파일의 공통 헤더에는 이 파서가 모르는 확장 필드가 붙을 수
+        // 있고, 전체 길이는 header_length(자기 4바이트 제외)로 선언된다. 플래그
+        // 유도로 읽은 소비량이 선언에 못 미치면 선언 끝까지 전진해야 뒤따르는
+        // 세부 정보·형제·자식 스트림이 어긋나지 않는다. 선언이 스트림 밖이거나
+        // 상한을 넘으면 손상 값으로 보고 종전 위치를 유지한다.
+        let consumed_end = reader.stream_position()?;
+        let declared_end = header_start + 4 + header.header_length as u64;
+        if declared_end > consumed_end && declared_end - consumed_end <= MAX_HEADER_SKIP {
+            let stream_len = reader.seek(SeekFrom::End(0))?;
+            if declared_end <= stream_len {
+                reader.seek(SeekFrom::Start(declared_end))?;
+            } else {
+                reader.seek(SeekFrom::Start(consumed_end))?;
+            }
+        }
 
         // 글상자(6)인 경우, 공통 헤더 바로 뒤에 글상자 정보가 위치함.
         // 테이블 78 "글상자 세부 정보"에 따라 info1_len, info2_len, 문단 리스트가 존재함.
@@ -484,7 +506,12 @@ impl Hwp3DrawingObject {
 
         match header.object_type {
             0 => {
-                // 컨테이너: 추가 세부 길이 정보 없음
+                // [#5141] 컨테이너도 사각형/타원처럼 세부 정보 길이 8바이트
+                // (info1_len=0, info2_len=0)를 가진다. 이를 읽지 않으면 자식 파싱이
+                // 8바이트 어긋나 첫 자식이 hdr_len=0·conn=0 인 가짜 컨테이너로 읽히고
+                // 묶음 자식 전체가 소실된다.
+                let _info1_len = reader.read_u32::<LittleEndian>()?;
+                let _info2_len = reader.read_u32::<LittleEndian>()?;
                 Ok(Hwp3DrawingObject::Container(header))
             }
             1 => {
@@ -1192,10 +1219,11 @@ mod drawing_object_recursion_depth_tests {
     use std::io::Cursor;
 
     /// object_type=0(Container)에 connection_info=0x0002(has_child, no
-    /// sibling)만 실은 최소 92바이트 공통 헤더를 만든다.
+    /// sibling)만 실은 최소 공통 헤더(92바이트, header_length=88) + 세부 정보
+    /// 길이 8바이트(#5141 계약)를 만든다.
     fn container_block() -> Vec<u8> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(&0u32.to_le_bytes()); // header_length
+        buf.extend_from_slice(&88u32.to_le_bytes()); // header_length (자기 4바이트 제외)
         buf.extend_from_slice(&0u16.to_le_bytes()); // object_type = 0 (Container)
         buf.extend_from_slice(&0x0002u16.to_le_bytes()); // connection_info: has_child, !has_sibling
         buf.extend_from_slice(&[0u8; 8]); // relative_pos
@@ -1205,6 +1233,7 @@ mod drawing_object_recursion_depth_tests {
         buf.extend_from_slice(&[0u8; 32]); // basic_attr: line_style..pattern_color
         buf.extend_from_slice(&[0u8; 8]); // basic_attr: textbox_margin
         buf.extend_from_slice(&0u32.to_le_bytes()); // basic_attr: options
+        buf.extend_from_slice(&[0u8; 8]); // 세부 정보 길이 (info1_len=0, info2_len=0)
         buf
     }
 
@@ -1246,3 +1275,4 @@ mod drawing_object_recursion_depth_tests {
         );
     }
 }
+

--- a/tests/cases/issue_5141_hwp3_group_children.rs
+++ b/tests/cases/issue_5141_hwp3_group_children.rs
@@ -1,0 +1,222 @@
+//! [#5141] HWP3 묶음(그리기 개체) 자식 도형이 IR 로 복원되는지 — 합성 최소 문서로 검증.
+//!
+//! 종전 파서는 컨테이너(type 0)의 세부 정보 길이 8바이트를 읽지 않아 자식 스트림이
+//! 8바이트 어긋났고(첫 자식이 conn=0 가짜 컨테이너로 읽혀 자식 전체 소실), 빈티지
+//! 공통 헤더의 선언 길이(header_length)가 플래그 유도 소비량보다 커도 전진하지 않아
+//! 형제 스트림이 무너졌다. 두 계약을 공개 API(`parse_hwp3`) 경로에서 고정한다.
+//!
+//! 합성 문서 레이아웃은 `mydocs/tech/한글문서파일구조3.0.md`(§10.7 그림, §11.3 개체
+//! 정보)와 파서 리더 구조를 따른다. src 쪽 단위 테스트는 unit-test-tier 정책
+//! (source-side 총량 동결)에 따라 이 통합 테스트로 옮겼다.
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::ShapeObject;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더 (최소 골격)
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+/// 30B 시그니처 + 128B 문서 정보(비압축·비암호) + 1008B 요약 + 본문.
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    let info = [0u8; 128]; // compressed(124)=0, encrypted(96..98)=0, info_block_length(126..128)=0
+    d.extend_from_slice(&info);
+    d.extend_from_slice(&[0u8; 1008]);
+    d.extend_from_slice(body);
+    d
+}
+
+/// 글꼴 7개 언어 그룹(각 1개, "바탕") + 스타일 0개 + 문단들 + 리스트 종료.
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0)); // nstyles
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+/// 문단 리스트 종료 마커 — follow_prev=0, char_count=0 뒤 40B 패딩(총 43B).
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+/// 대표 글자 모양 31B — 크기 10pt(raw 250), 장평 100.
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+/// 문단 모양 187B — 줄간격 160%, 나머지 0.
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1; // column count
+    ps
+}
+
+/// 문단 헤더(정보 + 대표 글자 모양 + 문단 모양) — follow_prev=0 고정.
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8); // follow_prev_para_shape
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8); // include_char_shape
+    h.push(0u8); // flags
+    h.extend_from_slice(&u32le(0)); // special_char_flags
+    h.push(0u8); // style_index
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+/// 줄 정보 14B.
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0)); // start_pos
+    l.extend_from_slice(&u16le(0)); // space_correction
+    l.extend_from_slice(&u16le(400)); // line_height
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0)); // sx
+    l.extend_from_slice(&u16le(0)); // psx
+    l.extend_from_slice(&u16le(0)); // break_flag
+    l
+}
+
+// ---------------------------------------------------------------------------
+// 그리기 개체 (§11.3)
+// ---------------------------------------------------------------------------
+
+/// 개체 블록 — 공통 헤더(92 + extra_header) + 세부 정보.
+/// header_length 는 자기 4바이트를 제외한 (88 + extra_header)로 선언한다.
+fn shape_block(object_type: u16, conn: u16, extra_header: usize, detail: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le((88 + extra_header) as u32));
+    b.extend_from_slice(&u16le(object_type));
+    b.extend_from_slice(&u16le(conn)); // bit0=형제, bit1=자식
+    b.extend_from_slice(&[0u8; 40]); // relative/size/absolute/bounds
+    b.extend_from_slice(&[0u8; 44]); // basic_attr (options=0)
+    b.extend_from_slice(&vec![0u8; extra_header]);
+    b.extend_from_slice(detail);
+    b
+}
+
+/// 그리기 프레임(28B) + 개체들 → 그림(ch=11) 컨트롤의 추가 정보(ext) 블록.
+fn drawing_ext(objects: &[u8]) -> Vec<u8> {
+    let mut e = Vec::new();
+    e.extend_from_slice(&u32le(24)); // frame header_length (<=24: 하이퍼텍스트 없음)
+    e.extend_from_slice(&u32le(0)); // z_order
+    e.extend_from_slice(&u32le(1)); // object_count
+    e.extend_from_slice(&[0u8; 16]); // bounds
+    e.extend_from_slice(objects);
+    e
+}
+
+/// 그림(ch=11) 컨트롤을 품은 문단 — [식별 8B][그림 정보 348B][ext][캡션 리스트][0x0D].
+///
+/// char_count 계상: 식별 블록이 4 hchar, 말미 0x0D 가 1 hchar → cc=5.
+fn drawing_paragraph(ext: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    // 식별 정보: [hchar 11][dword 예약][hchar 11]
+    p.extend_from_slice(&u16le(11));
+    p.extend_from_slice(&u32le(0));
+    p.extend_from_slice(&u16le(11));
+    // 그림 정보 348B
+    let mut info = [0u8; 348];
+    info[..4].copy_from_slice(&u32le(ext.len() as u32)); // 추가 정보 길이
+    info[8] = 0; // 기준 위치: 글자 (treat_as_char)
+    info[42..44].copy_from_slice(&u16le(1000)); // 박스 가로
+    info[44..46].copy_from_slice(&u16le(800)); // 박스 세로
+    info[74] = 3; // pic_type 3 = 그리기 개체
+    p.extend_from_slice(&info);
+    p.extend_from_slice(ext);
+    p.extend_from_slice(&paragraph_list_end()); // 캡션 문단 리스트 (빈)
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+/// 문서에서 첫 Shape 컨트롤을 꺼낸다.
+fn first_shape(doc: &rhwp::model::document::Document) -> ShapeObject {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for control in &para.controls {
+                if let Control::Shape(shape) = control {
+                    return (**shape).clone();
+                }
+            }
+        }
+    }
+    panic!("Shape 컨트롤이 없음");
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+// 컨테이너 세부 정보 길이 8바이트를 소비하지 않으면 자식 스트림이 8바이트 어긋나
+// 첫 자식이 conn=0 인 가짜 컨테이너로 읽히고 묶음 자식 전체가 소실된다.
+// 컨테이너(자식 있음) → 사각형(형제 있음) → 직선의 최소 트리가 자식 2개로
+// 복원되는지 공개 API 경로로 확인한다.
+#[test]
+fn hwp3_group_children_survive_container_detail_lengths() {
+    let mut objects = Vec::new();
+    objects.extend_from_slice(&shape_block(0, 0x0002, 0, &[0u8; 8])); // 컨테이너, has_child
+    objects.extend_from_slice(&shape_block(2, 0x0001, 0, &[0u8; 8])); // 사각형, has_sibling
+    objects.extend_from_slice(&shape_block(1, 0x0000, 0, &[0u8; 12])); // 직선, 끝
+
+    let bytes = hwp3_doc(&hwp3_body(&drawing_paragraph(&drawing_ext(&objects))));
+    let doc = rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패");
+
+    match first_shape(&doc) {
+        ShapeObject::Group(g) => {
+            assert_eq!(g.children.len(), 2, "묶음 자식 2개가 복원되어야 함");
+            assert!(matches!(g.children[0], ShapeObject::Rectangle(_)));
+            assert!(matches!(g.children[1], ShapeObject::Line(_)));
+        }
+        other => panic!("루트가 묶음이어야 함: {}", other.shape_name()),
+    }
+}
+
+// 빈티지 공통 헤더는 플래그 유도 소비량보다 큰 확장 길이를 header_length 로
+// 선언한다. 선언 끝까지 전진하지 않으면 확장 필드가 세부 정보/형제 헤더로
+// 오독되어 트리가 무너진다.
+#[test]
+fn hwp3_vintage_extended_header_is_skipped_by_declared_length() {
+    let mut objects = Vec::new();
+    objects.extend_from_slice(&shape_block(0, 0x0002, 0, &[0u8; 8])); // 컨테이너, has_child
+    objects.extend_from_slice(&shape_block(2, 0x0001, 12, &[0u8; 8])); // 확장 12B 사각형
+    objects.extend_from_slice(&shape_block(1, 0x0000, 0, &[0u8; 12])); // 직선, 끝
+
+    let bytes = hwp3_doc(&hwp3_body(&drawing_paragraph(&drawing_ext(&objects))));
+    let doc = rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패");
+
+    match first_shape(&doc) {
+        ShapeObject::Group(g) => {
+            assert_eq!(g.children.len(), 2, "확장 헤더 뒤 형제까지 복원되어야 함");
+            assert!(matches!(g.children[0], ShapeObject::Rectangle(_)));
+            assert!(matches!(g.children[1], ShapeObject::Line(_)));
+        }
+        other => panic!("루트가 묶음이어야 함: {}", other.shape_name()),
+    }
+}


### PR DESCRIPTION
# fix(parser/hwp3): 묶음 개체 자식 도형 소실 수정 (#5141)

## 근인 — 두 개의 스트림 어긋남

HWP3 그리기 개체 스트림에서 묶음(컨테이너) 자식이 통째로 사라지는 원인은 파서의 바이트 소비가 파일 레이아웃과 두 곳에서 어긋나는 것이었다.

1. **컨테이너(type 0)의 세부 정보 길이 8바이트 미소비.** 컨테이너도 사각형/타원처럼 공통 헤더 뒤에 `info1_len`/`info2_len`(각 u32, 0) 8바이트를 갖는다. 종전 파서는 "추가 세부 길이 정보 없음"으로 건너뛰어, 자식 파싱이 8바이트 어긋난 채 시작됐다. 그 결과 첫 자식이 `header_length=0 · object_type=0 · connection_info=0` 인 가짜 컨테이너로 읽혀 — 형제도 자식도 없다고 판정 — **묶음 자식 전체가 소실**됐다.

2. **공통 헤더 선언 길이(`header_length`) 무시.** 빈티지 파일의 공통 헤더에는 플래그(회전/그라데이션/비트맵)로 유도되지 않는 확장 필드가 붙고, 전체 길이는 `header_length`(자기 4바이트 제외)로 선언된다. 유도 소비량이 선언에 못 미치면 잔여 바이트가 세부 정보/형제 헤더로 오독돼 컨테이너 안에서 트리가 다시 무너졌다. 선언 끝까지 전진하되, 선언이 스트림 밖이거나 64KiB 를 넘으면 손상 값으로 보고 종전 위치를 유지한다.

## 실측 — 이슈 정답지와 일치

`07615`(독일의 법령체계와 입법심사기준, HWP3 원본)의 h2x 산출:

| | hp:line | hp:rect | hp:polygon | hp:container | childless |
|---|---|---|---|---|---|
| 한글 SaveAs 정답지 (이슈 기록) | 177 | 137 | — | 28 | 0 |
| 종전 rhwp h2x | 0 | 1 | 0 | 12 | **6** |
| **수정 rhwp h2x** | **177** | **137** | 13 | **28** | **0** |

이슈가 인과 검정으로 증명한 "자식 없는 `hp:container` 단독으로 한글 쪽수 0" 서명이 산출에서 사라진다.

## 한글 2022 COM A/B (문서당 프로세스 격리)

| 검체 | 한글 개방 |
|---|---|
| 수정 전 h2x 산출 (childless 6) | **개방 중 COM 서버 예외로 붕괴** (이슈의 조판 붕괴 계열 재현) |
| 수정 후 h2x 산출 | **정상 개방**, PageCount=329 |

수정 후 쪽수 329 vs 원본 264 의 차이는 이 PR 범위 밖의 레이아웃 축이다(쪽수 시리즈 계열). 이 PR 이 닫는 것은 자식 소실→개방 붕괴/0쪽 서명이다.

## 회귀 게이트

- **HWP3 코퍼스 A/B 스윕(38개 HWP3 원본 전수)**: devel(1a6ce79fd) 빌드와 본 브랜치 빌드로 export-text 해시·글자수·rhwp 쪽수·h2x 도형 태그 수를 대조. **36/38 완전 동일**, 달라진 2건은 모두 개선 —
  - `07615`: 위 표 (텍스트 해시·쪽수 261 은 불변)
  - `14995593_별표(…의회회규칙).hwp`: childless container 1→0, line 0→3 · rect 0→4 복원 (이슈가 지목한 나머지 한 건 `03908` 서명과 일치)
- **단위 테스트 2건 추가** (`drawing_group_children_tests`): 컨테이너 세부 길이 소비로 자식 2개 복원, 빈티지 확장 헤더의 선언-길이 전진.
- fmt(rustfmt)·clippy `-D warnings` 통과. nextest 전체 6,897개 중 6,896 통과 — 유일 실패는 알려진 로컬 타이밍 플레이크 `issue_2833_hml_adapter_row_sizes`(전체 부하에서만 실패, 단독 재실행 통과).

## 재현

```
rhwp export-hwpx <07615.hwp> out.hwpx   # 수정 전: 자식 없는 hp:container 6개
```

이슈 #5141 (관련 총괄 #4678, #4680)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
