### PR TITLE
fix(parser/hwp3): 줄나눔 기준(breakNonLatinWord)을 정렬에서 유도해 attr1 bit7 에 배선 (#5554)

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -674,6 +674,16 @@ fn convert_para_shape_with_layout_contract(
         _ => crate::model::style::Alignment::Justify,
     };
 
+    // [#5554] HWP3 에는 줄나눔 기준(어절/글자) 필드가 없고, 한글 2022 HWP3
+    // 임포터는 정렬에서 유도한다 — 양쪽 정렬 문단은 어절(KEEP_WORD, attr1 bit7=1),
+    // 그 외 정렬은 글자(BREAK_WORD). 한글 SaveAs HWPX 정답지 2건 6,097문단
+    // 전수에서 예외 0 으로 확인한 규칙이다(07615: JUSTIFY→KEEP 2,988·기타→BREAK
+    // 711, 교차검증 문서: 822/1,576). 배선하지 않으면 h2x 산출이 전량
+    // BREAK_WORD 로 나가 본문 줄바꿈이 정답지와 어긋난다.
+    if matches!(ps.alignment, crate::model::style::Alignment::Justify) {
+        ps.attr1 |= 1 << 7;
+    }
+
     // [#2976] 문단 테두리 연결(인접 문단끼리 테두리를 이어 그릴지) 플래그.
     // 접근자 border_connection()은 있었으나 attr1 bit 28(HWPX 직렬화기·편집
     // 커맨드가 공유하는 규약)로 배선되지 않아 항상 소실되었다.


### PR DESCRIPTION
# fix(parser/hwp3): 줄나눔 기준(breakNonLatinWord)을 정렬에서 유도해 attr1 bit7 에 배선 (#5554)

## 근인

HWP3 문단 모양에는 줄나눔 기준(어절/글자) 필드가 없다. 한글 2022 의 HWP3 임포터는 **정렬에서 유도**한다 — 양쪽 정렬 문단은 `KEEP_WORD`(attr1 bit7=1), 그 외 정렬은 `BREAK_WORD`(bit7=0). 한글 SaveAs HWPX 정답지 2건 **6,097문단 전수에서 예외 0** 으로 확인한 규칙이다:

| 문서 | JUSTIFY→KEEP | 그 외→BREAK | 예외 |
|---|---|---|---|
| 07615 (독일의 법령체계…) | 2,988 | 711 | 0 |
| 교차검증 문서 (행정법원 별지) | 822 | 1,576 | 0 |

rhwp 는 이 비트를 배선하지 않아 h2x 산출의 `breakNonLatinWord` 가 전량 `BREAK_WORD`(07615: 2,606개) 로 나갔다. 한글 렌더 실측(#2185)상 bit7=0 은 어절 유지(이른 줄바꿈)라 본문 줄 수가 정답지보다 늘어난다.

## 수정

`convert_para_shape`: `Alignment::Justify` 일 때 `attr1 |= 1<<7`. HWPX 직렬화기(`header.rs`)는 이미 bit7 에서 `breakNonLatinWord` 를 역매핑하므로 추가 배선 불필요. rhwp 줄바꿈기(`korean_break_unit`)도 같은 비트를 소비하므로 rhwp 자체 HWP3 조판이 한글 실측 방향(양쪽 정렬 본문=글자 채움)에 정합된다.

## 게이트

- **38개 HWP3 코퍼스 A/B**(devel vs 본 수정): rhwp 자체 쪽수·export-text 해시 **38건 전부 불변** — 렌더 회귀 0
- 산출 검증: 07615 h2x 헤더 KEEP 2,160 / BREAK 446 (정답지 분포와 정렬), 한글 2022 COM 쪽수 273→272
- rustfmt(변경 파일)·clippy `-D warnings`·nextest 전체 통과

## 남는 것

07615 한글 쪽수 잔여(+8)는 단일 레버가 아니라 px 수준 칼끝 복합으로 판정(#5554 코멘트의 주입 검정 표 — 그림·중첩 pos·lineseg·cellMargin 전부 단독 무영향). 독립 결함 2건을 분리 등록: #5557(셀 안여백 소실), #5558(묶음 글상자 텍스트 소실).

이슈 #5554 (계열: #5553=PR #5559, #5141=PR #5552, 총괄 #4678)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
