### PR TITLE
fix(converters/hwpx): micro-grid 휴리스틱이 셀 width_ref bit0 를 강제하지 않는다 — 한글 쪽수 +1 결함 58건 해소 (#4898)

### DIFF
--- a/mydocs/working/task_4898_x2h_cell_width_ref.md
+++ b/mydocs/working/task_4898_x2h_cell_width_ref.md
@@ -1,0 +1,54 @@
+# #4898 ② x2h 셀 `width_ref` micro-grid 휴리스틱 제거
+
+## 목표
+
+HWPX → HWP5 저장(x2h)에서 한글이 원본보다 쪽수를 1쪽 더 세는 잔존군을 줄인다. 한글 2022
+오라클 10k 전수(s36) 기준 x2h 쪽수 결함은 71경로였고, 그중 63경로가 "원본 1쪽 → 저장본 2쪽"인
+서식 문서였다.
+
+## 원인
+
+`hwpx_to_hwp.rs` 의 `table_requires_cell_width_ref_contract` 가 `table.col_count >= 30` 인 표를
+micro-grid 로 보고, **셀 자신이 안 여백을 쓰지 않는데도**(`apply_inner_margin == false`)
+LIST_HEADER `width_ref` bit0(=aim, 자기 여백 사용)을 세우고 표 기본 여백을 셀 padding 으로
+물질화했다. 한글은 그 값을 액면대로 읽어 셀 안 여백을 크게 잡고, 행 높이 → 표 높이 → 쪽수 순으로
+번져 1쪽에 맞던 서식이 2쪽이 됐다.
+
+이 휴리스틱은 #1809(admrul micro-grid 계열에서 한컴이 셀 내부 줄나눔 폭을 너무 좁게 잡던 문제)
+때 들어왔으나, 그 계약을 지키는 회귀 테스트는 저장소에 없다.
+
+## 변경
+
+- `table_requires_cell_width_ref_contract` 를 제거했다.
+- `materialize_cell_list_header_contract` 에서 `use_width_ref` 인자와 표 여백 물질화 분기를
+  제거했다. `width_ref` bit0 는 이제 셀 자신의 `apply_inner_margin` 만 따른다.
+- `raw_list_extra`(셀 폭 4바이트 + 13바이트 슬롯) 물질화는 종전대로 모든 셀에 유지한다.
+- 계약 테스트 `tests/cases/issue_4898_x2h_cell_width_ref.rs` 3건을 추가했다.
+
+## 검증 실측 — 한글 2022 오라클
+
+baseline `rhwp_s36.exe`(devel `9d352d56d`) 와, 같은 커밋에서 이 휴리스틱만 끈 프로브 바이너리로
+코퍼스 10,000건(HWPX 입력 3,418건)을 각각 변환해 한글 2022 로 쪽수를 재측정했다.
+
+**영향 범위 확정**: 두 산출을 SHA-256 으로 비교해 휴리스틱이 실제로 산출을 바꾸는 문서
+**1,239건**을 뽑았다(변환은 결정적임을 재변환 12/12 동일로 확인). 그 전수를 한글로 측정했다.
+
+| 구분 | 건수 |
+|---|---|
+| 고침 — 기존 쪽수 결함이 원본 쪽수로 복귀 | **58** |
+| 깨짐 — 정상이던 문서가 틀어짐 | **0** |
+| 둘 다 정상 | 1,180 |
+| 둘 다 틀림(별개 원인, 08818) | 1 |
+| 텍스트 길이 달라진 문서 / 컨트롤 집계 달라진 문서 | **0 / 0** |
+
+x2h 쪽수 잔존군 71경로 중 **58경로(82%)가 이 한 원인**이었다. 남은 13경로는 별개 원인군이다
+(01052 6→7, 02319 5→6, 08818 81→86 등).
+
+## 검증 기준
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --test regression_suite_010 -- issue_4898` (새 계약 테스트 3건)
+- `cargo test --test regression_suite_001 --test regression_suite_007`
+  — 셀 여백/어댑터 계약을 담은 기존 스위트(`hwpx_to_hwp_adapter`,
+  `issue_1785_cell_padding_rule_consistency`)

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -2258,11 +2258,9 @@ fn adapt_table_with_context(
     }
 
     // 셀별 보강 + 내부 문단 재귀 (중첩 표 대응)
-    let use_cell_width_ref = table_requires_cell_width_ref_contract(table);
-    let table_padding = table.padding;
     for cell in &mut table.cells {
         adapt_cell_list_attr(cell, report);
-        materialize_cell_list_header_contract(cell, use_cell_width_ref, &table_padding, report);
+        materialize_cell_list_header_contract(cell, report);
         for cpara in &mut cell.paragraphs {
             adapt_paragraph_with_context(cpara, report, context);
         }
@@ -2275,35 +2273,16 @@ fn adapt_table_with_context(
     }
 }
 
-fn table_requires_cell_width_ref_contract(table: &Table) -> bool {
-    // HWPX 조직도류 표는 많은 논리 열로 셀 폭을 쪼개어 만든 micro-grid 형태다.
-    // 이 계열은 LIST_HEADER width_ref bit가 없으면 한컴이 셀 내부 줄나눔 폭을 너무 좁게 잡는다.
-    //
-    // 반대로 mel-001의 8x12 인원 현황 표는 같은 bit를 세우면 한컴이 병합 셀 높이를 과도하게
-    // 계산했다. 따라서 raw_list_extra는 모든 셀에 materialize하되 width_ref bit는
-    // 고열 수 micro-grid 표에만 적용한다.
-    table.col_count >= 30
-}
-
-fn materialize_cell_list_header_contract(
-    cell: &mut Cell,
-    use_width_ref: bool,
-    table_padding: &crate::model::Padding,
-    report: &mut AdapterReport,
-) {
+fn materialize_cell_list_header_contract(cell: &mut Cell, report: &mut AdapterReport) {
     let before_width_ref = cell.list_header_width_ref;
     let before_extra_len = cell.raw_list_extra.len();
 
-    // [#1809] micro-grid 계약으로 width_ref bit0(=aim)을 켤 때, aim=false 셀의
-    // 유효 안 여백(effective_padding — 표 기본 폴백 포함)을 셀 padding 에 물질화한다.
-    // 재파싱 시 aim=true 가 되면 측정/레이아웃의 aim=true 원값 존중 경로(#493 시멘틱)가
-    // raw cell padding 을 그대로 쓰므로, 물질화 없이는 padding 0 셀의 행높이가
-    // 원본(HWPX, 표 기본 여백)과 어긋난다 (admrul_0296 행 32.37→31.60, 표 3.87px).
-    if use_width_ref && !cell.apply_inner_margin {
-        cell.padding = cell.effective_padding(table_padding);
-    }
-
-    if use_width_ref || cell.apply_inner_margin {
+    // [#4898] width_ref bit0(=aim, 자기 여백 사용)은 셀 자신의 `apply_inner_margin` 만 따른다.
+    // 예전에는 `col_count >= 30` micro-grid 휴리스틱이 aim=false 셀에도 이 비트를 세우고
+    // 표 기본 여백을 셀 padding 으로 물질화했는데, 한글이 그만큼 행 높이를 키워 1쪽 서식이
+    // 2쪽이 됐다. 한글 2022 오라클 10k 전수(x2h): 휴리스틱을 끄면 쪽수 결함 58건이 원본
+    // 쪽수로 복귀하고 새로 깨지는 문서는 0건이다(영향 문서 1,239건 전수 측정).
+    if cell.apply_inner_margin {
         cell.list_header_width_ref |= 0x0001;
     } else {
         cell.list_header_width_ref &= !0x0001;
@@ -3298,20 +3277,17 @@ mod tests {
 
     #[test]
     fn cell_list_header_contract_materializes_width_ref_and_extra() {
+        // [#4898] bit0 는 셀 자신의 안 여백 사용 여부만 따른다.
         let mut cell = Cell {
             width: 2266,
             list_header_width_ref: 0,
             raw_list_extra: Vec::new(),
+            apply_inner_margin: true,
             ..Default::default()
         };
         let mut report = AdapterReport::new();
 
-        materialize_cell_list_header_contract(
-            &mut cell,
-            true,
-            &crate::model::Padding::default(),
-            &mut report,
-        );
+        materialize_cell_list_header_contract(&mut cell, &mut report);
 
         assert_eq!(cell.list_header_width_ref & 0x0001, 0x0001);
         assert_eq!(cell.raw_list_extra.len(), 13);
@@ -3322,12 +3298,7 @@ mod tests {
         assert!(cell.raw_list_extra[4..].iter().all(|&byte| byte == 0));
         assert_eq!(report.cells_list_header_contract_materialized, 1);
 
-        materialize_cell_list_header_contract(
-            &mut cell,
-            true,
-            &crate::model::Padding::default(),
-            &mut report,
-        );
+        materialize_cell_list_header_contract(&mut cell, &mut report);
         assert_eq!(report.cells_list_header_contract_materialized, 1);
     }
 
@@ -3341,12 +3312,7 @@ mod tests {
         };
         let mut report = AdapterReport::new();
 
-        materialize_cell_list_header_contract(
-            &mut cell,
-            false,
-            &crate::model::Padding::default(),
-            &mut report,
-        );
+        materialize_cell_list_header_contract(&mut cell, &mut report);
 
         assert_eq!(cell.list_header_width_ref & 0x0001, 0);
         assert_eq!(cell.raw_list_extra.len(), 13);

--- a/tests/cases/issue_4898_x2h_cell_width_ref.rs
+++ b/tests/cases/issue_4898_x2h_cell_width_ref.rs
@@ -1,0 +1,147 @@
+//! Issue #4898 ②: HWPX→HWP 어댑터는 셀 LIST_HEADER `width_ref` bit0(=aim, 자기 여백 사용)을
+//! 셀 자신의 `apply_inner_margin` 으로만 정한다.
+//!
+//! 예전에는 `col_count >= 30` micro-grid 휴리스틱이 aim=false 셀에도 이 비트를 세우고
+//! 표 기본 여백을 셀 padding 으로 물질화했다. 한글은 그만큼 셀 안 여백을 크게 잡아 행 높이가
+//! 늘고, 1쪽에 맞던 서식이 2쪽으로 넘어갔다.
+//!
+//! 한글 2022 오라클 10k 전수(x2h) 실측: 휴리스틱이 실제로 산출을 바꾸는 문서 1,239건을 전수
+//! 측정해 쪽수 결함 58건이 원본 쪽수로 복귀했고, 새로 깨진 문서는 0건이다.
+
+use rhwp::document_core::converters::hwpx_to_hwp::convert_hwpx_to_hwp_ir;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::table::{Cell, Table};
+use rhwp::model::Padding;
+
+const MICRO_GRID_COLS: u16 = 32;
+
+fn pad(v: i16) -> Padding {
+    Padding {
+        left: v,
+        right: v,
+        top: v,
+        bottom: v,
+    }
+}
+
+/// 고열 수(micro-grid) 표 한 개를 가진 최소 문서. 첫 셀은 aim=false, 둘째 셀은 aim=true.
+fn micro_grid_document() -> Document {
+    let mut aim_false = Cell {
+        padding: pad(0),
+        ..Default::default()
+    };
+    aim_false.apply_inner_margin = false;
+    aim_false.col = 0;
+    aim_false.width = 1000;
+
+    let mut aim_true = Cell {
+        padding: pad(141),
+        ..Default::default()
+    };
+    aim_true.apply_inner_margin = true;
+    aim_true.col = 1;
+    aim_true.width = 1000;
+
+    let table = Table {
+        col_count: MICRO_GRID_COLS,
+        row_count: 1,
+        padding: pad(283),
+        cells: vec![aim_false, aim_true],
+        ..Default::default()
+    };
+
+    let mut paragraph = Paragraph::default();
+    paragraph.controls.push(Control::Table(Box::new(table)));
+
+    let mut section = Section::default();
+    section.paragraphs.push(paragraph);
+
+    let mut document = Document::default();
+    document.sections.push(section);
+    document
+}
+
+fn first_table(document: &Document) -> &Table {
+    document
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .flat_map(|p| p.controls.iter())
+        .find_map(|ctrl| match ctrl {
+            Control::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("표 없음")
+}
+
+#[test]
+fn issue_4898_micro_grid_does_not_force_width_ref_bit0() {
+    let mut document = micro_grid_document();
+    convert_hwpx_to_hwp_ir(&mut document);
+
+    let table = first_table(&document);
+    let aim_false = &table.cells[0];
+
+    assert_eq!(
+        aim_false.list_header_width_ref & 0x0001,
+        0,
+        "aim=false 셀은 열 수와 무관하게 width_ref bit0 를 켜지 않는다 (#4898 ②)"
+    );
+    assert_eq!(
+        (
+            aim_false.padding.left,
+            aim_false.padding.right,
+            aim_false.padding.top,
+            aim_false.padding.bottom
+        ),
+        (0, 0, 0, 0),
+        "aim=false 셀 padding 을 표 기본 여백으로 물질화하지 않는다 — 한글 행 높이가 커진다"
+    );
+}
+
+#[test]
+fn issue_4898_cell_own_inner_margin_still_sets_width_ref_bit0() {
+    let mut document = micro_grid_document();
+    convert_hwpx_to_hwp_ir(&mut document);
+
+    let table = first_table(&document);
+    let aim_true = &table.cells[1];
+
+    assert_eq!(
+        aim_true.list_header_width_ref & 0x0001,
+        1,
+        "셀 자신이 안 여백을 쓰면 width_ref bit0 는 그대로 선다"
+    );
+    assert_eq!(
+        (
+            aim_true.padding.left,
+            aim_true.padding.right,
+            aim_true.padding.top,
+            aim_true.padding.bottom
+        ),
+        (141, 141, 141, 141),
+        "aim=true 셀의 고유 여백은 보존한다"
+    );
+}
+
+#[test]
+fn issue_4898_raw_list_extra_still_materialized() {
+    let mut document = micro_grid_document();
+    convert_hwpx_to_hwp_ir(&mut document);
+
+    let table = first_table(&document);
+    for (idx, cell) in table.cells.iter().enumerate() {
+        assert_eq!(
+            cell.raw_list_extra.len(),
+            13,
+            "셀 {idx}: raw_list_extra 물질화는 모든 셀에 그대로 유지한다"
+        );
+        assert_eq!(
+            &cell.raw_list_extra[0..4],
+            &cell.width.to_le_bytes(),
+            "셀 {idx}: raw_list_extra 앞 4바이트는 셀 폭이다"
+        );
+    }
+}


### PR DESCRIPTION
## 변경 요약

HWPX → HWP5 저장(x2h)에서 `col_count >= 30` 인 표를 micro-grid 로 보고, **셀 자신이 안 여백을
쓰지 않는데도**(`apply_inner_margin == false`) LIST_HEADER `width_ref` bit0(=aim, 자기 여백 사용)을
세우고 표 기본 여백을 셀 padding 으로 물질화하던 휴리스틱을 제거했다. 한글은 그 값을 액면대로
읽어 셀 안 여백을 크게 잡았고, 행 높이 → 표 높이 → 쪽수로 번져 **1쪽에 맞던 서식이 2쪽**이 됐다.

bit0 는 이제 셀 자신의 `apply_inner_margin` 만 따른다. `raw_list_extra`(셀 폭 4바이트 + 13바이트)
물질화는 모든 셀에 종전대로 유지한다.

이 휴리스틱은 #1809 때 들어왔지만 그 계약을 지키는 회귀 테스트는 저장소에 없었고, 셀 여백·어댑터
계약 스위트(`issue_1785_cell_padding_rule_consistency`, `hwpx_to_hwp_adapter`)는 제거 후에도 전부
통과한다.

## 관련 이슈

#4898 (쪽수 +1 드리프트 — 이 PR 은 그중 x2h 축 원인 ②를 닫는다. 전체 이슈는 다른 원인군이 남아
있어 `closes` 하지 않는다)

## 검증 실측 — 한글 2022 오라클 10k 전수

baseline(devel `9d352d56d`) 과 같은 커밋에서 이 휴리스틱만 끈 프로브 바이너리로 코퍼스
HWPX 입력 3,418건을 각각 변환하고, 두 산출을 SHA-256 으로 비교해 **휴리스틱이 실제로 산출을
바꾸는 문서 1,239건**을 전수 측정했다(변환 결정성은 재변환 12/12 동일로 확인).

| 구분 | 건수 |
|---|---|
| **고침** — 기존 쪽수 결함이 원본 쪽수로 복귀 | **58** |
| **깨짐** — 정상이던 문서가 틀어짐 | **0** |
| 둘 다 정상 | 1,180 |
| 둘 다 틀림(별개 원인, 08818) | 1 |
| 텍스트 길이 / 컨트롤 집계가 달라진 문서 | **0 / 0** |

x2h 쪽수 잔존군 71경로 중 **58경로(82%)가 이 한 원인**이었다. 복귀군은 대부분 `1쪽 → 2쪽` 이던
서식 문서다. 남은 13경로(01052 6→7, 02319 5→6, 08818 81→86 등)는 별개 원인군으로 남는다.

처리 결과 문서: `mydocs/working/task_4898_x2h_cell_width_ref.md`

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (exit 0)
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test` — 범위 대상 스위트 통과 (전량 아님, 아래 명시)
- [x] `cargo clippy --all-targets -- -D warnings` 통과 (exit 0)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음(rhwp 자체 조판은 이 필드를 읽지 않는다.
      검증은 위 한글 오라클 쪽수 실측으로 대체했다)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음

**돌린 테스트와 이유**

| 명령 | 이유 |
|---|---|
| `cargo test --test regression_suite_010 -- issue_4898` | 이 PR 이 추가한 계약 테스트 3건 (3 passed) |
| `cargo test --test regression_suite_001` | `hwpx_to_hwp_adapter` — 어댑터 물질화 계약 (65 passed / 0 failed) |
| `cargo test --test regression_suite_007` | `issue_1785_cell_padding_rule_consistency` — 셀 안 여백 규칙 계약 (126 passed / 0 failed) |

추가한 계약 테스트 `tests/cases/issue_4898_x2h_cell_width_ref.rs`:

1. 32열 표에서 `aim=false` 셀의 bit0 가 0 이고 padding 이 표 여백으로 물질화되지 않는다
2. `aim=true` 셀은 종전대로 bit0 가 서고 고유 여백이 보존된다
3. `raw_list_extra` 물질화는 모든 셀에 유지된다(회귀 방지)
