### PR TITLE
fix: #3315 문서 범위 파생 상태를 문서 경계에서 거둔다 — 세션 누적 제거

### DIFF
--- a/rhwp-studio/src/view/flow-image-url-cache.ts
+++ b/rhwp-studio/src/view/flow-image-url-cache.ts
@@ -28,13 +28,7 @@
  * 그대로 둔다.
  */
 
-/** 캐시가 어느 문서의 것인지 — `WasmBridge` 의 문서 신원과 같은 재료를 쓴다. */
-export interface FlowImageDocumentIdentity {
-  /** `WasmBridge.documentDigest`. 문서를 모르는 상태(`null`)에서는 캐시하지 않는다. */
-  digest: string | null;
-  /** 같은 원본 파일을 다시 연 경우까지 구분하는 `WasmBridge.documentGeneration`. */
-  generation: number;
-}
+import { isSameRenderDocument, type RenderDocumentIdentity } from './render-document-identity.ts';
 
 export class FlowImageUrlCache {
   private urls = new Map<string, string>();
@@ -48,12 +42,8 @@ export class FlowImageUrlCache {
    * 둔다. 신원을 모르면(`digest === null`) 항목을 어느 문서 것이라고 표시할 수 없으므로 이후
    * 조회는 캐시하지 않고 되돌린다.
    */
-  beginDocument(document: FlowImageDocumentIdentity): void {
-    if (
-      this.identity !== null
-      && this.identity.digest === document.digest
-      && this.identity.generation === document.generation
-    ) return;
+  beginDocument(document: RenderDocumentIdentity): void {
+    if (isSameRenderDocument(this.identity, document)) return;
 
     this.releaseAll();
     if (document.digest === null) return;

--- a/rhwp-studio/src/view/image-prefetch-signature.ts
+++ b/rhwp-studio/src/view/image-prefetch-signature.ts
@@ -7,6 +7,8 @@
  * (`getPageSourceImageKeys`, 수백 바이트)을 서명으로 쓴다.
  */
 
+import { isSameRenderDocument } from './render-document-identity.ts';
+
 export interface PrefetchSignature {
   /**
    * 이 서명이 설명하는 문서 (`WasmBridge.documentDigest`).
@@ -87,8 +89,12 @@ export function shouldSkipImagePrefetch(
   currentRawSvgCount: number,
 ): boolean {
   if (imageKeys === null || documentDigest === null || !cached) return false;
-  if (cached.documentDigest !== documentDigest) return false;
-  if (cached.documentGeneration !== documentGeneration) return false;
+  if (
+    !isSameRenderDocument(
+      { digest: cached.documentDigest, generation: cached.documentGeneration },
+      { digest: documentDigest, generation: documentGeneration },
+    )
+  ) return false;
   // 그림 키가 덮지 못하는 rawSvg가 현재 새로 생긴 경우도 전체 JSON을 다시 읽어야 한다.
   if (currentRawSvgCount > 0) return false;
   if (cached.hadRawSvg) return false;

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -24,6 +24,7 @@ import {
 import { FlowImageUrlCache } from './flow-image-url-cache';
 import { drawPageMarginGuides, type PageSpaceRect } from './page-margin-guides';
 import type { RenderBackend } from './render-backend';
+import { isSameRenderDocument, type RenderDocumentIdentity } from './render-document-identity.ts';
 
 interface LayerPlaneSummary {
   hasBehind: boolean;
@@ -82,9 +83,9 @@ export class PageRenderer {
    * prefetch 를 끝낸 페이지의 그림 서명 (Task #3315).
    *
    * 내용에서 유도된 키라 스스로 무효화된다 — 편집 때 비우지 않는다. 비우면 서명을 두는
-   * 의미가 사라진다. 문서 경계는 서명이 들고 다니는 `documentDigest` 로 갈린다 —
-   * `PageRenderer` 는 문서보다 오래 살고 문서 로드 경로가 이 맵을 비우지 않으므로,
-   * 비우기에 기대지 않고 항목 자체가 어느 문서의 것인지 말하게 한다.
+   * 의미가 사라진다. 서명은 자기가 어느 문서의 것인지(`documentDigest`) 함께 들고 다니므로
+   * 옛 문서의 항목이 새 문서에서 잘못 맞아떨어지지 않는다. 다만 **맞지 않을 뿐 사라지지도
+   * 않으므로**, 수명은 `beginDocument` 가 문서 경계에서 거둔다.
    */
   private prefetchedImageSignatures = new Map<number, PrefetchSignature>();
   /**
@@ -94,6 +95,14 @@ export class PageRenderer {
    * `beginDocument` 가 가른다.
    */
   private flowImageUrls = new FlowImageUrlCache();
+  /**
+   * 위 페이지 단위 파생 상태가 어느 문서의 것인지 (Task #3315).
+   *
+   * `beginDocument` 가 이 값과 현재 문서를 견줘 거둘지 말지 정한다. 항목마다 신원이 박혀 있는
+   * 것과 별개로 필요하다 — 항목의 신원은 "새 문서에서 잘못 맞지 않게" 하고, 이 값은 "옛 문서의
+   * 항목을 언제 버릴지"를 정한다.
+   */
+  private documentScope: RenderDocumentIdentity | null = null;
   private prefetchRequestTokens = new Map<number, number>();
   private nextPrefetchRequestToken = 0;
   private flowSplitSupported: boolean | null = null;
@@ -129,17 +138,38 @@ export class PageRenderer {
   /**
    * 문서 (재)로드 경계 — `CanvasView.prepareDocumentLoad` 가 부른다 (Task #3315).
    *
-   * 문서 범위 자원 가운데 브라우저가 명시적 회수까지 붙들고 있는 것(flow 그림 object URL)을
-   * 여기서 넘긴다. 조회 시점으로 미루면 새 문서가 flow 그림을 한 장도 조회하지 않을 때
-   * (그림 없는 문서·CanvasKit 경로) 옛 문서의 URL 이 그대로 남는다.
+   * **문서 범위 파생 상태의 수명을 정하는 유일한 자리다.** `PageRenderer` 는 문서보다 오래
+   * 살므로, 여기서 거두지 않으면 세션이 끝날 때까지 남는다 — `dispose()` 는 문서 닫기·뷰 교체
+   * 기능이 생길 때를 위한 자리라 지금은 호출부가 없다(`CanvasView.dispose`).
    *
-   * 같은 문서를 다시 로드한 경우에는 캐시가 신원을 보고 그대로 둔다.
+   * 거두는 것은 셋이다.
+   *
+   * - flow 그림 object URL — 브라우저가 명시적 회수까지 붙들고 있다. 조회 시점으로 미루면 새
+   *   문서가 flow 그림을 한 장도 조회하지 않을 때(그림 없는 문서·CanvasKit 경로) 옛 문서의
+   *   URL 이 그대로 남는다.
+   * - 재시도 키(`imageRetryCounts`)·prefetch 서명(`prefetchedImageSignatures`) — 둘 다 키에
+   *   문서 신원이 박혀 있어 새 문서에서 **잘못 맞아떨어지지는 않는다.** 그래서 이건 정확성이
+   *   아니라 수명 문제다. 다시 읽히지 않을 항목이 문서를 열 때마다 페이지 수만큼 쌓인다.
+   *
+   * 편집(문서 revision 변화)으로는 거두지 않는다 — 그 경계는 `resetImageRetryState` 이고,
+   * 거기서 재시도 키를 비우면 페이지마다 재렌더가 한 번 더 돈다(#3672). 페이지가 풀에서
+   * 빠질 때도 거두지 않는다 — 같은 이유로 페이지를 다시 볼 때마다 재렌더가 한 번 더 돈다.
+   *
+   * 같은 문서를 다시 로드한 경우에는 신원이 같으므로 그대로 둔다.
    */
   beginDocument(): void {
-    this.flowImageUrls.beginDocument({
+    const identity: RenderDocumentIdentity = {
       digest: this.wasm.documentDigest,
       generation: this.wasm.documentGeneration,
-    });
+    };
+    this.flowImageUrls.beginDocument(identity);
+    if (isSameRenderDocument(this.documentScope, identity)) return;
+
+    this.imageRetryCounts.clear();
+    this.prefetchedImageSignatures.clear();
+    // 신원을 모르면(`digest === null`) 항목이 어느 문서 것인지 표시할 수 없다. 그 상태에서는
+    // `buildImageRetryKey` 도 서명 기록도 멈추므로 지킬 것이 없다 — 범위를 비워 둔다.
+    this.documentScope = identity.digest === null ? null : identity;
   }
 
   invalidateDocumentRevision(): void {
@@ -1252,8 +1282,11 @@ export class PageRenderer {
    * (`refreshPages` → `releaseAllRenderedPages`) 불리므로, 비우면 페이지마다 재렌더가 한 번 더
    * 돈다 — prefetch 가 서명으로 건너뛰어 `finish()` 가 즉시 불리고 다시 그린다.
    *
-   * 문서 경계와 그림 내용 변화는 재시도 키가 직접 든다(`buildImageRetryKey`). 그래서 바깥에서
-   * 비워 줄 시점을 맞출 필요가 없다 — 맞춰야 하는 계약이 #3648·P1 에서 깨진 그 계약이다.
+   * 문서 경계와 그림 내용 변화는 재시도 키가 직접 든다(`buildImageRetryKey`). 그래서 **편집
+   * 시점에** 비워 줄 필요가 없다 — 맞춰야 하는 계약이 #3648·P1 에서 깨진 그 계약이다.
+   *
+   * 다만 "잘못 맞지 않는다"와 "사라진다"는 다르다. 다시 읽히지 않을 항목을 거두는 자리는
+   * 문서 경계인 `beginDocument` 다.
    */
   resetImageRetryState(): void {
     this.prefetchRequestTokens.clear();
@@ -1269,6 +1302,7 @@ export class PageRenderer {
     this.layerSummaryCache.clear();
     this.canvaskitDiagnosticsByPage.clear();
     this.flowImageUrls.releaseAll();
+    this.documentScope = null;
     this.canvaskitRenderer = null;
   }
 }

--- a/rhwp-studio/src/view/render-document-identity.ts
+++ b/rhwp-studio/src/view/render-document-identity.ts
@@ -1,0 +1,35 @@
+/**
+ * 렌더러가 들고 있는 파생 상태가 **어느 문서의 것인지** (Task #3315).
+ *
+ * `PageRenderer` 는 문서보다 오래 산다. 그래서 페이지 단위로 캐시한 항목은 자기가 어느 문서의
+ * 것인지 함께 들고 다녀야 한다 — `bin_data_id` 는 문서마다 1 부터, 세대 번호는 0 부터 다시
+ * 매겨져서 두 문서의 0쪽 첫 그림이 똑같이 `bin:0:1:src` 이기 때문이다.
+ *
+ * 같은 판정이 세 곳에서 필요하다 — flow 그림 object URL 캐시(`FlowImageUrlCache`), 그림 prefetch
+ * 서명(`shouldSkipImagePrefetch`), 그리고 문서 경계에서 파생 상태를 거두는
+ * `PageRenderer.beginDocument`. 규칙이 갈라지면 한쪽만 옛 문서의 항목을 살려 두게 되므로 한 곳에
+ * 둔다.
+ */
+
+/** 문서 인스턴스의 신원 — `WasmBridge` 가 내주는 재료를 그대로 쓴다. */
+export interface RenderDocumentIdentity {
+  /** `WasmBridge.documentDigest`. 문서를 모르는 상태는 `null` 이다. */
+  digest: string | null;
+  /** 같은 원본 파일을 다시 연 경우까지 가르는 `WasmBridge.documentGeneration`. */
+  generation: number;
+}
+
+/**
+ * 두 신원이 같은 문서 인스턴스를 가리키는지.
+ *
+ * 문서를 모르는 상태(`digest === null`)는 **어느 것과도 같지 않다.** 신원을 모르면 들고 있던
+ * 항목이 그 문서의 것이라고 말할 수 없으므로, 재사용하지 않는 쪽(=거두는 쪽)으로 판정한다.
+ */
+export function isSameRenderDocument(
+  a: RenderDocumentIdentity | null,
+  b: RenderDocumentIdentity | null,
+): boolean {
+  if (a === null || b === null) return false;
+  if (a.digest === null || b.digest === null) return false;
+  return a.digest === b.digest && a.generation === b.generation;
+}

--- a/rhwp-studio/tests/issue-3315-document-scope.test.ts
+++ b/rhwp-studio/tests/issue-3315-document-scope.test.ts
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+import {
+  isSameRenderDocument,
+  type RenderDocumentIdentity,
+} from '../src/view/render-document-identity.ts';
+
+// [#3315] 문서 범위 파생 상태의 수명은 문서 경계가 정한다.
+//
+// `imageRetryCounts`·`prefetchedImageSignatures` 는 항목마다 문서 신원(digest·generation)을 들고
+// 다닌다. 그래서 새 문서에서 **잘못 맞아떨어지지는 않는다** — 정확성은 이미 서 있다.
+//
+// 문제는 수명이다. 두 맵을 비우는 자리는 `dispose()` 뿐인데 `CanvasView.dispose` 에는 호출부가
+// 없다(문서 닫기·뷰 교체 기능이 생길 때를 위한 자리다). 그래서 문서를 열 때마다 그 문서의 페이지
+// 수만큼 항목이 쌓이고, 세션이 끝날 때까지 하나도 줄지 않는다.
+//
+// 거두는 자리는 편집 경계(`resetImageRetryState`)도, 페이지 풀 해제도 아니다 — 둘 다 페이지마다
+// 재렌더를 한 번 더 돌게 만든다(#3672 가 없앤 그 비용). 문서 경계(`beginDocument`)다.
+
+const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+
+const DOC_A: RenderDocumentIdentity = { digest: 'blake3:aaaa', generation: 1 };
+const DOC_B: RenderDocumentIdentity = { digest: 'blake3:bbbb', generation: 2 };
+
+const signature = (identity: RenderDocumentIdentity) => ({
+  documentDigest: identity.digest,
+  documentGeneration: identity.generation,
+  imageKeys: '{"keys":["bin:0:1:src"]}',
+  hadRawSvg: false,
+});
+
+/** 두 맵에 페이지 항목을 심는다 (private 필드 — 런타임에는 평범한 속성이다). */
+const seedPageEntries = (renderer: any, identity: RenderDocumentIdentity, pages: number): void => {
+  for (let pageIdx = 0; pageIdx < pages; pageIdx += 1) {
+    renderer.imageRetryCounts.set(pageIdx, `${identity.digest}|${identity.generation}|k`);
+    renderer.prefetchedImageSignatures.set(pageIdx, signature(identity));
+  }
+};
+
+const entryCounts = (renderer: any): { retry: number; prefetch: number } => ({
+  retry: renderer.imageRetryCounts.size,
+  prefetch: renderer.prefetchedImageSignatures.size,
+});
+
+async function withPageRenderer(
+  run: (make: (wasm: any) => any) => void | Promise<void>,
+): Promise<void> {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    const { PageRenderer } = await vite.ssrLoadModule('/src/view/page-renderer.ts');
+    await run((wasm: any) => new PageRenderer(wasm));
+  } finally {
+    await vite.close();
+  }
+}
+
+test('[#3315] 문서가 갈리면 옛 문서의 페이지 항목을 거둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 40);
+    assert.deepEqual(entryCounts(renderer), { retry: 40, prefetch: 40 });
+
+    // 다음 문서를 연다 — 세대는 로드마다 오르므로 신원이 반드시 갈린다.
+    wasm.documentDigest = DOC_B.digest;
+    wasm.documentGeneration = DOC_B.generation;
+    renderer.beginDocument();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 0, prefetch: 0 },
+      '옛 문서의 항목은 새 문서에서 다시 읽히지 않는다 — 읽히지 않을 뿐 사라지지도 않으면 '
+        + '세션 내내 쌓인다',
+    );
+  });
+});
+
+test('[#3315] 긴 문서를 본 뒤 짧은 문서를 열면 긴 문서의 페이지가 남지 않는다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    // 400쪽짜리 그림 문서를 끝까지 훑는다.
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 400);
+
+    // 그리고 5쪽짜리 문서를 연다. 페이지 색인이 겹치는 0..4 는 덮이지만 5..399 는 덮을
+    // 항목이 없다 — 거두지 않으면 그 395개가 세션 내내 남는다.
+    wasm.documentDigest = DOC_B.digest;
+    wasm.documentGeneration = DOC_B.generation;
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_B, 5);
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 5, prefetch: 5 },
+      '항목 수는 지금 열린 문서의 페이지 수여야 한다 — 세션에서 본 가장 긴 문서의 페이지 수가 '
+        + '아니다',
+    );
+  });
+});
+
+test('[#3315] 같은 문서를 다시 준비하면 항목을 그대로 둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 12);
+    renderer.beginDocument();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 12, prefetch: 12 },
+      '신원이 같으면 거둘 이유가 없다 — 거두면 같은 페이지를 다시 데우고 다시 그린다',
+    );
+  });
+});
+
+test('[#3315] 편집 경계는 여전히 재시도 키를 비우지 않는다 (#3672 회귀 방지)', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 8);
+    // `refreshPages` → `releaseAllRenderedPages` 가 편집마다 부르는 자리.
+    renderer.resetImageRetryState();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 8, prefetch: 8 },
+      '편집마다 비우면 페이지마다 재렌더가 한 번 더 돈다 — #3672 가 없앤 비용이다',
+    );
+  });
+});
+
+test('[#3315] 문서 신원을 모르면 범위를 비워 둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm: { documentDigest: string | null; documentGeneration: number } = {
+      documentDigest: DOC_A.digest,
+      documentGeneration: DOC_A.generation,
+    };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 5);
+
+    // 신원을 알 수 없는 문서(digest 계산 실패). 항목을 어느 문서 것이라 표시할 수 없다.
+    wasm.documentDigest = null;
+    wasm.documentGeneration = 3;
+    renderer.beginDocument();
+
+    assert.deepEqual(entryCounts(renderer), { retry: 0, prefetch: 0 });
+    // 그리고 그 상태가 "같은 문서"로 굳지 않아야 한다 — 다음 준비에서도 거둔다.
+    seedPageEntries(renderer, DOC_A, 5);
+    renderer.beginDocument();
+    assert.deepEqual(entryCounts(renderer), { retry: 0, prefetch: 0 });
+  });
+});
+
+test('[#3315] 문서 신원 판정은 한 규칙이다', () => {
+  assert.equal(isSameRenderDocument(DOC_A, { ...DOC_A }), true);
+  assert.equal(isSameRenderDocument(DOC_A, DOC_B), false);
+  // 세대만 달라도 다른 문서 인스턴스다 — 같은 파일을 다시 연 경우가 여기 걸린다.
+  assert.equal(isSameRenderDocument(DOC_A, { digest: DOC_A.digest, generation: 2 }), false);
+  // 신원을 모르면 어느 것과도 같지 않다 — 두 `null` 도 같지 않다.
+  assert.equal(isSameRenderDocument({ digest: null, generation: 1 }, { digest: null, generation: 1 }), false);
+  assert.equal(isSameRenderDocument(null, DOC_A), false);
+});


### PR DESCRIPTION
관련 이슈: #3315

## 문제

`PageRenderer` 의 페이지 단위 파생 상태가 **문서를 닫아도 사라지지 않습니다.** 문서를 열 때마다
그 문서의 페이지 수만큼 항목이 쌓이고, 세션이 끝날 때까지 하나도 줄지 않습니다.

[#3672 사후 검토](https://github.com/edwardkim/rhwp/blob/devel/mydocs/pr/archives/pr_3672_review.md)가
남긴 P2 입니다. 다만 실제 범위가 거기 적힌 "page pool release 누적"보다 넓습니다 — 페이지 풀
해제만이 아니라 **문서 교체에서도 거두지 않기 때문**입니다.

## 원인

두 맵이 문서 범위인데 문서 경계에 걸려 있지 않습니다.

```ts
// page-renderer.ts
private imageRetryCounts = new Map<number, string>();          // 값에 digest·generation 포함
private prefetchedImageSignatures = new Map<number, PrefetchSignature>();  // 필드로 digest·generation 보유
```

둘 다 **항목마다 문서 신원을 들고 다니므로 새 문서에서 잘못 맞아떨어지지는 않습니다**
(`buildImageRetryKey` `page-renderer.ts:1033`, `shouldSkipImagePrefetch`
`image-prefetch-signature.ts:82`). 정확성은 이미 서 있고, 남은 것은 수명입니다.

비우는 자리는 `dispose()` 뿐인데(`page-renderer.ts:1264`) 그 유일한 호출부인
`CanvasView.dispose()`(`canvas-view.ts:955`)에는 **호출부가 없습니다.** 저장소가 그렇게 적어
두었습니다 — "이 메서드와 `disposed` 가드들이 살아나는 시점은 하나뿐이다: 문서 닫기나 뷰 교체
기능이 생길 때… 그 전까지 호출부를 지어내지 않는다."

문서 경계 훅은 이미 있습니다. `PageRenderer.beginDocument()`(`page-renderer.ts:138`)가
`CanvasView.prepareDocumentLoad` 에서 문서 (재)로드마다 불립니다. 그런데 거기서 넘기는 것은
flow 그림 object URL 하나뿐입니다. 나머지 둘은 "항목이 스스로 어느 문서 것인지 말하므로 비울
필요가 없다"는 주석과 함께 남았는데(`page-renderer.ts:84-87`), 그 주석의 전제("문서 로드 경로가 이
맵을 비우지 않으므로")는 **`beginDocument` 가 생기기 전 이야기**입니다.

측정 — 실제 키 형식으로 잰 한 쪽당 두 맵 합계 **564 bytes**(UTF-16 문자열, Map 오버헤드 제외).
구성은 `blake3:` digest 71자 + 세대 + `imageKeys`(그림 2장 페이지, #3455 실측 42 bytes 수준) +
개수 + `retrySignature`, 그리고 같은 digest·`imageKeys` 를 한 벌 더 가진 prefetch 서명입니다:

| 훑은 문서 | 닫은 뒤에도 남는 양 |
|---|---|
| 100쪽 | 0.05 MB |
| 1,000쪽 | 0.54 MB |
| 5,000쪽 | 2.69 MB |

문서 하나를 열 때마다 이만큼이 더해집니다.

## 변경

**문서 범위 파생 상태의 수명을 `PageRenderer.beginDocument` 한 곳에서 정합니다.** 새 기구를
들이지 않고, flow 그림 object URL 이 이미 쓰던 그 경계에 나머지 둘을 붙였습니다.

```ts
beginDocument(): void {
  const identity: RenderDocumentIdentity = {
    digest: this.wasm.documentDigest,
    generation: this.wasm.documentGeneration,
  };
  this.flowImageUrls.beginDocument(identity);
  if (isSameRenderDocument(this.documentScope, identity)) return;

  this.imageRetryCounts.clear();
  this.prefetchedImageSignatures.clear();
  this.documentScope = identity.digest === null ? null : identity;
}
```

`prepareDocumentLoad` 는 WASM 문서 교체 **뒤에** 불리므로(`main.ts:1336-1337`,
`main.ts:1485-1486`) 여기서 보는 신원은 새 문서의 것입니다. 같은 문서를 다시 준비하는 경우
(신원 동일)에는 그대로 둡니다 — `FlowImageUrlCache` 가 이미 쓰던 규칙과 같습니다.

문서 신원 판정이 이미 두 곳에 복제돼 있어(`FlowImageUrlCache.beginDocument`,
`shouldSkipImagePrefetch`) 새 경계가 **세 번째 사본**이 될 자리였습니다.
`isSameRenderDocument`(`render-document-identity.ts`) 한 규칙으로 모으고 세 곳이 함께 씁니다.
규칙이 갈라지면 한쪽만 옛 문서 항목을 살려 두게 됩니다.

### 페이지 풀 해제·bounded LRU 를 고르지 않은 이유

P2 는 두 방향을 제안했지만, 둘 다 이 이슈가 없앤 비용을 되돌립니다.

페이지가 풀에서 빠질 때 재시도 키를 지우면, 그 페이지를 다시 볼 때 `scheduleReRender` 가 키를
못 찾아 fallback timer 를 다시 무장합니다. prefetch 는 서명으로 건너뛰므로 `finish()` 가 즉시
불리고 **페이지마다 재렌더가 한 번 더 돕니다.** 저장소가 이미 같은 논거를 갖고 있습니다 —
`resetImageRetryState` 주석(`page-renderer.ts:1251`)이 편집 경계에 대해 똑같이 적어 둔 내용이고,
#3672 가 없앤 것이 바로 그 비용입니다. 하필 P2 가 걱정한 "긴 그림 문서 탐색"이 앞뒤로 스크롤해
페이지 재진입이 잦은 시나리오라, 그 자리에서 가장 크게 손해입니다.

bounded LRU 는 새 기구(용량 상수 + 축출 정책)를 들이면서, 스크롤 중에는 곧 되돌아올 페이지를
축출합니다 — 같은 낭비를 덜 예측 가능하게 만듭니다.

남는 축은 **한 문서 안에서의 증가**입니다. 이건 그대로 두었습니다 — 항목 수가 지금 열린 문서의
페이지 수에 비례하는 것은 페이지 단위 캐시의 본래 크기이고(`layerSummaryCache`·
`prefetchRequestTokens` 도 같은 축), 5,000쪽 문서에서도 2.69 MB 로 그림 1장(4 MB)보다 작습니다.
경계 없이 자라던 축은 **문서 수**였고 그쪽을 닫았습니다. 한 문서 안의 증가가 실제로 문제가 되는
측정이 나오면 그때 LRU 를 별도로 다루는 편이 낫다고 봅니다.

### 테스트

`rhwp-studio/tests/issue-3315-document-scope.test.ts` (6개). vite SSR 로 실제 `PageRenderer` 를
띄우고 문서 신원을 갈아 끼우며 맵을 관찰합니다 — 소스 정규식 가드가 아니라 행위 테스트입니다.

- 문서가 갈리면 옛 문서 항목을 거둔다
- 400쪽 문서를 훑은 뒤 5쪽 문서를 열면 항목이 5개다(수정 전 400개 — 색인이 겹치는 0..4 만 덮이고 5..399 는 남는다)
- 같은 문서를 다시 준비하면 그대로 둔다
- **편집 경계(`resetImageRetryState`)는 여전히 비우지 않는다** — #3672 회귀 방지
- 문서 신원을 모르면(`digest === null`) 범위를 비워 두고, 그 상태가 "같은 문서"로 굳지 않는다
- `isSameRenderDocument` 단위 판정(세대만 달라도 다른 문서, `null` 은 어느 것과도 다름)

## 검증

devel `1a6ce79fd56e3cdf5813c7938338fcb5b7d0a859` 기준.

- **수정 전 실패 증명**: 새 테스트를 devel 소스에 그대로 걸면 6개 중 3개 실패
  (`문서가 갈리면 옛 문서의 페이지 항목을 거둔다`, `긴 문서를 본 뒤 짧은 문서를 열면…`,
  `문서 신원을 모르면 범위를 비워 둔다`). 수정 후 6개 모두 통과.
- `npm --prefix rhwp-studio run test` — **964 tests, 0 fail** (skipped 1 은 이 PR 과 무관한 기존
  테스트 — 새 테스트 6개는 모두 실행·통과).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0. `wasm-pack build --target
  web --dev` 로 `pkg/` 를 새로 만든 뒤 실행했습니다.
- Rust 를 건드리지 않는 변경이라 `cargo` 게이트는 영향 없습니다.

## 범위 외

- 한 문서 안에서 페이지 수에 비례하는 증가(위 근거).
- `CanvasView.dispose()` 에 호출부를 만드는 일 — 문서 닫기·뷰 교체 기능이 생길 때 다룰
  문제이고, 저장소가 그렇게 적어 두었습니다. 이 PR 은 그 자리에 기대지 않도록 문서 경계에서
  거두게 할 뿐입니다.
- `layerSummaryCache`·`prefetchRequestTokens` — 편집 경계(`resetImageRetryState`)에서 이미
  비웁니다. 수명이 문서보다 짧아 이 문제에 해당하지 않습니다.
