### PR TITLE
fix(parser/hwp3): 라틴 확장 문자(Latin-1 Supplement)를 유니코드 값 그대로 디코딩한다 (#5555)

### DIFF
--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -342,23 +342,6 @@ mod tests {
     }
 
     #[test]
-    fn latin1_supplement_passes_through() {
-        // [#5555] 07615 원시 실측 8문자 — 종전에는 전부 '?' → 파서가 조용히 버려
-        // "für"→"fr" 처럼 라틴 확장 문자가 삭제됐다(정답지 본문 478자 전량 소실).
-        assert_eq!(decode_johab(0x00FC), 'ü');
-        assert_eq!(decode_johab(0x00E4), 'ä');
-        assert_eq!(decode_johab(0x00F6), 'ö');
-        assert_eq!(decode_johab(0x00DF), 'ß');
-        assert_eq!(decode_johab(0x00D6), 'Ö');
-        assert_eq!(decode_johab(0x00DC), 'Ü');
-        assert_eq!(decode_johab(0x00C4), 'Ä');
-        assert_eq!(decode_johab(0x00E9), 'é');
-        // 사적 따옴표 매핑(0x0081/0x0082)은 구간 밖 — 종전 유지.
-        assert_eq!(decode_johab(0x0081), '\u{201C}');
-        assert_eq!(decode_johab(0x0082), '\u{201D}');
-    }
-
-    #[test]
     fn hancom_tilde_variant_matches_hangul() {
         // KS X 1001 0xA1AD 는 표준 매핑이 U+223C(∼)지만 한글은 U+FF5E(～)를 쓴다.
         // 실측 80건 — 보정하지 않으면 되살린 문자가 다른 글자가 된다.

--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -171,6 +171,17 @@ fn decode_hwp3_ksc_hanja(ch: u16) -> Option<char> {
 /// 하드코딩 표를 **먼저** 본 뒤 규칙(기호·한자 완성형 좌표)을 적용한다. 순서가 중요하다 —
 /// 예컨대 회사명 graphic 0x37C0..0x37C5 는 기호 규칙으로는 가타카나가 되어 버린다.
 fn decode_hwp3_extra(ch: u16) -> Option<char> {
+    // [#5555] 라틴 확장(Latin-1 Supplement) — HWP3 은 이 구간 문자를 유니코드 값
+    // 그대로(0x00A0..=0x00FF) hchar 에 담는다. 07615 원시 실측: ü(0x00FC)·ä(0x00E4)·
+    // ö(0x00F6)·ß(0x00DF)·Ö(0x00D6)이 "Tübingen"·"Europäischer"·"Götz"·
+    // "ausschließliche"·"DÖV" 문맥에서 원시값으로 확인되고, 한글 SaveAs 정답지의
+    // 8문자 분포(ü·ö·ä·ß·Ö·Ü·Ä·é)와 정합한다 — 실측 8코드 전부 항등이라 구간
+    // 항등 통과가 근거를 갖는다. 매핑이 없으면 '?' → 파서가 조용히 버려
+    // "für"→"fr" 처럼 글자가 삭제된다. 사적 따옴표(0x0081/0x0082)는 구간 밖이라
+    // 아래 하드코딩이 그대로 담당한다.
+    if (0x00A0..=0x00FF).contains(&ch) {
+        return char::from_u32(ch as u32);
+    }
     // [Task #877 Stage 3] 로마숫자 대문자 Ⅰ~Ⅹ: 0x3590~0x3599 → U+2160~U+2169.
     // sample16 (hwp3-sample16.hwp) 의 cross-ref 로 도출. 한컴 HWP5 변환본의
     // paragraph 26/31/36/44 ("Ⅰ. 사업개요", "Ⅱ. 제안 일반사항", "Ⅲ ...", "Ⅳ ...") 정합.
@@ -328,6 +339,23 @@ mod tests {
                 "0x{ch:04X} 는 근거 없이 매핑하면 안 된다"
             );
         }
+    }
+
+    #[test]
+    fn latin1_supplement_passes_through() {
+        // [#5555] 07615 원시 실측 8문자 — 종전에는 전부 '?' → 파서가 조용히 버려
+        // "für"→"fr" 처럼 라틴 확장 문자가 삭제됐다(정답지 본문 478자 전량 소실).
+        assert_eq!(decode_johab(0x00FC), 'ü');
+        assert_eq!(decode_johab(0x00E4), 'ä');
+        assert_eq!(decode_johab(0x00F6), 'ö');
+        assert_eq!(decode_johab(0x00DF), 'ß');
+        assert_eq!(decode_johab(0x00D6), 'Ö');
+        assert_eq!(decode_johab(0x00DC), 'Ü');
+        assert_eq!(decode_johab(0x00C4), 'Ä');
+        assert_eq!(decode_johab(0x00E9), 'é');
+        // 사적 따옴표 매핑(0x0081/0x0082)은 구간 밖 — 종전 유지.
+        assert_eq!(decode_johab(0x0081), '\u{201C}');
+        assert_eq!(decode_johab(0x0082), '\u{201D}');
     }
 
     #[test]

--- a/tests/cases/issue_5555_hwp3_latin1_supplement.rs
+++ b/tests/cases/issue_5555_hwp3_latin1_supplement.rs
@@ -1,0 +1,29 @@
+//! [Issue #5555] HWP3 라틴 확장(Latin-1 Supplement)은 유니코드 값 그대로 디코딩된다.
+//!
+//! HWP3 은 0x00A0..=0x00FF 구간 문자를 hchar 에 유니코드 값 그대로 담는다.
+//! 매핑이 없으면 '?' 가 되어 파서가 조용히 버리고 "für"→"fr" 처럼 글자가
+//! 삭제된다. 07615 원시 실측 8문자(ü·ä·ö·ß·Ö·Ü·Ä·é)는 한글 SaveAs 정답지의
+//! 분포와 정합한다. 사적 따옴표(0x0081/0x0082)는 구간 밖이라 종전 하드코딩이
+//! 그대로 담당한다.
+
+use rhwp::parser::hwp3::johab::decode_johab;
+
+/// 계약 1 — 실측 8문자가 유니코드 항등으로 통과한다.
+#[test]
+fn latin1_supplement_passes_through() {
+    assert_eq!(decode_johab(0x00FC), 'ü');
+    assert_eq!(decode_johab(0x00E4), 'ä');
+    assert_eq!(decode_johab(0x00F6), 'ö');
+    assert_eq!(decode_johab(0x00DF), 'ß');
+    assert_eq!(decode_johab(0x00D6), 'Ö');
+    assert_eq!(decode_johab(0x00DC), 'Ü');
+    assert_eq!(decode_johab(0x00C4), 'Ä');
+    assert_eq!(decode_johab(0x00E9), 'é');
+}
+
+/// 계약 2 — 구간 밖 사적 따옴표 매핑은 종전대로 유지된다.
+#[test]
+fn private_quote_mappings_are_unchanged() {
+    assert_eq!(decode_johab(0x0081), '\u{201C}');
+    assert_eq!(decode_johab(0x0082), '\u{201D}');
+}


### PR DESCRIPTION
# fix(parser/hwp3): 라틴 확장 문자(Latin-1 Supplement)를 유니코드 값 그대로 디코딩한다 (#5555)

## 근인

HWP3 은 라틴 확장 문자(ü·ö·ä·ß·Ö·Ü·Ä·é 등)를 **Latin-1 코드값 그대로 hchar**(0x00A0..=0x00FF)에 담는다. `decode_johab` 의 사적영역 경로(`decode_hwp3_extra`, 0x0080..0x7FFF)에 이 구간 매핑이 없어 '?'가 되고, HWP3 파서는 미지원 사적 코드를 조용히 버린다 — 대체가 아니라 **삭제**라 "für"→"fr" 처럼 글자 수 자체가 줄고 lineseg 문자 계상에도 2차 영향을 준다.

## 실측 (07615 원시 이진 대조)

- 압축 해제 본문의 u16 스트림에서 원시값 직접 확인: 0x00FC="T·bingen"(Tübingen), 0x00E4="Europ·ischer", 0x00F6="G·tz", 0x00DF="schlie·liche", 0x00D6="D·V".
- 원시 전수 계수 {ü 232, ö 100, ä 139, ß 42, Ö 44, Ü 14, Ä 5, é 2} = 578 — 한글 SaveAs 정답지 본문 분포(478, 이슈 표)와 방향 정합(원시가 본문 외 글상자·각주 텍스트를 포함해 상회), Ä=5·é=2 는 정확 일치.
- 구간 내 실측 8코드가 전부 항등 매핑 — Latin-1 Supplement 항등 통과의 근거.

## 수정

`decode_hwp3_extra` 에 0x00A0..=0x00FF 항등 통과 한 줄. 하드코딩 사적 매핑(0x0081/0x0082 따옴표)은 구간 밖이라 종전 유지. `decode_johab` 단일 디코딩 지점이라 본문·글상자·각주 전 경로에 일괄 적용된다.

## 게이트

- 단위 테스트: 실측 8문자 항등 디코딩(신규) + 기존 사적 매핑 회귀 없음
- `07615` export-text: 라틴 확장 계수 **0 → 561** ({ü 230, ä 137, ö 100, ß 40, Ö 36, Ü 11, Ä 5, é 2}) — "Baden-Württemberg"·"für"·"Thürungen" 자연 복원. 원시 계수 578 과의 잔차는 그리기 글상자 내부 텍스트(#5558 축) 몫
- rustfmt·clippy `-D warnings`·nextest 전체 통과 (7,721건, 실패 0)
- 10k 코퍼스의 HWP3 전수 38건 중 원시 스캔으로 선별한 영향 후보 28건 A/B(`word-count --json`): **pageCount 변화 0 / 28**, charCount 는 07615 +260·1480000-201400060 +1 두 건만 증가(복원분), 감소 0
- 영향 범위: HWP3 디코더 한정(`decode_johab` 사용처는 `src/parser/hwp3/` 3파일뿐 — HWP5/HWPX 무영향). 종전 이 구간은 전부 '?'→삭제라 **회귀 여지 없음**(어떤 문서도 이 구간을 다른 글자로 쓰지 못했다)

참고: 같은 문서에서 0x2010(하이픈, "Kosten‐Absch…" 문맥 1건)도 같은 축으로 소실되나, 한글 표시 대조 미실측이라 이번 범위에서 제외(사적 구간 0x2000 대의 실측-한정 원칙, `only_measured_private_codes_are_mapped`).

이슈 #5555 (총괄 #4678, 같은 문서 계열 #5553/#5554/#5557/#5558)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
