### PR TITLE
fix(serializer/hwpx): HWP3 합성 쪽나눔을 pageBreak 로 저장하지 않는다 (#5553)

### DIFF
--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -631,6 +631,8 @@ fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Divergenc
         style_id,
         column_type,
         raw_break_type,
+        // 합성 쪽나눔 표식 — 파일에 실리지 않는 파서 조판 힌트라 IR 비교 대상 아님.
+        page_break_synthesized: _,
         text,
         char_offsets,
         char_shapes,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -18,6 +18,11 @@ pub struct Paragraph {
     pub column_type: ColumnBreakType,
     /// 원본 break_type 바이트 (라운드트립 보존용, 0이면 column_type에서 재구성)
     pub raw_break_type: u8,
+    /// `column_type=Page` 가 원본의 명시적 쪽나눔이 아니라 파서가 저장 당시
+    /// 자연 쪽 경계(HWP3 pgy 감소·break_flag)에서 승격한 합성값인지 여부.
+    /// 합성 나눔은 rhwp 조판(원본 쪽배치 정합)에만 쓰고, 저장 포맷으로 내보내면
+    /// 한글 재조판의 자연 경계와 이중 작용해 빈 쪽을 만든다(07615 264→329쪽).
+    pub page_break_synthesized: bool,
     /// 문단 텍스트 (UTF-16에서 변환된 문자열)
     pub text: String,
     /// 텍스트 문자별 UTF-16 코드 유닛 위치 (LineSeg/CharShapeRef 위치와 매핑용)
@@ -1313,6 +1318,7 @@ impl Paragraph {
             style_id: self.style_id,
             column_type: ColumnBreakType::None,
             raw_break_type: 0,
+            page_break_synthesized: false,
             control_mask: new_control_mask,
             controls: new_controls,
             ctrl_data_records: new_ctrl_data_records,

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -3467,6 +3467,10 @@ pub(crate) fn parse_paragraph_list(
             let is_empty_no_ctrl = para.text.is_empty() && para.controls.is_empty();
             if !is_empty_no_ctrl {
                 para.column_type = crate::model::paragraph::ColumnBreakType::Page;
+                // pgy/break_flag 승격은 저장 당시 자연 쪽 경계일 뿐 사용자의 명시적
+                // 쪽나눔이 아니다. 합성 표시를 남겨 저장 포맷 방출에서 제외한다
+                // (명시 flags bit1 나눔만 실제 pageBreak 로 저장).
+                para.page_break_synthesized = !prev_para_had_flags_break;
             } else {
                 force_vpos_reset = true;
             }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -662,7 +662,11 @@ pub fn write_section(
 /// (미등록 스타일 → 0, #1933). 전 문단 경로가 이 함수를 거치므로 여기가 단일
 /// 방출 지점이다.
 pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32, style_id_ref: u8) -> String {
-    let page_break = if matches!(p.column_type, ColumnBreakType::Page) {
+    // 합성 쪽나눔(파서가 자연 쪽 경계에서 승격, HWP3)은 문서 내용이 아니라 조판
+    // 힌트라 저장하지 않는다. 저장하면 한글 재조판의 자연 경계와 이중 작용해
+    // 빈 쪽을 만든다(07615: 합성 138건이 264→329쪽 부풀림, 중화 시 264쪽 복원).
+    let page_break = if matches!(p.column_type, ColumnBreakType::Page) && !p.page_break_synthesized
+    {
         1
     } else {
         0

--- a/tests/cases/issue_5553_synth_pagebreak_not_serialized.rs
+++ b/tests/cases/issue_5553_synth_pagebreak_not_serialized.rs
@@ -1,0 +1,57 @@
+//! [#5553] 합성 쪽나눔(파서가 자연 쪽 경계에서 승격한 column_type=Page)은 조판
+//! 힌트일 뿐 문서 내용이 아니므로 HWPX `pageBreak` 로 저장되지 않아야 한다.
+//! 저장하면 한글 재조판의 자연 경계와 이중 작용해 빈 쪽이 생긴다
+//! (07615: 합성 138건이 264쪽 → 329쪽 부풀림, 전량 중화 시 264쪽 복원).
+//!
+//! src 쪽 단위 테스트는 unit-test-tier 정책(source-side 총량 동결)에 따라
+//! 공개 API(`serialize_hwpx`) 경로의 이 통합 테스트로 옮겼다.
+
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{ColumnBreakType, Paragraph};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+fn doc_with_paragraph(para: Paragraph) -> Document {
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    let mut doc = Document::default();
+    doc.sections.push(section);
+    doc
+}
+
+fn section0_xml(doc: &Document) -> String {
+    let bytes = serialize_hwpx(doc).expect("HWPX 직렬화 실패");
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("zip 열기 실패");
+    let mut file = zip
+        .by_name("Contents/section0.xml")
+        .expect("section0.xml 없음");
+    let mut xml = String::new();
+    std::io::Read::read_to_string(&mut file, &mut xml).expect("section0.xml 읽기 실패");
+    xml
+}
+
+// 합성 표시가 없는(명시적) Page 나눔은 종전대로 pageBreak="1" 로 저장된다.
+#[test]
+fn explicit_page_break_is_serialized() {
+    let mut para = Paragraph::default();
+    para.text = "p1".to_string();
+    para.column_type = ColumnBreakType::Page;
+    let xml = section0_xml(&doc_with_paragraph(para));
+    assert!(
+        xml.contains(r#"pageBreak="1""#),
+        "명시적 Page 나눔은 pageBreak=1 이어야 함"
+    );
+}
+
+// 합성 표시(page_break_synthesized)가 켜진 Page 나눔은 pageBreak="0" 으로 나간다.
+#[test]
+fn synthesized_page_break_is_not_serialized() {
+    let mut para = Paragraph::default();
+    para.text = "p1".to_string();
+    para.column_type = ColumnBreakType::Page;
+    para.page_break_synthesized = true;
+    let xml = section0_xml(&doc_with_paragraph(para));
+    assert!(
+        xml.contains(r#"pageBreak="0""#) && !xml.contains(r#"pageBreak="1""#),
+        "합성 쪽나눔은 pageBreak=0 으로 나가야 함"
+    );
+}


### PR DESCRIPTION
# fix(serializer/hwpx): HWP3 합성 쪽나눔을 pageBreak 로 저장하지 않는다 (#5553)

## 근인

HWP3 파서는 저장 당시 자연 쪽 경계(pgy 감소·`break_flag 0x8001`)를 `column_type=Page` 로 승격한다 — rhwp 조판을 원본 쪽배치에 정합시키는 **조판 힌트**다. 그런데 HWPX 직렬화기(`render_hp_p_open`)가 이를 명시적 `pageBreak="1"` 로 저장했다. 한글이 재조판하면 자연 경계가 승격 지점과 몇 줄씩 어긋나고, 자연 나눔 직후 합성 나눔이 또 걸려 **빈 쪽**이 생긴다.

`07615`(독일의 법령체계와 입법심사기준, HWP3): 산출의 `pageBreak="1"` **172개** vs 한글 SaveAs 정답지 **34개** — 138개가 합성이다.

## 수정

- `Paragraph.page_break_synthesized` 출처 표식 추가 — HWP3 파서의 pgy/break_flag 승격에만 표시(명시 flags bit1 나눔은 표시 안 함). 파일에 실리지 않는 조판 힌트라 `ir_field_sweep` 비교 대상에서 제외로 등록.
- HWPX `render_hp_p_open` 이 `column_type=Page && !page_break_synthesized` 일 때만 `pageBreak="1"` 방출.
- 조판 경로는 `column_type` 을 그대로 소비 — **rhwp 자체 렌더링·쪽배치 불변** (07615 원본 dump-pages 261 유지).

## 실측 (한글 2022 COM, 문서당 프로세스 격리)

인과 검정(이슈 #5553 상세): 그리기 개체 전량 제거=329 무변, linesegarray 제거=355 악화, **pageBreak 전량 중화=정확히 264** — 쪽수 부풀림의 단독 원인.

| 검체 | pageBreak="1" | 한글 PageCount |
|---|---|---|
| 원본 .hwp | — | 264 |
| 한글 SaveAs 정답지 | 34 | 264 |
| 종전 h2x (devel) | 172 | **329** (+65) |
| **본 수정 h2x** | **33** | **273** (+9) |

잔여 +9 는 별개 축 — 명시 나눔이 정답지처럼 빈 문단이 아니라 뒤따르는 표제 문단에 실리는 배치 드리프트로, #5554 로 분리 추적한다.

## 게이트

- 단위 테스트: 합성 Page 나눔 → `pageBreak="0"` 방출(신규), 비합성 Page 나눔 → `pageBreak="1"` 유지(기존 통과)
- rustfmt(변경 파일)·clippy `-D warnings` 통과
- nextest 전체 통과 (알려진 로컬 타이밍 플레이크 `issue_2833` 제외)
- 영향 범위: 표식은 HWP3 파서만 설정 — HWP5/HWPX 원본의 x2x·x2h·h2h 경로는 바이트 불변. HWP5 직렬화기(h2h)의 같은 축은 저장 lineseg 존중으로 증상이 작아(실측 259/264) 별도 측정 후 후속.

이슈 #5553 (잔여 #5554, 관련 #5141=PR #5552, 총괄 #4678)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
