### PR TITLE
fix(parser/hwp3): 공통 헤더 뒤 글상자 정보의 내부 문단 리스트를 회수한다 (#5558)

### DIFF
--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -219,6 +219,10 @@ pub struct Hwp3DrawingObjectCommonHeader {
     pub rotation_attr: Option<Hwp3DrawingObjectRotationAttr>,
     pub gradient_attr: Option<Hwp3DrawingObjectGradientAttr>,
     pub bitmap_pattern_attr: Option<Hwp3DrawingObjectBitmapPatternAttr>,
+    /// [#5558] 공통 헤더 뒤 글상자 정보(스펙 11.3 optional 블록, 표 78 형식)로 실려 온
+    /// 내부 문단 리스트. 사각형 등 비-글상자 개체도 "글상자로 만들기"면 이 블록을 갖고,
+    /// 이 빈티지 코퍼스는 그 전체 길이를 header_length 로 선언한다.
+    pub textbox_paragraph_list: Option<Vec<u8>>,
 }
 
 impl Hwp3DrawingObjectCommonHeader {
@@ -277,6 +281,7 @@ impl Hwp3DrawingObjectCommonHeader {
             rotation_attr,
             gradient_attr,
             bitmap_pattern_attr,
+            textbox_paragraph_list: None,
         })
     }
 }
@@ -482,21 +487,43 @@ const MAX_HEADER_SKIP: u64 = 64 * 1024;
 impl Hwp3DrawingObject {
     pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error> {
         let header_start = reader.stream_position()?;
-        let header = Hwp3DrawingObjectCommonHeader::read(&mut reader)?;
+        let mut header = Hwp3DrawingObjectCommonHeader::read(&mut reader)?;
 
         // [#5141] 빈티지 파일의 공통 헤더에는 이 파서가 모르는 확장 필드가 붙을 수
         // 있고, 전체 길이는 header_length(자기 4바이트 제외)로 선언된다. 플래그
         // 유도로 읽은 소비량이 선언에 못 미치면 선언 끝까지 전진해야 뒤따르는
         // 세부 정보·형제·자식 스트림이 어긋나지 않는다. 선언이 스트림 밖이거나
         // 상한을 넘으면 손상 값으로 보고 종전 위치를 유지한다.
+        //
+        // [#5558] 그 잉여 구간의 실체는 스펙 11.3 의 optional 글상자 정보인 경우가
+        // 대부분이다(표 78 형식: [정보1 길이][정보2 길이][문단 리스트]). 잉여 길이가
+        // 표 78 과 정확히 맞아떨어지면 내부 문단 리스트를 회수하고, 아니면 종전대로
+        // 건너뛴다(07615 실측: 잉여 보유 137개 중 136개 정합·1개는 3바이트 슬랙).
+        // 글상자(type 6)는 세부 정보 경로가 같은 구조를 읽으므로 제외한다.
         let consumed_end = reader.stream_position()?;
         let declared_end = header_start + 4 + header.header_length as u64;
         if declared_end > consumed_end && declared_end - consumed_end <= MAX_HEADER_SKIP {
             let stream_len = reader.seek(SeekFrom::End(0))?;
+            reader.seek(SeekFrom::Start(consumed_end))?;
             if declared_end <= stream_len {
-                reader.seek(SeekFrom::Start(declared_end))?;
-            } else {
-                reader.seek(SeekFrom::Start(consumed_end))?;
+                let surplus = declared_end - consumed_end;
+                let mut recovered = false;
+                if header.object_type != 6 && surplus >= 8 {
+                    let info1_len = reader.read_u32::<LittleEndian>()?;
+                    let info2_len = reader.read_u32::<LittleEndian>()?;
+                    if u64::from(info1_len) + u64::from(info2_len) == surplus - 8 && info2_len > 0 {
+                        if info1_len > 0 {
+                            reader.seek(SeekFrom::Current(i64::from(info1_len)))?;
+                        }
+                        let mut list = super::alloc_record_buf(info2_len as usize)?;
+                        reader.read_exact(&mut list)?;
+                        header.textbox_paragraph_list = Some(list);
+                        recovered = true;
+                    }
+                }
+                if !recovered {
+                    reader.seek(SeekFrom::Start(declared_end))?;
+                }
             }
         }
 
@@ -850,6 +877,30 @@ fn map_to_shape_object(
 
     let connection_info = header.connection_info;
     let mut final_shape = shape;
+
+    // [#5558] 공통 헤더 뒤 글상자 정보로 실려 온 내부 문단 리스트(사각형 등
+    // 비-글상자 개체의 라벨 텍스트). 글상자(type 6)와 같은 계약으로 파싱해
+    // 아래 text_box 조립에 태운다. 손상된 리스트는 텍스트만 포기하고 도형은
+    // 유지한다(종전 동작과 동일).
+    if parsed_paragraphs.is_empty() {
+        if let Some(data) = header.textbox_paragraph_list.as_deref() {
+            let mut text_cursor = std::io::Cursor::new(data);
+            if let Ok(paras) = crate::parser::hwp3::parse_paragraph_list(
+                &mut text_cursor,
+                doc_char_shapes,
+                doc_para_shapes,
+                doc_border_fills,
+                doc_tab_defs,
+                pic_name_to_id,
+                0,            // body_left_hu: 드로잉 내부 텍스트, wrap zone 불필요
+                i32::MAX / 2, // column_width_hu
+                0,            // body_height_hu: 도형 내부 텍스트는 본문 페이지 분할 제외
+                false,        // 복호화 원본의 본문 Square-wrap 계약은 적용하지 않음
+            ) {
+                parsed_paragraphs = paras;
+            }
+        }
+    }
 
     let common = CommonObjAttr {
         width: header.object_size[0].saturating_mul(HWP3_UNIT_SCALE as u32),

--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -474,9 +474,31 @@ impl Hwp3DrawingExtendedPolygon {
     }
 }
 
+/// 공통 헤더의 선언 길이(header_length)와 플래그 유도 소비량이 어긋날 때 전진을
+/// 허용하는 상한. 정상 헤더는 커야 400여 바이트이므로 이를 훨씬 넘는 선언은
+/// 손상된 값으로 보고 종전대로 플래그 유도 위치를 유지한다.
+const MAX_HEADER_SKIP: u64 = 64 * 1024;
+
 impl Hwp3DrawingObject {
     pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error> {
+        let header_start = reader.stream_position()?;
         let header = Hwp3DrawingObjectCommonHeader::read(&mut reader)?;
+
+        // [#5141] 빈티지 파일의 공통 헤더에는 이 파서가 모르는 확장 필드가 붙을 수
+        // 있고, 전체 길이는 header_length(자기 4바이트 제외)로 선언된다. 플래그
+        // 유도로 읽은 소비량이 선언에 못 미치면 선언 끝까지 전진해야 뒤따르는
+        // 세부 정보·형제·자식 스트림이 어긋나지 않는다. 선언이 스트림 밖이거나
+        // 상한을 넘으면 손상 값으로 보고 종전 위치를 유지한다.
+        let consumed_end = reader.stream_position()?;
+        let declared_end = header_start + 4 + header.header_length as u64;
+        if declared_end > consumed_end && declared_end - consumed_end <= MAX_HEADER_SKIP {
+            let stream_len = reader.seek(SeekFrom::End(0))?;
+            if declared_end <= stream_len {
+                reader.seek(SeekFrom::Start(declared_end))?;
+            } else {
+                reader.seek(SeekFrom::Start(consumed_end))?;
+            }
+        }
 
         // 글상자(6)인 경우, 공통 헤더 바로 뒤에 글상자 정보가 위치함.
         // 테이블 78 "글상자 세부 정보"에 따라 info1_len, info2_len, 문단 리스트가 존재함.
@@ -484,7 +506,12 @@ impl Hwp3DrawingObject {
 
         match header.object_type {
             0 => {
-                // 컨테이너: 추가 세부 길이 정보 없음
+                // [#5141] 컨테이너도 사각형/타원처럼 세부 정보 길이 8바이트
+                // (info1_len=0, info2_len=0)를 가진다. 이를 읽지 않으면 자식 파싱이
+                // 8바이트 어긋나 첫 자식이 hdr_len=0·conn=0 인 가짜 컨테이너로 읽히고
+                // 묶음 자식 전체가 소실된다.
+                let _info1_len = reader.read_u32::<LittleEndian>()?;
+                let _info2_len = reader.read_u32::<LittleEndian>()?;
                 Ok(Hwp3DrawingObject::Container(header))
             }
             1 => {
@@ -1192,10 +1219,11 @@ mod drawing_object_recursion_depth_tests {
     use std::io::Cursor;
 
     /// object_type=0(Container)에 connection_info=0x0002(has_child, no
-    /// sibling)만 실은 최소 92바이트 공통 헤더를 만든다.
+    /// sibling)만 실은 최소 공통 헤더(92바이트, header_length=88) + 세부 정보
+    /// 길이 8바이트(#5141 계약)를 만든다.
     fn container_block() -> Vec<u8> {
         let mut buf = Vec::new();
-        buf.extend_from_slice(&0u32.to_le_bytes()); // header_length
+        buf.extend_from_slice(&88u32.to_le_bytes()); // header_length (자기 4바이트 제외)
         buf.extend_from_slice(&0u16.to_le_bytes()); // object_type = 0 (Container)
         buf.extend_from_slice(&0x0002u16.to_le_bytes()); // connection_info: has_child, !has_sibling
         buf.extend_from_slice(&[0u8; 8]); // relative_pos
@@ -1205,6 +1233,7 @@ mod drawing_object_recursion_depth_tests {
         buf.extend_from_slice(&[0u8; 32]); // basic_attr: line_style..pattern_color
         buf.extend_from_slice(&[0u8; 8]); // basic_attr: textbox_margin
         buf.extend_from_slice(&0u32.to_le_bytes()); // basic_attr: options
+        buf.extend_from_slice(&[0u8; 8]); // 세부 정보 길이 (info1_len=0, info2_len=0)
         buf
     }
 
@@ -1246,3 +1275,4 @@ mod drawing_object_recursion_depth_tests {
         );
     }
 }
+

--- a/tests/cases/issue_5141_hwp3_group_children.rs
+++ b/tests/cases/issue_5141_hwp3_group_children.rs
@@ -1,0 +1,222 @@
+//! [#5141] HWP3 묶음(그리기 개체) 자식 도형이 IR 로 복원되는지 — 합성 최소 문서로 검증.
+//!
+//! 종전 파서는 컨테이너(type 0)의 세부 정보 길이 8바이트를 읽지 않아 자식 스트림이
+//! 8바이트 어긋났고(첫 자식이 conn=0 가짜 컨테이너로 읽혀 자식 전체 소실), 빈티지
+//! 공통 헤더의 선언 길이(header_length)가 플래그 유도 소비량보다 커도 전진하지 않아
+//! 형제 스트림이 무너졌다. 두 계약을 공개 API(`parse_hwp3`) 경로에서 고정한다.
+//!
+//! 합성 문서 레이아웃은 `mydocs/tech/한글문서파일구조3.0.md`(§10.7 그림, §11.3 개체
+//! 정보)와 파서 리더 구조를 따른다. src 쪽 단위 테스트는 unit-test-tier 정책
+//! (source-side 총량 동결)에 따라 이 통합 테스트로 옮겼다.
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::ShapeObject;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더 (최소 골격)
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+/// 30B 시그니처 + 128B 문서 정보(비압축·비암호) + 1008B 요약 + 본문.
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    let info = [0u8; 128]; // compressed(124)=0, encrypted(96..98)=0, info_block_length(126..128)=0
+    d.extend_from_slice(&info);
+    d.extend_from_slice(&[0u8; 1008]);
+    d.extend_from_slice(body);
+    d
+}
+
+/// 글꼴 7개 언어 그룹(각 1개, "바탕") + 스타일 0개 + 문단들 + 리스트 종료.
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0)); // nstyles
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+/// 문단 리스트 종료 마커 — follow_prev=0, char_count=0 뒤 40B 패딩(총 43B).
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+/// 대표 글자 모양 31B — 크기 10pt(raw 250), 장평 100.
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+/// 문단 모양 187B — 줄간격 160%, 나머지 0.
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1; // column count
+    ps
+}
+
+/// 문단 헤더(정보 + 대표 글자 모양 + 문단 모양) — follow_prev=0 고정.
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8); // follow_prev_para_shape
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8); // include_char_shape
+    h.push(0u8); // flags
+    h.extend_from_slice(&u32le(0)); // special_char_flags
+    h.push(0u8); // style_index
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+/// 줄 정보 14B.
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0)); // start_pos
+    l.extend_from_slice(&u16le(0)); // space_correction
+    l.extend_from_slice(&u16le(400)); // line_height
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0)); // sx
+    l.extend_from_slice(&u16le(0)); // psx
+    l.extend_from_slice(&u16le(0)); // break_flag
+    l
+}
+
+// ---------------------------------------------------------------------------
+// 그리기 개체 (§11.3)
+// ---------------------------------------------------------------------------
+
+/// 개체 블록 — 공통 헤더(92 + extra_header) + 세부 정보.
+/// header_length 는 자기 4바이트를 제외한 (88 + extra_header)로 선언한다.
+fn shape_block(object_type: u16, conn: u16, extra_header: usize, detail: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le((88 + extra_header) as u32));
+    b.extend_from_slice(&u16le(object_type));
+    b.extend_from_slice(&u16le(conn)); // bit0=형제, bit1=자식
+    b.extend_from_slice(&[0u8; 40]); // relative/size/absolute/bounds
+    b.extend_from_slice(&[0u8; 44]); // basic_attr (options=0)
+    b.extend_from_slice(&vec![0u8; extra_header]);
+    b.extend_from_slice(detail);
+    b
+}
+
+/// 그리기 프레임(28B) + 개체들 → 그림(ch=11) 컨트롤의 추가 정보(ext) 블록.
+fn drawing_ext(objects: &[u8]) -> Vec<u8> {
+    let mut e = Vec::new();
+    e.extend_from_slice(&u32le(24)); // frame header_length (<=24: 하이퍼텍스트 없음)
+    e.extend_from_slice(&u32le(0)); // z_order
+    e.extend_from_slice(&u32le(1)); // object_count
+    e.extend_from_slice(&[0u8; 16]); // bounds
+    e.extend_from_slice(objects);
+    e
+}
+
+/// 그림(ch=11) 컨트롤을 품은 문단 — [식별 8B][그림 정보 348B][ext][캡션 리스트][0x0D].
+///
+/// char_count 계상: 식별 블록이 4 hchar, 말미 0x0D 가 1 hchar → cc=5.
+fn drawing_paragraph(ext: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    // 식별 정보: [hchar 11][dword 예약][hchar 11]
+    p.extend_from_slice(&u16le(11));
+    p.extend_from_slice(&u32le(0));
+    p.extend_from_slice(&u16le(11));
+    // 그림 정보 348B
+    let mut info = [0u8; 348];
+    info[..4].copy_from_slice(&u32le(ext.len() as u32)); // 추가 정보 길이
+    info[8] = 0; // 기준 위치: 글자 (treat_as_char)
+    info[42..44].copy_from_slice(&u16le(1000)); // 박스 가로
+    info[44..46].copy_from_slice(&u16le(800)); // 박스 세로
+    info[74] = 3; // pic_type 3 = 그리기 개체
+    p.extend_from_slice(&info);
+    p.extend_from_slice(ext);
+    p.extend_from_slice(&paragraph_list_end()); // 캡션 문단 리스트 (빈)
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+/// 문서에서 첫 Shape 컨트롤을 꺼낸다.
+fn first_shape(doc: &rhwp::model::document::Document) -> ShapeObject {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for control in &para.controls {
+                if let Control::Shape(shape) = control {
+                    return (**shape).clone();
+                }
+            }
+        }
+    }
+    panic!("Shape 컨트롤이 없음");
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+// 컨테이너 세부 정보 길이 8바이트를 소비하지 않으면 자식 스트림이 8바이트 어긋나
+// 첫 자식이 conn=0 인 가짜 컨테이너로 읽히고 묶음 자식 전체가 소실된다.
+// 컨테이너(자식 있음) → 사각형(형제 있음) → 직선의 최소 트리가 자식 2개로
+// 복원되는지 공개 API 경로로 확인한다.
+#[test]
+fn hwp3_group_children_survive_container_detail_lengths() {
+    let mut objects = Vec::new();
+    objects.extend_from_slice(&shape_block(0, 0x0002, 0, &[0u8; 8])); // 컨테이너, has_child
+    objects.extend_from_slice(&shape_block(2, 0x0001, 0, &[0u8; 8])); // 사각형, has_sibling
+    objects.extend_from_slice(&shape_block(1, 0x0000, 0, &[0u8; 12])); // 직선, 끝
+
+    let bytes = hwp3_doc(&hwp3_body(&drawing_paragraph(&drawing_ext(&objects))));
+    let doc = rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패");
+
+    match first_shape(&doc) {
+        ShapeObject::Group(g) => {
+            assert_eq!(g.children.len(), 2, "묶음 자식 2개가 복원되어야 함");
+            assert!(matches!(g.children[0], ShapeObject::Rectangle(_)));
+            assert!(matches!(g.children[1], ShapeObject::Line(_)));
+        }
+        other => panic!("루트가 묶음이어야 함: {}", other.shape_name()),
+    }
+}
+
+// 빈티지 공통 헤더는 플래그 유도 소비량보다 큰 확장 길이를 header_length 로
+// 선언한다. 선언 끝까지 전진하지 않으면 확장 필드가 세부 정보/형제 헤더로
+// 오독되어 트리가 무너진다.
+#[test]
+fn hwp3_vintage_extended_header_is_skipped_by_declared_length() {
+    let mut objects = Vec::new();
+    objects.extend_from_slice(&shape_block(0, 0x0002, 0, &[0u8; 8])); // 컨테이너, has_child
+    objects.extend_from_slice(&shape_block(2, 0x0001, 12, &[0u8; 8])); // 확장 12B 사각형
+    objects.extend_from_slice(&shape_block(1, 0x0000, 0, &[0u8; 12])); // 직선, 끝
+
+    let bytes = hwp3_doc(&hwp3_body(&drawing_paragraph(&drawing_ext(&objects))));
+    let doc = rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패");
+
+    match first_shape(&doc) {
+        ShapeObject::Group(g) => {
+            assert_eq!(g.children.len(), 2, "확장 헤더 뒤 형제까지 복원되어야 함");
+            assert!(matches!(g.children[0], ShapeObject::Rectangle(_)));
+            assert!(matches!(g.children[1], ShapeObject::Line(_)));
+        }
+        other => panic!("루트가 묶음이어야 함: {}", other.shape_name()),
+    }
+}

--- a/tests/cases/issue_5558_hwp3_textbox_recovery.rs
+++ b/tests/cases/issue_5558_hwp3_textbox_recovery.rs
@@ -1,0 +1,230 @@
+//! [#5558] 공통 헤더 뒤 글상자 정보(스펙 §11.3 optional 블록, 표 78 형식)로 실려 온
+//! 내부 문단 리스트가 회수되는지 — 합성 최소 문서로 검증.
+//!
+//! "글상자로 만들기"가 걸린 사각형 등 비-글상자 개체는 공통 헤더 뒤에
+//! `[정보1 길이][정보2 길이][문단 리스트]` 블록을 갖고, 빈티지 코퍼스는 그 전체
+//! 길이를 header_length 로 선언한다. #5141 의 선언-길이 전진만으로는 이 블록을
+//! 통째로 건너뛰어 묶음 안 상자 라벨이 전멸했다(07615: 정답지 drawText 134 vs 1).
+//!
+//! src 쪽 단위 테스트는 unit-test-tier 정책(source-side 총량 동결)에 따라
+//! 공개 API(`parse_hwp3`) 경로의 이 통합 테스트로 옮겼다.
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::ShapeObject;
+
+// ---------------------------------------------------------------------------
+// 합성 HWP3 문서 빌더 (최소 골격 — issue_5141 테스트와 동형)
+// ---------------------------------------------------------------------------
+
+fn u16le(v: u16) -> [u8; 2] {
+    v.to_le_bytes()
+}
+
+fn u32le(v: u32) -> [u8; 4] {
+    v.to_le_bytes()
+}
+
+fn hwp3_doc(body: &[u8]) -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(b"HWP Document File V3.00 \x1a\x01\x02\x03\x04\x05");
+    assert_eq!(d.len(), 30);
+    d.extend_from_slice(&[0u8; 128]);
+    d.extend_from_slice(&[0u8; 1008]);
+    d.extend_from_slice(body);
+    d
+}
+
+fn hwp3_body(paragraphs: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    for _ in 0..7 {
+        b.extend_from_slice(&u16le(1));
+        let mut name = [0u8; 40];
+        name[..4].copy_from_slice(&[0xB9, 0xD9, 0xC5, 0xC1]); // "바탕" (EUC-KR)
+        b.extend_from_slice(&name);
+    }
+    b.extend_from_slice(&u16le(0));
+    b.extend_from_slice(paragraphs);
+    b.extend_from_slice(&paragraph_list_end());
+    b
+}
+
+fn paragraph_list_end() -> [u8; 43] {
+    [0u8; 43]
+}
+
+fn char_shape31() -> [u8; 31] {
+    let mut cs = [0u8; 31];
+    cs[..2].copy_from_slice(&u16le(250));
+    for r in &mut cs[9..16] {
+        *r = 100;
+    }
+    cs
+}
+
+fn para_shape187() -> [u8; 187] {
+    let mut ps = [0u8; 187];
+    ps[6..8].copy_from_slice(&u16le(160));
+    ps[172] = 1;
+    ps
+}
+
+fn para_header(char_count: u16, line_count: u16) -> Vec<u8> {
+    let mut h = Vec::new();
+    h.push(0u8);
+    h.extend_from_slice(&u16le(char_count));
+    h.extend_from_slice(&u16le(line_count));
+    h.push(0u8);
+    h.push(0u8);
+    h.extend_from_slice(&u32le(0));
+    h.push(0u8);
+    h.extend_from_slice(&char_shape31());
+    h.extend_from_slice(&para_shape187());
+    h
+}
+
+fn line_info(pgy: u16) -> Vec<u8> {
+    let mut l = Vec::new();
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(400));
+    l.extend_from_slice(&u16le(pgy));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l.extend_from_slice(&u16le(0));
+    l
+}
+
+/// 텍스트 문단 — 문단 리스트(글상자 내부용)에 넣을 "ja" 라벨.
+fn text_paragraph(text: &str) -> Vec<u8> {
+    let chars: Vec<u16> = text.chars().map(|c| c as u16).collect();
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header((chars.len() + 1) as u16, 1));
+    p.extend_from_slice(&line_info(100));
+    for ch in chars {
+        p.extend_from_slice(&u16le(ch));
+    }
+    p.extend_from_slice(&u16le(13)); // 문단 끝
+    p
+}
+
+// ---------------------------------------------------------------------------
+// 그리기 개체 (§11.3) — 글상자 정보를 품은 사각형
+// ---------------------------------------------------------------------------
+
+fn shape_block(object_type: u16, conn: u16, detail: &[u8]) -> Vec<u8> {
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le(88));
+    b.extend_from_slice(&u16le(object_type));
+    b.extend_from_slice(&u16le(conn));
+    b.extend_from_slice(&[0u8; 40]);
+    b.extend_from_slice(&[0u8; 44]);
+    b.extend_from_slice(detail);
+    b
+}
+
+/// 글상자 정보(표 78: [정보1 길이=0][정보2 길이=n][문단 리스트 n])를 품은 사각형 —
+/// header_length 는 (88 + 글상자 정보 길이)로 선언된다(빈티지 계약).
+fn textbox_rect_block(conn: u16, inner_list: &[u8]) -> Vec<u8> {
+    let mut tbox = Vec::new();
+    tbox.extend_from_slice(&u32le(0)); // 정보 1의 길이
+    tbox.extend_from_slice(&u32le(inner_list.len() as u32)); // 정보 2의 길이
+    tbox.extend_from_slice(inner_list);
+
+    let mut b = Vec::new();
+    b.extend_from_slice(&u32le((88 + tbox.len()) as u32));
+    b.extend_from_slice(&u16le(2)); // 사각형
+    b.extend_from_slice(&u16le(conn));
+    b.extend_from_slice(&[0u8; 40]);
+    b.extend_from_slice(&[0u8; 44]);
+    b.extend_from_slice(&tbox); // 글상자 정보 (header_length 에 포함)
+    b.extend_from_slice(&[0u8; 8]); // 사각형 세부 정보 길이
+    b
+}
+
+fn drawing_ext(objects: &[u8]) -> Vec<u8> {
+    let mut e = Vec::new();
+    e.extend_from_slice(&u32le(24));
+    e.extend_from_slice(&u32le(0));
+    e.extend_from_slice(&u32le(1));
+    e.extend_from_slice(&[0u8; 16]);
+    e.extend_from_slice(objects);
+    e
+}
+
+fn drawing_paragraph(ext: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&para_header(5, 1));
+    p.extend_from_slice(&line_info(100));
+    p.extend_from_slice(&u16le(11));
+    p.extend_from_slice(&u32le(0));
+    p.extend_from_slice(&u16le(11));
+    let mut info = [0u8; 348];
+    info[..4].copy_from_slice(&u32le(ext.len() as u32));
+    info[42..44].copy_from_slice(&u16le(1000));
+    info[44..46].copy_from_slice(&u16le(800));
+    info[74] = 3; // pic_type 3 = 그리기 개체
+    p.extend_from_slice(&info);
+    p.extend_from_slice(ext);
+    p.extend_from_slice(&paragraph_list_end()); // 캡션 (빈)
+    p.extend_from_slice(&u16le(13));
+    p
+}
+
+fn first_shape(doc: &rhwp::model::document::Document) -> ShapeObject {
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            for control in &para.controls {
+                if let Control::Shape(shape) = control {
+                    return (**shape).clone();
+                }
+            }
+        }
+    }
+    panic!("Shape 컨트롤이 없음");
+}
+
+// ---------------------------------------------------------------------------
+// 테스트
+// ---------------------------------------------------------------------------
+
+// 잉여 구간이 표 78 과 정확히 맞으면 문단 리스트를 회수해 사각형의 글상자
+// 텍스트로 붙인다 — 묶음(컨테이너 자식) 안 상자 라벨이 살아나야 한다.
+#[test]
+fn hwp3_textbox_info_paragraph_list_is_recovered() {
+    let mut inner = Vec::new();
+    inner.extend_from_slice(&text_paragraph("ja"));
+    inner.extend_from_slice(&paragraph_list_end());
+
+    let mut objects = Vec::new();
+    objects.extend_from_slice(&shape_block(0, 0x0002, &[0u8; 8])); // 컨테이너, has_child
+    objects.extend_from_slice(&textbox_rect_block(0x0001, &inner)); // 글상자 사각형, 형제
+    objects.extend_from_slice(&shape_block(1, 0x0000, &[0u8; 12])); // 직선, 끝
+
+    let bytes = hwp3_doc(&hwp3_body(&drawing_paragraph(&drawing_ext(&objects))));
+    let doc = rhwp::parser::hwp3::parse_hwp3(&bytes).expect("합성 HWP3 파싱 실패");
+
+    match first_shape(&doc) {
+        ShapeObject::Group(g) => {
+            assert_eq!(
+                g.children.len(),
+                2,
+                "글상자 회수 후 형제 스트림이 이어져야 함"
+            );
+            let ShapeObject::Rectangle(rect) = &g.children[0] else {
+                panic!("첫 자식이 사각형이어야 함");
+            };
+            let text_box = rect
+                .drawing
+                .text_box
+                .as_ref()
+                .expect("글상자 문단 리스트가 회수되어야 함");
+            assert_eq!(
+                text_box.paragraphs.first().map(|p| p.text.as_str()),
+                Some("ja"),
+                "회수된 글상자 라벨 텍스트"
+            );
+            assert!(matches!(g.children[1], ShapeObject::Line(_)));
+        }
+        other => panic!("루트가 묶음이어야 함: {}", other.shape_name()),
+    }
+}


### PR DESCRIPTION
# fix(parser/hwp3): 공통 헤더 뒤 글상자 정보의 내부 문단 리스트를 회수한다 (#5558)

**의존: PR #5552** (이 브랜치는 #5552 위에 쌓여 있다 — 선언 header_length 전진 로직을 글상자 회수로 확장하는 수정이라 분리가 불가능하다.)

## 근인

스펙 11.3 의 개체 구조는 `공통 헤더 → {optional 글상자 정보} → 세부 정보 1/2` 이고, 글상자 정보는 표 78 형식(`[정보1 길이][정보2 길이][문단 리스트]`)이다. "글상자로 만들기"가 걸린 사각형 등 비-글상자 개체도 이 블록을 가지며, 이 빈티지 코퍼스는 그 전체 길이를 `header_length` 로 선언한다.

\#5141(PR #5552)의 선언-길이 전진은 스트림 동기는 지켰지만 이 블록을 통째로 건너뛰어, 묶음 안 사각형들의 라벨 텍스트가 전멸했다:

| | 한글 SaveAs 정답지 | 종전 rhwp h2x |
|---|---|---|
| `hp:drawText` | 134 | **1** |
| 순서도 `<hp:t>ja</hp:t>` 라벨 | 8 | **0** |

## 수정

`Hwp3DrawingObject::read` 의 잉여 구간 처리에서, 잉여가 표 78 과 **정확히 맞아떨어지면**(`정보1 길이 + 정보2 길이 + 8 == 잉여`) 문단 리스트를 회수해 글상자(type 6)와 같은 계약(`parse_paragraph_list`)으로 파싱하고 도형의 `text_box` 로 붙인다. 정합하지 않으면 종전대로 건너뛴다.

- 07615 실측: 잉여 보유 개체 137개 중 **136개 정합**(잔여 1개 = 3바이트 슬랙, 종전 동작 유지)
- 손상된 문단 리스트는 텍스트만 포기하고 도형은 유지(비치명)

## 실측

- 07615 h2x: `hp:drawText` 1 → **137**, `<hp:t>ja</hp:t>` 0 → **8** (정답지 8), `nein` 0 → 8
- 한글 2022 COM: 산출 정상 개방, 쪽수 중립(이 축은 텍스트만 복원)
- 단위 테스트: 잉여 구간 표 78 정합 시 문단 리스트 회수 + 형제 스트림 유지

## 게이트

- rustfmt·clippy `-D warnings`·nextest 전체 통과 (알려진 로컬 플레이크 issue_2833 제외)
- 회수 조건이 길이 방정식으로 잠겨 있어(정확 일치 요구) 비정합 파일은 종전 경로 그대로

이슈 #5558 (계열: #5141=PR #5552, #5553=PR #5559, #5554=PR #5560, 총괄 #4678)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
