### PR TITLE
기능: 문서 에이전트 공개 명령 브리지 추가

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -60,3 +60,11 @@ date: 2026-08-19
 - 최신 source head의 CI preflight, Lint, Frontend package gate, Native Skia, test archive, slow·regular shard, Build & Test aggregate, CodeQL 세 언어, Proptest, Adapter inter-diff가 모두 통과했다. workflow 변경 PR이므로 Adapter 본 job은 fail-closed로 실행된 것이 정상이다.
 - 사용자 지시에 따라 merge 뒤 옵션 B의 별도 문서 전용 PR로 [PR #5576 검토 기록](../pr/archives/pr_5576_review.md)과 이 완료 기록을 보존한다.
 - 옵션 B 문서 PR [#5579](https://github.com/edwardkim/rhwp/pull/5579)에서 중앙 무거운 lane은 모두 skipped, Build & Test aggregate는 5초 성공, [Adapter inter-diff workflow](https://github.com/edwardkim/rhwp/actions/runs/32224422692)는 preflight 48초 성공과 본 `adapter inter-diff`의 skipped 상태를 남겨 문서 전용 fast-pass 동작을 확인했다.
+
+## #5569 문서 에이전트 exact command 공개 브리지
+
+- 첫 기여자 `@coolwithyou`의 PR [#5569](https://github.com/edwardkim/rhwp/pull/5569)는 최신 `devel` 기준 code candidate `364962caf60189b22dad244bb47f340dd2262261`에서 공개 SDK, strict iframe RPC, snapshot apply/revert, HWP/HWPX 브라우저 회귀를 추가한다.
+- reviewer `@jangster77`은 최신 `upstream/devel`에서 가시성 검토 브랜치로 기여자 변경을 cherry-pick해 검토했다. 메인터너 코드 보정은 없었다.
+- 로컬에서 editor 계약 32건, Studio 982건(기존 skip 1건), TypeScript/Vite build, HWP/HWPX document-agent 브라우저 계약 30건, editor 선언 검사와 `npm pack --dry-run`을 통과했다.
+- 생성 WASM 기준선의 `getFontDecisionTrace` 선언 누락 때문에 일반 public-embed 검사 두 건은 로컬에서 기준선 오류로 중단됐다. 이 PR은 `pkg/`와 해당 Rust export를 변경하지 않았고, 동일 candidate의 GitHub Frontend package gate와 Build & Test, CodeQL, Render Diff는 성공했다.
+- [PR #5569 검토 기록](../pr/archives/pr_5569_review.md)과 이 항목만 single-parent trailing commit으로 contributor source branch에 올린다. 최신 head의 review-only fast-pass aggregate와 mergeability를 다시 확인한 뒤, 첫 기여자에게 환영과 구체적인 검증 결과를 담은 승인 코멘트를 남기고 merge·후속 정리를 진행한다.

--- a/mydocs/pr/archives/pr_5569_review.md
+++ b/mydocs/pr/archives/pr_5569_review.md
@@ -1,0 +1,58 @@
+---
+kind: pr-review
+status: active
+pr: 5569
+---
+
+# PR #5569 검토: 문서 에이전트 exact command 공개 브리지
+
+## 접수
+
+- PR: [#5569](https://github.com/edwardkim/rhwp/pull/5569) `기능: 문서 에이전트 공개 명령 브리지 추가`
+- 작성자: `@coolwithyou` (first-time contributor)
+- base: `devel` (`5305e994207b8b7a4eddac7600be3f804cfbf2f8`)
+- code candidate: `364962caf60189b22dad244bb47f340dd2262261`
+- 작성 시점 상태: `MERGEABLE`, `CLEAN`, non-draft. Reviewer `@jangster77`을 지정했다.
+- base route: `collaborator_external_pr.md`
+- modifiers: `intake_and_review.md`, `local_validation.md`, `visual_fixture_evidence.md`, `multi_pr_update_branch.md`, `review_only_fast_pass.md`
+- loaded documents: `pr_review_workflow.md`, `pr_review/README.md` 및 위 라우팅 문서
+
+## 변경 범위와 계보
+
+- contributor의 단일 기능 commit을 최신 `upstream/devel` 위 가시성 브랜치 `review/coolwithyou-5569-20260819`에 cherry-pick했다.
+- `@rhwp/editor`에 strict v1 DTO 검증, document state/selection/apply/revert/focus/event 공개 표면을 추가한다.
+- Studio에는 capability 협상, snapshot transaction, exact inverse revert, document-agent 변경 이벤트와 strict render 완료 경로를 연결한다.
+- HWP/HWPX browser E2E와 SDK·transport·controller·history 회귀를 추가한다.
+- 메인터너 코드·테스트 보정은 없다. 이 문서와 오늘할일만 contributor code candidate 뒤에 single-parent trailing commit으로 추가한다.
+
+## 검토 결과
+
+**차단 결함 없음.** public SDK의 strict 요청·응답 검증, capability fail-closed 동작, command fence, snapshot rollback, 일반 undo와 agent revert의 경계, event 구독 수명과 renderer commit 순서를 검토했다.
+
+첫 기여자 처리로 최신 trailing head의 CI가 성공하면, 환영과 다음의 구체적 검증 결과를 포함한 approval comment를 게시한다. 검증 수준은 첫 기여 여부와 무관하게 일반 contributor PR과 동일하게 유지한다.
+
+## 검증 증적
+
+### 로컬
+
+- `npm --prefix npm/editor test`: 32 passed.
+- `npm --prefix rhwp-studio test`: 982 passed, 기존 skipped 1건.
+- `npm --prefix rhwp-studio run build`: lockfile 기준 `npm ci` 뒤 통과.
+- `(cd rhwp-studio && npx tsc --ignoreConfig --noEmit --skipLibCheck ../npm/editor/index.d.ts)`: 통과.
+- `(cd npm/editor && npm pack --dry-run --json)`: `@rhwp/editor@0.8.5`, 배포 파일 6개 확인.
+- `VITE_URL=http://127.0.0.1:7700 npm --prefix rhwp-studio run e2e:document-agent`: HWP/HWPX 각각 15개, 총 30개 browser assertion 통과. apply/revert, strict render 3초 상한, target 밖 manifest, focus/selection, native typing/undo, event 3회를 확인했다.
+- `git diff --check upstream/devel...HEAD`: 통과.
+
+### 기준선·환경 한계
+
+- 표준 `docker compose --env-file .env.docker run --rm wasm`은 이 macOS host에서 Docker daemon 부재로 실행할 수 없었다.
+- `node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs`와 일반 `e2e:embed`는 `pkg/rhwp.d.ts`에 없는 `getFontDecisionTrace` 때문에 중단됐다. 이 Rust export와 `pkg/`는 PR #5569 diff 밖의 최신 `devel` 기준선이며, document-agent E2E 자체는 통과했다. 이 사유로 PR 변경을 실패로 분류하지 않는다.
+
+### GitHub Actions
+
+- code candidate `364962caf60189b22dad244bb47f340dd2262261`의 CI preflight, Frontend package gate, Build & Test aggregate, CodeQL 세 언어, Proptest, Adapter inter-diff, Canvas visual diff가 성공했다.
+- Rust·Native Skia·archive worker는 impact policy에 따라 skipped됐으며, Frontend package 변경 범위에 대한 gate가 실행된 것을 확인했다.
+
+## 다음 게이트
+
+이 문서와 오늘할일만 담은 single-parent trailing commit을 contributor source branch에 push한다. 이후 최신 head의 review-only fast-pass preflight와 Build & Test aggregate가 성공하고 mergeability가 유지될 때 first-time contributor approval comment를 게시한 뒤 merge한다.

--- a/mydocs/tech/wasm_agent_surface/README.md
+++ b/mydocs/tech/wasm_agent_surface/README.md
@@ -2,7 +2,7 @@
 kind: guide
 status: active
 canonical: mydocs/tech/wasm_agent_surface/README.md
-last_verified: 2026-08-03
+last_verified: 2026-08-19
 ---
 
 # WASM/브라우저 에이전트 표면 문서 지도
@@ -44,6 +44,7 @@ M24 는 세 줄짜리 체크리스트다(#3608 본문 §8 "장기 지평(M18~M30
 | --- | --- | --- | --- |
 | [WASM capabilities 자기서술 설계](self_description.md) | canonical | 브라우저 소비자가 "이 모듈이 뭘 할 수 있나"를 아는 방법, CLI 와의 동등성 유지 | M24 첫 줄을 구현할 때. **이 축의 전제** |
 | [브라우저 내 MCP-유사 브리지](browser_bridge.md) | canonical | JSON-RPC 를 postMessage·MessageChannel·Worker 중 무엇에 얹을지, 그리고 origin 경계 | M24 둘째 줄. studio 연동을 설계할 때 |
+| [문서 에이전트 exact command 계약](document_agent_command.md) | canonical | HWP/HWPX 문단 교체의 상태 fence, 재현 가능한 SHA-256, 트랜잭션·되돌리기·이벤트 계약 | 서버가 만든 편집 후보를 Studio에서 안전하게 적용할 때 |
 | [설치 0 온보딩 데모](zero_install_onboarding.md) | guide | 아무것도 설치하지 않고 rhwp 를 써보는 경로, 크기 예산, 오프라인 동작 | M24 셋째 줄. #3869 의 진입점 |
 
 셋은 **순서대로 의존한다.** 자기서술이 없으면 브리지가 무엇을 노출할지 정할 수 없고,

--- a/mydocs/tech/wasm_agent_surface/document_agent_command.md
+++ b/mydocs/tech/wasm_agent_surface/document_agent_command.md
@@ -1,0 +1,155 @@
+---
+kind: canonical
+status: active
+canonical: mydocs/tech/wasm_agent_surface/document_agent_command.md
+last_verified: 2026-08-19
+---
+
+# 문서 에이전트 exact command 계약
+
+서버가 HWP/HWPX 원문에서 만든 문단 교체 후보를 `@rhwp/editor`가 현재 열린 문서에 적용하는
+v1 계약이다. 서버는 **후보 생성 권위**, Studio는 **현재 문서 상태와 쓰기 권위**를 가진다.
+명령은 자유 형식 편집 지시가 아니라 상태·원문·서식·인접 문맥을 모두 결속한 exact command다.
+
+구현 정본은 다음 네 곳이다.
+
+- 공개 SDK와 strict 응답 검증: `npm/editor/index.js`, `npm/editor/document-agent-contract.js`
+- iframe capability/session 경계: `npm/editor/transport.js`, `rhwp-studio/src/embed/`
+- 명령 트랜잭션과 postcondition: `rhwp-studio/src/document-agent/controller.ts`
+- 기존 편집기 undo/selection 경로: `rhwp-studio/src/engine/input-handler.ts`
+
+## 1. 공개 표면
+
+```ts
+const state = await editor.getDocumentState();
+const selection = await editor.getSelectionContext();
+const receipt = await editor.applyTextCommand(command);
+const reverted = await editor.revertTextCommand(revertCommand);
+await editor.focusTarget(target);
+
+const off = editor.onDocumentChanged((event) => {
+  // reason: agent_apply | agent_revert
+});
+off();
+```
+
+Studio가 해당 capability를 광고하지 않으면 SDK는 요청을 보내지 않고
+`CAPABILITY_UNSUPPORTED`로 실패한다. v1 DTO는 알 수 없는 필드를 허용하지 않는다.
+
+| 메서드 | capability | 역할 |
+| --- | --- | --- |
+| `getDocumentState` | `document-state-v1` | epoch, change sequence, 페이지 수, 현재 직렬화 바이트 SHA |
+| `getSelectionContext` | `selection-context-v1` | 현재 body paragraph exact target과 선택 SHA |
+| `applyTextCommand` / `revertTextCommand` | `document-agent-command-v1` | 검증된 단일 문단 교체·역패치 |
+| `focusTarget` | `target-navigation-v1` | mutation 없이 exact 문단 선택·중앙 이동 |
+| `onDocumentChanged` | `document-change-events-v1` | 성공적으로 commit된 agent apply/revert 통지 |
+
+## 2. 지원 target과 제한
+
+v1은 본문 문단 전체만 지원한다.
+
+```json
+{
+  "kind": "body_paragraph",
+  "section": 0,
+  "paragraph": 12,
+  "charOffset": 0,
+  "length": 31
+}
+```
+
+- `charOffset`은 항상 `0`이다.
+- `length`와 모든 offset은 UTF-16 code unit가 아니라 Unicode code point 수다.
+- 대상 문단은 최대 4,000 code point다.
+- replacement는 한 문단의 plain text이며 U+0000..U+001F, U+007F control 문자를 허용하지 않는다.
+- 대상에 control, field, 혼합 `charShapeId`가 있으면 `TARGET_FORMAT_MISMATCH`다.
+- HWP/HWPX만 지원한다. 표 셀, 머리말, 각주, 글상자는 v1 대상이 아니다.
+- 인접 문단에는 control이나 혼합 서식이 있어도 되며, 그 상태 전체가 context SHA에 들어간다.
+
+## 3. SHA-256 정규형
+
+모든 digest는 **정규화하지 않은 원문 문자열의 UTF-8 바이트** 또는 아래에 정의한 공백 없는
+JSON UTF-8 바이트에 SHA-256을 적용한 소문자 64자리 hex다. JSON key 순서는 이 문서의 순서로
+고정한다. 런타임 `stable_id`는 세션 계보 값이므로 어떤 외부 digest에도 넣지 않는다.
+
+### 3.1 원문 SHA
+
+```text
+expectedBeforeSha256 = sha256(utf8(targetParagraphText))
+```
+
+예제 `기존 문단`의 값은
+`73b107c1b8b366ea082beba6cf29568890d48845fa212849f74b516209a6378e`다.
+
+### 3.2 서식 SHA
+
+```json
+{"schemaVersion":1,"charShapeId":4,"paraShapeId":2,"styleId":3}
+```
+
+위 바이트의 SHA는
+`5479c59c8c99dde1c9bb45c70a4689eab28233b28dcf31976db9ab8e4b74ec71`다.
+대상 문단의 모든 code point가 같은 `charShapeId`일 때만 이 값을 만든다. 빈 문단은 offset 0의
+기본 글자 모양을 사용한다.
+
+### 3.3 인접 문맥 SHA
+
+바로 앞·뒤 문단을 다음 고정 key 순서로 직렬화한다. 구역 경계 밖이면 `null`이다.
+
+```ts
+type AdjacentParagraphV1 = {
+  section: number;
+  paragraph: number;
+  length: number;
+  textSha256: string;
+  paraShapeId: number;
+  styleId: number;
+  charShapeIds: number[]; // 각 code point, 빈 문단은 기본값 1개
+  controls: number[];     // control text position, 원래 순서
+};
+
+JSON.stringify({ schemaVersion: 1, previous, next })
+```
+
+`앞 문단` / target `기존 문단` / `뒤 문단`이 모두 `charShapeId=4`, `paraShapeId=2`,
+`styleId=3`, control 없음일 때 SHA는
+`17026195f4004b9995060c1dd27a14fb8619c9afc502a371cbdebf94025b7568`다.
+
+### 3.4 문서 SHA
+
+`documentSha256`은 현재 IR을 원래 source format으로 직렬화한 전체 바이트의 SHA다.
+HWPX writer는 ZIP mtime을 1980-01-01로 고정하므로 같은 상태의 출력은 결정적이다. 명령 작성자는
+원본 업로드 파일의 SHA를 추측해 넣지 말고, 적용 직전 `getDocumentState()`가 반환한 값을 사용한다.
+
+## 4. 적용 순서
+
+1. `getDocumentState()`와 서버 후보의 document binding을 비교한다.
+2. `expectedDocumentEpoch`, `expectedChangeSeq`, `expectedDocumentSha256`, target의 세 SHA를 넣어
+   `applyTextCommand()`를 호출한다.
+3. Studio는 mutation 전에 모든 fence를 검사한다.
+4. 기존 snapshot undo 경로 안에서 문단 전체를 교체하고 원래 글자·문단 모양을 복원한다.
+5. target 밖 semantic manifest, 인접 문맥, 페이지 수, 시간 예산(3초)을 검사한다.
+6. 하나라도 다르면 같은 snapshot transaction을 rollback한다. 성공하면 `changeSeq`가 정확히 1
+   증가한 receipt와 `documentChanged` 이벤트를 반환한다.
+
+같은 `commandId`와 완전히 같은 binding의 apply/revert 재전송은 저장된 receipt를 돌려준다.
+같은 ID에 다른 binding을 쓰면 `COMMAND_REPLAY_MISMATCH`다.
+
+## 5. 되돌리기와 일반 undo
+
+`revertTextCommand()`는 가장 최근에 성공한 agent command만 exact inverse patch로 되돌린다.
+apply 뒤 사용자 입력이나 다른 mutation이 한 번이라도 있으면 `COMMAND_NOT_LATEST`로 거부한다.
+apply와 revert는 각각 기존 편집기의 snapshot transaction 하나이므로 일반 Ctrl/Cmd+Z history에도
+한 단계씩 기록된다. agent revert와 일반 undo를 동시에 성공했다고 간주해서는 안 된다.
+
+## 6. 실패와 증거 경계
+
+대표 오류는 epoch/sequence/document SHA 불일치, target 원문·서식·문맥 불일치, target 밖 변경,
+페이지 수 변경, replay 충돌, 시간 초과, transaction 실패다. 모든 실패는 error code로 분기하고
+메시지 문자열을 판정 권위로 쓰지 않는다. `TRANSACTION_FAILED`와 `RENDER_FAILED` Error에는
+`recovered: boolean`이 붙는다. `false`이면 화면 복구까지 실패한 fatal 상태이므로 host는 추가
+mutation을 막고 현재 문서 다운로드 또는 신뢰 가능한 server head 재로드만 제공해야 한다.
+
+단위·계약 테스트와 TypeScript·Vite·WASM 빌드는 경계 로직과 컴파일 가능성을 증명한다. 실제 HWP와
+HWPX 파일의 적용·revert·사용자 입력·undo·시각 보존은 실행 중인 Studio를 대상으로 한 브라우저
+게이트가 별도로 필요하다.

--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -171,6 +171,49 @@ await editor.loadFile(buffer, 'sample.hwpx', { suppressDialogs: false });
 const count = await editor.pageCount();
 ```
 
+### 문서 에이전트 exact command
+
+서버가 만든 HWP/HWPX 문단 교체 후보는 현재 문서의 epoch, change sequence, 전체 문서 SHA,
+target 원문·서식·인접 문맥 SHA를 모두 결속한 뒤 한 snapshot transaction으로 적용할 수 있습니다.
+
+```javascript
+const state = await editor.getDocumentState();
+const selection = await editor.getSelectionContext();
+if (!selection.editable || !selection.target) throw new Error('편집할 수 없는 target');
+
+const receipt = await editor.applyTextCommand({
+  schemaVersion: 1,
+  commandId: crypto.randomUUID(),
+  expectedDocumentEpoch: state.documentEpoch,
+  expectedChangeSeq: state.changeSeq,
+  expectedDocumentSha256: state.documentSha256,
+  target: selection.target,
+  expectedBeforeSha256: candidate.beforeSha256,
+  expectedFormatSha256: candidate.formatSha256,
+  expectedAdjacentContextSha256: candidate.adjacentContextSha256,
+  replacement: candidate.replacement,
+});
+
+await editor.focusTarget(receipt.target);
+const off = editor.onDocumentChanged(event => console.log(event.reason, event.changeSeq));
+
+await editor.revertTextCommand({
+  schemaVersion: 1,
+  commandId: receipt.commandId,
+  expectedDocumentEpoch: receipt.documentEpoch,
+  expectedChangeSeq: receipt.afterChangeSeq,
+  expectedAfterDocumentSha256: receipt.afterDocumentSha256,
+  expectedAfterSha256: receipt.afterTextSha256,
+});
+off();
+```
+
+v1 target은 control·field·혼합 글자 서식이 없는 본문 문단 전체(최대 4,000 Unicode code point)로
+제한됩니다. apply 뒤 다른 편집이 있으면 agent revert는 실패합니다. `TRANSACTION_FAILED`와
+`RENDER_FAILED`에는 snapshot 복구 여부인 `error.recovered`가 포함됩니다. SHA 정규형과 오류 계약은
+[`document_agent_command.md`](https://github.com/edwardkim/rhwp/blob/devel/mydocs/tech/wasm_agent_surface/document_agent_command.md)를
+참조하세요.
+
 ### editor.getPageSvg(page?)
 
 특정 페이지를 SVG 문자열로 렌더링합니다.

--- a/npm/editor/document-agent-contract.js
+++ b/npm/editor/document-agent-contract.js
@@ -1,0 +1,217 @@
+const SHA256 = /^[0-9a-f]{64}$/;
+
+function contractError(code, message) {
+  const error = new TypeError(message);
+  error.code = code;
+  return error;
+}
+
+function record(value, label, code) {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw contractError(code, `${label} must be an object`);
+  }
+  return value;
+}
+
+function exactKeys(value, keys, label, code) {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw contractError(code, `${label} has invalid fields`);
+  }
+}
+
+function safeInteger(value, label, minimum, code) {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw contractError(code, `${label} must be a safe integer >= ${minimum}`);
+  }
+}
+
+function sha256(value, label, code) {
+  if (typeof value !== 'string' || !SHA256.test(value)) {
+    throw contractError(code, `${label} must be a lowercase SHA-256 hex digest`);
+  }
+}
+
+function boolean(value, label, code) {
+  if (typeof value !== 'boolean') throw contractError(code, `${label} must be boolean`);
+}
+
+export function assertCapability(transport, capability) {
+  if (transport.supports(capability)) return;
+  const error = new Error(`${capability} is not supported by this Studio`);
+  error.code = 'CAPABILITY_UNSUPPORTED';
+  throw error;
+}
+
+export function validateBodyParagraphTarget(value, code = 'INVALID_COMMAND') {
+  const target = record(value, 'target', code);
+  exactKeys(
+    target,
+    ['kind', 'section', 'paragraph', 'charOffset', 'length'],
+    'target',
+    code,
+  );
+  if (target.kind !== 'body_paragraph') {
+    throw contractError(code, 'target.kind must be body_paragraph');
+  }
+  safeInteger(target.section, 'target.section', 0, code);
+  safeInteger(target.paragraph, 'target.paragraph', 0, code);
+  if (target.charOffset !== 0) throw contractError(code, 'target.charOffset must be 0');
+  safeInteger(target.length, 'target.length', 0, code);
+  if (target.length > 4000) throw contractError(code, 'target.length must be <= 4000');
+  return target;
+}
+
+export function validateApplyTextCommand(value) {
+  const code = 'INVALID_COMMAND';
+  const command = record(value, 'command', code);
+  exactKeys(command, [
+    'schemaVersion', 'commandId', 'expectedDocumentEpoch', 'expectedChangeSeq',
+    'expectedDocumentSha256', 'target', 'expectedBeforeSha256',
+    'expectedFormatSha256', 'expectedAdjacentContextSha256', 'replacement',
+  ], 'command', code);
+  if (command.schemaVersion !== 1) throw contractError(code, 'command.schemaVersion must be 1');
+  if (typeof command.commandId !== 'string'
+      || command.commandId.length < 1 || command.commandId.length > 128) {
+    throw contractError(code, 'command.commandId must be a string in 1..=128 characters');
+  }
+  safeInteger(command.expectedDocumentEpoch, 'command.expectedDocumentEpoch', 1, code);
+  safeInteger(command.expectedChangeSeq, 'command.expectedChangeSeq', 0, code);
+  sha256(command.expectedDocumentSha256, 'command.expectedDocumentSha256', code);
+  validateBodyParagraphTarget(command.target, code);
+  sha256(command.expectedBeforeSha256, 'command.expectedBeforeSha256', code);
+  sha256(command.expectedFormatSha256, 'command.expectedFormatSha256', code);
+  sha256(command.expectedAdjacentContextSha256, 'command.expectedAdjacentContextSha256', code);
+  if (typeof command.replacement !== 'string'
+      || Array.from(command.replacement).length > 4000) {
+    throw contractError(code, 'command.replacement must be a string with at most 4000 characters');
+  }
+  if (/[\u0000-\u001f\u007f]/u.test(command.replacement)) {
+    throw contractError(code, 'command.replacement must not contain control characters');
+  }
+  return command;
+}
+
+export function validateRevertTextCommand(value) {
+  const code = 'INVALID_COMMAND';
+  const command = record(value, 'command', code);
+  exactKeys(command, [
+    'schemaVersion', 'commandId', 'expectedDocumentEpoch', 'expectedChangeSeq',
+    'expectedAfterDocumentSha256', 'expectedAfterSha256',
+  ], 'command', code);
+  if (command.schemaVersion !== 1) throw contractError(code, 'command.schemaVersion must be 1');
+  if (typeof command.commandId !== 'string'
+      || command.commandId.length < 1 || command.commandId.length > 128) {
+    throw contractError(code, 'command.commandId must be a string in 1..=128 characters');
+  }
+  safeInteger(command.expectedDocumentEpoch, 'command.expectedDocumentEpoch', 1, code);
+  safeInteger(command.expectedChangeSeq, 'command.expectedChangeSeq', 0, code);
+  sha256(command.expectedAfterDocumentSha256, 'command.expectedAfterDocumentSha256', code);
+  sha256(command.expectedAfterSha256, 'command.expectedAfterSha256', code);
+  return command;
+}
+
+export function validateDocumentState(value) {
+  const code = 'INVALID_RESPONSE';
+  const state = record(value, 'document state', code);
+  exactKeys(state, [
+    'schemaVersion', 'format', 'documentEpoch', 'changeSeq', 'dirty', 'pageCount',
+    'documentSha256',
+  ], 'document state', code);
+  if (state.schemaVersion !== 1) throw contractError(code, 'document state schemaVersion must be 1');
+  if (state.format !== 'hwp' && state.format !== 'hwpx') {
+    throw contractError(code, 'document state format must be hwp or hwpx');
+  }
+  safeInteger(state.documentEpoch, 'document state documentEpoch', 1, code);
+  safeInteger(state.changeSeq, 'document state changeSeq', 0, code);
+  boolean(state.dirty, 'document state dirty', code);
+  safeInteger(state.pageCount, 'document state pageCount', 1, code);
+  sha256(state.documentSha256, 'document state documentSha256', code);
+  return state;
+}
+
+export function validateSelectionContext(value) {
+  const code = 'INVALID_RESPONSE';
+  const selection = record(value, 'selection context', code);
+  exactKeys(selection, [
+    'schemaVersion', 'documentEpoch', 'changeSeq', 'page', 'editable', 'collapsed',
+    'target', 'selectedTextSha256',
+  ], 'selection context', code);
+  if (selection.schemaVersion !== 1) {
+    throw contractError(code, 'selection context schemaVersion must be 1');
+  }
+  safeInteger(selection.documentEpoch, 'selection context documentEpoch', 1, code);
+  safeInteger(selection.changeSeq, 'selection context changeSeq', 0, code);
+  safeInteger(selection.page, 'selection context page', 1, code);
+  boolean(selection.editable, 'selection context editable', code);
+  boolean(selection.collapsed, 'selection context collapsed', code);
+  if (selection.target !== null) validateBodyParagraphTarget(selection.target, code);
+  if (selection.selectedTextSha256 !== null) {
+    sha256(selection.selectedTextSha256, 'selection context selectedTextSha256', code);
+  }
+  return selection;
+}
+
+export function validateTextCommandReceipt(value) {
+  const code = 'INVALID_RESPONSE';
+  const receipt = record(value, 'text command receipt', code);
+  exactKeys(receipt, [
+    'schemaVersion', 'commandId', 'operation', 'documentEpoch', 'beforeChangeSeq',
+    'afterChangeSeq', 'beforeDocumentSha256', 'afterDocumentSha256',
+    'beforeTextSha256', 'afterTextSha256', 'formatSha256',
+    'adjacentContextSha256', 'pageCountBefore', 'pageCountAfter', 'target',
+  ], 'text command receipt', code);
+  if (receipt.schemaVersion !== 1) throw contractError(code, 'receipt.schemaVersion must be 1');
+  if (typeof receipt.commandId !== 'string'
+      || receipt.commandId.length < 1 || receipt.commandId.length > 128) {
+    throw contractError(code, 'receipt.commandId is invalid');
+  }
+  if (receipt.operation !== 'apply' && receipt.operation !== 'revert') {
+    throw contractError(code, 'receipt.operation is invalid');
+  }
+  safeInteger(receipt.documentEpoch, 'receipt.documentEpoch', 1, code);
+  safeInteger(receipt.beforeChangeSeq, 'receipt.beforeChangeSeq', 0, code);
+  safeInteger(receipt.afterChangeSeq, 'receipt.afterChangeSeq', 1, code);
+  if (receipt.afterChangeSeq !== receipt.beforeChangeSeq + 1) {
+    throw contractError(code, 'receipt change sequence is invalid');
+  }
+  for (const key of [
+    'beforeDocumentSha256', 'afterDocumentSha256', 'beforeTextSha256',
+    'afterTextSha256', 'formatSha256', 'adjacentContextSha256',
+  ]) sha256(receipt[key], `receipt.${key}`, code);
+  safeInteger(receipt.pageCountBefore, 'receipt.pageCountBefore', 1, code);
+  safeInteger(receipt.pageCountAfter, 'receipt.pageCountAfter', 1, code);
+  validateBodyParagraphTarget(receipt.target, code);
+  return receipt;
+}
+
+export function validateFocusTargetResult(value) {
+  const code = 'INVALID_RESPONSE';
+  const result = record(value, 'focus target result', code);
+  exactKeys(result, ['focused', 'page'], 'focus target result', code);
+  boolean(result.focused, 'focus target result focused', code);
+  safeInteger(result.page, 'focus target result page', 1, code);
+  return result;
+}
+
+export function validateDocumentChangedEvent(value) {
+  const code = 'INVALID_RESPONSE';
+  const event = record(value, 'document changed event', code);
+  exactKeys(event, [
+    'schemaVersion', 'reason', 'documentEpoch', 'changeSeq', 'commandId',
+  ], 'document changed event', code);
+  if (event.schemaVersion !== 1) {
+    throw contractError(code, 'document changed event schemaVersion must be 1');
+  }
+  if (event.reason !== 'agent_apply' && event.reason !== 'agent_revert') {
+    throw contractError(code, 'document changed event reason is invalid');
+  }
+  safeInteger(event.documentEpoch, 'document changed event documentEpoch', 1, code);
+  safeInteger(event.changeSeq, 'document changed event changeSeq', 1, code);
+  if (typeof event.commandId !== 'string'
+      || event.commandId.length < 1 || event.commandId.length > 128) {
+    throw contractError(code, 'document changed event commandId is invalid');
+  }
+  return event;
+}

--- a/npm/editor/index.d.ts
+++ b/npm/editor/index.d.ts
@@ -200,6 +200,90 @@ export interface LoadFileOptions {
   suppressDialogs?: boolean;
 }
 
+export interface RhwpBodyParagraphTargetV1 {
+  kind: 'body_paragraph';
+  section: number;
+  paragraph: number;
+  charOffset: 0;
+  length: number;
+}
+
+export interface RhwpDocumentStateV1 {
+  schemaVersion: 1;
+  format: 'hwp' | 'hwpx';
+  documentEpoch: number;
+  changeSeq: number;
+  dirty: boolean;
+  pageCount: number;
+  documentSha256: string;
+}
+
+export interface RhwpSelectionContextV1 {
+  schemaVersion: 1;
+  documentEpoch: number;
+  changeSeq: number;
+  /** 1부터 시작하는 UI 페이지 번호 */
+  page: number;
+  editable: boolean;
+  collapsed: boolean;
+  target: RhwpBodyParagraphTargetV1 | null;
+  selectedTextSha256: string | null;
+}
+
+export interface RhwpApplyTextCommandV1 {
+  schemaVersion: 1;
+  commandId: string;
+  expectedDocumentEpoch: number;
+  expectedChangeSeq: number;
+  expectedDocumentSha256: string;
+  target: RhwpBodyParagraphTargetV1;
+  expectedBeforeSha256: string;
+  expectedFormatSha256: string;
+  expectedAdjacentContextSha256: string;
+  replacement: string;
+}
+
+export interface RhwpRevertTextCommandV1 {
+  schemaVersion: 1;
+  commandId: string;
+  expectedDocumentEpoch: number;
+  expectedChangeSeq: number;
+  expectedAfterDocumentSha256: string;
+  expectedAfterSha256: string;
+}
+
+export interface RhwpTextCommandReceiptV1 {
+  schemaVersion: 1;
+  commandId: string;
+  operation: 'apply' | 'revert';
+  documentEpoch: number;
+  beforeChangeSeq: number;
+  afterChangeSeq: number;
+  beforeDocumentSha256: string;
+  afterDocumentSha256: string;
+  beforeTextSha256: string;
+  afterTextSha256: string;
+  formatSha256: string;
+  adjacentContextSha256: string;
+  pageCountBefore: number;
+  pageCountAfter: number;
+  target: RhwpBodyParagraphTargetV1;
+}
+
+export interface RhwpDocumentChangedEventV1 {
+  schemaVersion: 1;
+  reason: 'agent_apply' | 'agent_revert';
+  documentEpoch: number;
+  changeSeq: number;
+  commandId: string;
+}
+
+export interface RhwpDocumentAgentError extends Error {
+  code: string;
+  /** TRANSACTION_FAILED/RENDER_FAILED에서 snapshot 복구 성공 여부 */
+  recovered?: boolean;
+}
+
 export declare class RhwpEditor {
   private constructor();
   /** HWP 파일을 로드합니다 */
@@ -229,6 +313,18 @@ export declare class RhwpEditor {
    * 스튜디오가 notify-saved-v1 capability를 광고하지 않으면 요청 없이 실패합니다.
    */
   notifySaved(fileName?: string): Promise<{ ok: true; wasDirty: boolean }>;
+  /** 현재 문서의 에이전트 명령 fence와 SHA-256 상태 */
+  getDocumentState(): Promise<RhwpDocumentStateV1>;
+  /** 현재 캐럿/선택의 exact body paragraph 컨텍스트 */
+  getSelectionContext(): Promise<RhwpSelectionContextV1>;
+  /** exact preimage fence를 검증하고 문단 전체를 한 트랜잭션으로 교체 */
+  applyTextCommand(command: RhwpApplyTextCommandV1): Promise<RhwpTextCommandReceiptV1>;
+  /** 가장 최근에 성공한 exact command를 한 트랜잭션으로 되돌림 */
+  revertTextCommand(command: RhwpRevertTextCommandV1): Promise<RhwpTextCommandReceiptV1>;
+  /** exact body paragraph target으로 캐럿과 뷰포트 이동 */
+  focusTarget(target: RhwpBodyParagraphTargetV1): Promise<{ focused: boolean; page: number }>;
+  /** agent apply/revert가 commit된 뒤 strict v1 변경 이벤트 구독 */
+  onDocumentChanged(listener: (event: RhwpDocumentChangedEventV1) => void): () => void;
   /** iframe 엘리먼트를 반환합니다 */
   readonly element: HTMLIFrameElement;
   // ── 브리지 표면 ────────────────────────────────────────────────

--- a/npm/editor/index.js
+++ b/npm/editor/index.js
@@ -10,6 +10,17 @@
  */
 
 import { EditorTransport } from './transport.js';
+import {
+  assertCapability,
+  validateApplyTextCommand,
+  validateBodyParagraphTarget,
+  validateDocumentState,
+  validateDocumentChangedEvent,
+  validateFocusTargetResult,
+  validateRevertTextCommand,
+  validateSelectionContext,
+  validateTextCommandReceipt,
+} from './document-agent-contract.js';
 
 const DEFAULT_STUDIO_URL = 'https://edwardkim.github.io/rhwp/';
 
@@ -87,6 +98,10 @@ export class RhwpEditor {
   constructor(iframe, transport) {
     this._iframe = iframe;
     this._transport = transport;
+    this._documentChangedListeners = new Set();
+    this._offDocumentChanged = null;
+    this._lastDocumentEpoch = null;
+    this._lastDocumentChangeSeq = null;
   }
 
   /**
@@ -132,12 +147,15 @@ export class RhwpEditor {
    * ```
    */
   async loadFile(data, fileName = 'document.hwp', options = {}) {
-    return this._request('loadFile', {
+    const result = await this._request('loadFile', {
       data,
       fileName,
       skipUnsavedGuard: options.skipUnsavedGuard === true,
       suppressDialogs: options.suppressDialogs === undefined || options.suppressDialogs === true,
     });
+    this._lastDocumentEpoch = null;
+    this._lastDocumentChangeSeq = null;
+    return result;
   }
 
   /**
@@ -259,6 +277,100 @@ export class RhwpEditor {
     return this._request('notifySaved', params);
   }
 
+  /** 현재 문서의 에이전트 명령 fence와 SHA-256 상태를 반환합니다. */
+  async getDocumentState() {
+    assertCapability(this._transport, 'document-state-v1');
+    const state = validateDocumentState(await this._request('getDocumentState'));
+    this._rememberDocumentVersion(state.documentEpoch, state.changeSeq);
+    return state;
+  }
+
+  /** 현재 캐럿/선택을 body paragraph exact target으로 정규화해 반환합니다. */
+  async getSelectionContext() {
+    assertCapability(this._transport, 'selection-context-v1');
+    const selection = validateSelectionContext(await this._request('getSelectionContext'));
+    this._rememberDocumentVersion(selection.documentEpoch, selection.changeSeq);
+    return selection;
+  }
+
+  /** exact preimage fence를 검증하고 한 Studio 트랜잭션으로 문단 전체를 교체합니다. */
+  async applyTextCommand(command) {
+    assertCapability(this._transport, 'document-agent-command-v1');
+    const validCommand = validateApplyTextCommand(command);
+    const receipt = validateTextCommandReceipt(await this._request('applyTextCommand', {
+      command: validCommand,
+    }));
+    this._rememberDocumentVersion(receipt.documentEpoch, receipt.afterChangeSeq);
+    return receipt;
+  }
+
+  /** 가장 최근에 성공한 exact command를 한 Studio 트랜잭션으로 되돌립니다. */
+  async revertTextCommand(command) {
+    assertCapability(this._transport, 'document-agent-command-v1');
+    const validCommand = validateRevertTextCommand(command);
+    const receipt = validateTextCommandReceipt(await this._request('revertTextCommand', {
+      command: validCommand,
+    }));
+    this._rememberDocumentVersion(receipt.documentEpoch, receipt.afterChangeSeq);
+    return receipt;
+  }
+
+  /** exact body paragraph target으로 캐럿과 뷰포트를 이동합니다. */
+  async focusTarget(target) {
+    assertCapability(this._transport, 'target-navigation-v1');
+    const validTarget = validateBodyParagraphTarget(target);
+    return validateFocusTargetResult(await this._request('focusTarget', {
+      target: validTarget,
+    }));
+  }
+
+  /** agent apply/revert가 commit된 뒤 strict v1 변경 이벤트를 구독합니다. */
+  onDocumentChanged(listener) {
+    assertCapability(this._transport, 'document-change-events-v1');
+    if (typeof listener !== 'function') throw new TypeError('listener must be a function');
+    this._documentChangedListeners.add(listener);
+    if (!this._offDocumentChanged) {
+      this._offDocumentChanged = this._transport.on('documentChanged', (payload) => {
+        let event;
+        try {
+          event = validateDocumentChangedEvent(payload);
+        } catch {
+          return;
+        }
+        if (!this._isFreshDocumentEvent(event.documentEpoch, event.changeSeq)) return;
+        this._rememberDocumentVersion(event.documentEpoch, event.changeSeq);
+        for (const subscriber of this._documentChangedListeners) {
+          try { subscriber(event); } catch { /* 한 listener가 다른 listener를 막지 않는다. */ }
+        }
+      });
+    }
+    return () => {
+      this._documentChangedListeners.delete(listener);
+      if (this._documentChangedListeners.size === 0) {
+        this._offDocumentChanged?.();
+        this._offDocumentChanged = null;
+      }
+    };
+  }
+
+  _isFreshDocumentEvent(epoch, changeSeq) {
+    if (this._lastDocumentEpoch === null) return true;
+    if (epoch !== this._lastDocumentEpoch) return epoch > this._lastDocumentEpoch;
+    return this._lastDocumentChangeSeq === null || changeSeq > this._lastDocumentChangeSeq;
+  }
+
+  _rememberDocumentVersion(epoch, changeSeq) {
+    if (this._lastDocumentEpoch === null || epoch > this._lastDocumentEpoch) {
+      this._lastDocumentEpoch = epoch;
+      this._lastDocumentChangeSeq = changeSeq;
+      return;
+    }
+    if (epoch === this._lastDocumentEpoch
+        && (this._lastDocumentChangeSeq === null || changeSeq > this._lastDocumentChangeSeq)) {
+      this._lastDocumentChangeSeq = changeSeq;
+    }
+  }
+
   /**
    * iframe 엘리먼트를 반환합니다.
    */
@@ -348,6 +460,9 @@ export class RhwpEditor {
    * iframe 을 DOM 이동시키면 브라우저가 문서를 재로드해 편집 상태가 사라집니다.
    */
   destroy() {
+    this._offDocumentChanged?.();
+    this._offDocumentChanged = null;
+    this._documentChangedListeners.clear();
     this._transport.destroy();
     this._iframe.remove();
   }

--- a/npm/editor/package.json
+++ b/npm/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rhwp/editor",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "HWP 에디터 웹 컴포넌트 — iframe 기반 임베드",
   "type": "module",
   "main": "index.js",
@@ -12,6 +12,7 @@
     "index.js",
     "index.d.ts",
     "transport.js",
+    "document-agent-contract.js",
     "README.md"
   ],
   "keywords": [

--- a/npm/editor/tests/document-agent-command-v1.contract.test.mjs
+++ b/npm/editor/tests/document-agent-command-v1.contract.test.mjs
@@ -1,0 +1,257 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { RhwpEditor } from '../index.js';
+
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+const SHA_C = 'c'.repeat(64);
+const SHA_D = 'd'.repeat(64);
+
+function target() {
+  return {
+    kind: 'body_paragraph',
+    section: 0,
+    paragraph: 2,
+    charOffset: 0,
+    length: 7,
+  };
+}
+
+function state() {
+  return {
+    schemaVersion: 1,
+    format: 'hwp',
+    documentEpoch: 3,
+    changeSeq: 11,
+    dirty: true,
+    pageCount: 2,
+    documentSha256: SHA_A,
+  };
+}
+
+function selection() {
+  return {
+    schemaVersion: 1,
+    documentEpoch: 3,
+    changeSeq: 11,
+    page: 2,
+    editable: true,
+    collapsed: true,
+    target: target(),
+    selectedTextSha256: null,
+  };
+}
+
+function applyCommand() {
+  return {
+    schemaVersion: 1,
+    commandId: 'cmd-001',
+    expectedDocumentEpoch: 3,
+    expectedChangeSeq: 11,
+    expectedDocumentSha256: SHA_A,
+    target: target(),
+    expectedBeforeSha256: SHA_B,
+    expectedFormatSha256: SHA_C,
+    expectedAdjacentContextSha256: SHA_D,
+    replacement: '새 문단',
+  };
+}
+
+function revertCommand() {
+  return {
+    schemaVersion: 1,
+    commandId: 'cmd-001',
+    expectedDocumentEpoch: 3,
+    expectedChangeSeq: 12,
+    expectedAfterDocumentSha256: SHA_B,
+    expectedAfterSha256: SHA_C,
+  };
+}
+
+function receipt(operation = 'apply') {
+  return {
+    schemaVersion: 1,
+    commandId: 'cmd-001',
+    operation,
+    documentEpoch: 3,
+    beforeChangeSeq: operation === 'apply' ? 11 : 12,
+    afterChangeSeq: operation === 'apply' ? 12 : 13,
+    beforeDocumentSha256: SHA_A,
+    afterDocumentSha256: SHA_B,
+    beforeTextSha256: SHA_C,
+    afterTextSha256: SHA_D,
+    formatSha256: SHA_A,
+    adjacentContextSha256: SHA_B,
+    pageCountBefore: 2,
+    pageCountAfter: 2,
+    target: target(),
+  };
+}
+
+function editorHarness(results, capabilities = [
+  'document-state-v1',
+  'selection-context-v1',
+  'document-agent-command-v1',
+  'target-navigation-v1',
+  'document-change-events-v1',
+]) {
+  const requests = [];
+  const listeners = new Map();
+  const transport = {
+    request(method, params) {
+      requests.push({ method, params });
+      return Promise.resolve(results[method]);
+    },
+    supports(capability) { return capabilities.includes(capability); },
+    on(event, listener) {
+      listeners.set(event, listener);
+      return () => listeners.delete(event);
+    },
+    destroy() {},
+  };
+  return {
+    editor: new RhwpEditor({ remove() {} }, transport),
+    requests,
+    emit(event, payload) { listeners.get(event)?.(payload); },
+    listeners,
+  };
+}
+
+test('문서 에이전트 공개 API는 exact RPC 메서드와 파라미터를 사용한다', async () => {
+  const results = {
+    getDocumentState: state(),
+    getSelectionContext: selection(),
+    applyTextCommand: receipt('apply'),
+    revertTextCommand: receipt('revert'),
+    focusTarget: { focused: true, page: 2 },
+  };
+  const { editor, requests } = editorHarness(results);
+
+  assert.deepEqual(await editor.getDocumentState(), state());
+  assert.deepEqual(await editor.getSelectionContext(), selection());
+  assert.deepEqual(await editor.applyTextCommand(applyCommand()), receipt('apply'));
+  assert.deepEqual(await editor.revertTextCommand(revertCommand()), receipt('revert'));
+  assert.deepEqual(await editor.focusTarget(target()), { focused: true, page: 2 });
+
+  assert.deepEqual(requests, [
+    { method: 'getDocumentState', params: {} },
+    { method: 'getSelectionContext', params: {} },
+    { method: 'applyTextCommand', params: { command: applyCommand() } },
+    { method: 'revertTextCommand', params: { command: revertCommand() } },
+    { method: 'focusTarget', params: { target: target() } },
+  ]);
+});
+
+test('문서 에이전트 공개 API는 capability가 없으면 요청 전에 실패한다', async () => {
+  const { editor, requests } = editorHarness({}, []);
+
+  for (const call of [
+    () => editor.getDocumentState(),
+    () => editor.getSelectionContext(),
+    () => editor.applyTextCommand(applyCommand()),
+    () => editor.revertTextCommand(revertCommand()),
+    () => editor.focusTarget(target()),
+  ]) {
+    await assert.rejects(call, (error) => error.code === 'CAPABILITY_UNSUPPORTED');
+  }
+  assert.deepEqual(requests, []);
+});
+
+test('문서 에이전트 공개 API는 extra key와 잘못된 SHA를 요청 전에 거부한다', async () => {
+  const { editor, requests } = editorHarness({});
+
+  await assert.rejects(
+    () => editor.applyTextCommand({ ...applyCommand(), unexpected: true }),
+    (error) => error.code === 'INVALID_COMMAND',
+  );
+  await assert.rejects(
+    () => editor.applyTextCommand({ ...applyCommand(), expectedDocumentSha256: 'not-a-sha' }),
+    (error) => error.code === 'INVALID_COMMAND',
+  );
+  await assert.rejects(
+    () => editor.applyTextCommand({ ...applyCommand(), replacement: '두 문단\n금지' }),
+    (error) => error.code === 'INVALID_COMMAND',
+  );
+  await assert.rejects(
+    () => editor.focusTarget({ ...target(), charOffset: 1 }),
+    (error) => error.code === 'INVALID_COMMAND',
+  );
+  assert.deepEqual(requests, []);
+});
+
+test('문서 에이전트 공개 API는 malformed 응답을 명시적으로 거부한다', async () => {
+  const malformedState = { ...state(), pageCount: Number.NaN };
+  const malformedSelection = { ...selection(), page: 0 };
+  const malformedReceipt = { ...receipt(), extra: true };
+  const malformedFocus = { focused: true, page: 1, extra: true };
+  const { editor } = editorHarness({
+    getDocumentState: malformedState,
+    getSelectionContext: malformedSelection,
+    applyTextCommand: malformedReceipt,
+    focusTarget: malformedFocus,
+  });
+
+  await assert.rejects(
+    () => editor.getDocumentState(),
+    (error) => error.code === 'INVALID_RESPONSE',
+  );
+  await assert.rejects(
+    () => editor.getSelectionContext(),
+    (error) => error.code === 'INVALID_RESPONSE',
+  );
+  await assert.rejects(
+    () => editor.applyTextCommand(applyCommand()),
+    (error) => error.code === 'INVALID_RESPONSE',
+  );
+  await assert.rejects(
+    () => editor.focusTarget(target()),
+    (error) => error.code === 'INVALID_RESPONSE',
+  );
+});
+
+test('문서 변경 이벤트는 capability와 strict v1 payload를 사용한다', () => {
+  const { editor, emit, listeners } = editorHarness({});
+  const received = [];
+  const off = editor.onDocumentChanged((event) => received.push(event));
+  const event = {
+    schemaVersion: 1,
+    reason: 'agent_apply',
+    documentEpoch: 3,
+    changeSeq: 12,
+    commandId: 'cmd-001',
+  };
+  emit('documentChanged', event);
+  assert.deepEqual(received, [event]);
+  off();
+  assert.equal(listeners.has('documentChanged'), false);
+
+  const unsupported = editorHarness({}, []).editor;
+  assert.throws(
+    () => unsupported.onDocumentChanged(() => {}),
+    (error) => error.code === 'CAPABILITY_UNSUPPORTED',
+  );
+});
+
+test('문서 변경 이벤트는 모든 listener에 한 번 전달하고 stale epoch/seq를 버린다', () => {
+  const { editor, emit } = editorHarness({});
+  const first = [];
+  const second = [];
+  editor.onDocumentChanged(event => first.push(event.changeSeq));
+  editor.onDocumentChanged(event => second.push(event.changeSeq));
+
+  const event = (documentEpoch, changeSeq) => ({
+    schemaVersion: 1,
+    reason: 'agent_apply',
+    documentEpoch,
+    changeSeq,
+    commandId: `cmd-${documentEpoch}-${changeSeq}`,
+  });
+  emit('documentChanged', event(3, 2));
+  emit('documentChanged', event(3, 2));
+  emit('documentChanged', event(2, 99));
+  emit('documentChanged', event(3, 3));
+
+  assert.deepEqual(first, [2, 3]);
+  assert.deepEqual(second, [2, 3]);
+});

--- a/npm/editor/tests/transport.test.mjs
+++ b/npm/editor/tests/transport.test.mjs
@@ -16,6 +16,11 @@ test('EditorTransport는 exact origin의 v1 port로 binary를 caller detach 없�
         'renderer-diagnostics-v1',
         'font-decision-trace-v1',
         'notify-saved-v1',
+        'document-state-v1',
+        'selection-context-v1',
+        'document-agent-command-v1',
+        'target-navigation-v1',
+        'document-change-events-v1',
       ]);
       const server = ports[0];
       server.onmessage = ({ data }) => {
@@ -156,6 +161,75 @@ test('EditorTransport.destroy는 pending request를 거부한다', async () => {
   const pending = transport.request('pageCount');
   transport.destroy();
   await assert.rejects(pending, /Editor destroyed/);
+});
+
+test('EditorTransport는 bound v1 session의 documentChanged event만 전달한다', async () => {
+  let server;
+  const contentWindow = {
+    postMessage(message, _targetOrigin, ports) {
+      server = ports[0];
+      server.start();
+      server.postMessage({
+        type: 'rhwp-connected', version: 1, sessionId: message.sessionId,
+        capabilities: ['transferable-array-buffer', 'document-change-events-v1'],
+      });
+      queueMicrotask(() => {
+        server.postMessage({
+          type: 'rhwp-event', version: 1, sessionId: 'forged',
+          event: 'documentChanged', payload: { changeSeq: 1 },
+        });
+        server.postMessage({
+          type: 'rhwp-event', version: 1, sessionId: message.sessionId,
+          event: 'documentChanged', payload: { changeSeq: 2 },
+        });
+      });
+    },
+  };
+  const transport = new EditorTransport(
+    { contentWindow },
+    'https://studio.example/app',
+    { window: { addEventListener() {}, removeEventListener() {} } },
+  );
+  const received = [];
+  transport.on('documentChanged', (payload) => received.push(payload));
+  await transport.connect();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(received, [{ changeSeq: 2 }]);
+  transport.destroy();
+  server.close();
+});
+
+test('EditorTransport는 document-agent recovered 오류 필드를 보존한다', async () => {
+  let server;
+  const contentWindow = {
+    postMessage(message, _targetOrigin, ports) {
+      server = ports[0];
+      server.onmessage = ({ data }) => {
+        server.postMessage({
+          type: 'rhwp-response', version: 1, sessionId: data.sessionId, id: data.id,
+          error: { code: 'RENDER_FAILED', message: 'render failed', recovered: true },
+        });
+      };
+      server.start();
+      server.postMessage({
+        type: 'rhwp-connected', version: 1, sessionId: message.sessionId,
+        capabilities: ['transferable-array-buffer', 'document-agent-command-v1'],
+      });
+    },
+  };
+  const transport = new EditorTransport(
+    { contentWindow },
+    'https://studio.example/app',
+    { window: { addEventListener() {}, removeEventListener() {} } },
+  );
+
+  await transport.connect();
+  await assert.rejects(
+    transport.request('applyTextCommand', { command: {} }),
+    (error) => error.code === 'RENDER_FAILED' && error.recovered === true,
+  );
+  transport.destroy();
+  server.close();
 });
 
 test('EditorTransport는 일반 요청 10초와 load/export 60초 기본 timeout을 구분한다', () => {

--- a/npm/editor/transport.js
+++ b/npm/editor/transport.js
@@ -5,6 +5,11 @@ const CAPABILITIES = [
   'renderer-diagnostics-v1',
   'font-decision-trace-v1',
   'notify-saved-v1',
+  'document-state-v1',
+  'selection-context-v1',
+  'document-agent-command-v1',
+  'target-navigation-v1',
+  'document-change-events-v1',
 ];
 const LONG_RUNNING_METHODS = new Set([
   'loadFile', 'getFontDecisionTrace', 'exportHwp', 'exportHwpVerify', 'exportHwpx', 'exportHml',
@@ -46,8 +51,17 @@ function isResponseEnvelope(message, legacy, sessionId) {
   const hasResult = Object.prototype.hasOwnProperty.call(message, 'result');
   const hasError = Object.prototype.hasOwnProperty.call(message, 'error');
   if (hasResult === hasError) return false;
-  return !hasError || (typeof message.error?.code === 'string'
-    && typeof message.error?.message === 'string');
+  const expectedEnvelopeKeys = ['id', hasError ? 'error' : 'result', 'sessionId', 'type', 'version'].sort();
+  const envelopeKeys = Object.keys(message).sort();
+  if (envelopeKeys.length !== expectedEnvelopeKeys.length
+      || envelopeKeys.some((key, index) => key !== expectedEnvelopeKeys[index])) return false;
+  if (!hasError) return true;
+  if (typeof message.error?.code !== 'string' || typeof message.error?.message !== 'string'
+      || (message.error.recovered !== undefined && typeof message.error.recovered !== 'boolean')) {
+    return false;
+  }
+  const allowedErrorKeys = ['code', 'message', 'recovered', 'supportedVersions'];
+  return Object.keys(message.error).every(key => allowedErrorKeys.includes(key));
 }
 
 export class EditorTransport {
@@ -64,6 +78,7 @@ export class EditorTransport {
     this._sessionId = sessionId();
     this._nextId = 0;
     this._pending = new Map();
+    this._listeners = new Map();
     this._port = null;
     this._peerCapabilities = new Set();
     this._legacy = false;
@@ -115,6 +130,16 @@ export class EditorTransport {
     return this._peerCapabilities.has(capability);
   }
 
+  on(event, listener) {
+    if (this._destroyed) throw new Error('Editor destroyed');
+    if (typeof event !== 'string' || typeof listener !== 'function') {
+      throw new TypeError('event and listener are required');
+    }
+    if (!this._listeners.has(event)) this._listeners.set(event, new Set());
+    this._listeners.get(event).add(listener);
+    return () => this._listeners.get(event)?.delete(listener);
+  }
+
   destroy() {
     if (this._destroyed) return;
     this._destroyed = true;
@@ -128,6 +153,7 @@ export class EditorTransport {
       pending.reject(new Error('Editor destroyed'));
     }
     this._pending.clear();
+    this._listeners.clear();
   }
 
   _send(message, transfer) {
@@ -150,6 +176,20 @@ export class EditorTransport {
       this._connectResolve = null;
       this._connectReject = null;
       resolve?.();
+      return;
+    }
+    if (message?.type === 'rhwp-event') {
+      const keys = Object.keys(message).sort();
+      const expectedKeys = ['event', 'payload', 'sessionId', 'type', 'version'];
+      if (message.version !== PROTOCOL_VERSION
+          || message.sessionId !== this._sessionId
+          || !this._peerCapabilities.has('document-change-events-v1')
+          || keys.length !== expectedKeys.length
+          || keys.some((key, index) => key !== expectedKeys[index])
+          || typeof message.event !== 'string') return;
+      for (const listener of this._listeners.get(message.event) || []) {
+        try { listener(message.payload); } catch { /* 한 listener가 다른 listener를 막지 않는다. */ }
+      }
       return;
     }
     if (message?.type === 'rhwp-connect-error'
@@ -197,6 +237,7 @@ export class EditorTransport {
     if (message.error) {
       const error = new Error(message.error.message || message.error);
       if (message.error.code) error.code = message.error.code;
+      if (typeof message.error.recovered === 'boolean') error.recovered = message.error.recovered;
       pending.reject(error);
     }
     else pending.resolve(message.result);

--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -30,6 +30,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `debug-table-pos.mjs` | 진단 | active | E2E 디버그: 표 삽입 후 텍스트 위치 확인 | — | 수동 | 수동 디버그 |
 | `debug-textbox.mjs` | 진단 | active | E2E 디버그: 글상자 삽입 후 텍스트 위치 확인 | — | 수동 | 수동 디버그 |
 | `dialog-theme.test.mjs` | 상시 | active | 다이얼로그 다크 테마 색상 정책 | — | 수동 |  |
+| `document-agent-command.test.mjs` | 상시 | active | HWP/HWPX exact command apply·strict render·revert·focus·native typing·일반 Ctrl+Z·modal 0회 | para-001.hwp, hwpx/para-001.hwpx | npm e2e:document-agent | fresh WASM 필수 |
 | `drag-selection-autoscroll.test.mjs` | 상시 | active | 텍스트 드래그 선택 edge 자동 스크롤 | — | npm e2e:drag-autoscroll |  |
 | `drop-confirm.test.mjs` | 상시 | active | #1439 드래그&드롭 로컬 파일 로딩 보안 게이트 | — | 수동 |  |
 | `edit-pipeline.test.mjs` | 상시 | active | 편집 파이프라인 검증 (Issue #2) | — | 수동 |  |

--- a/rhwp-studio/e2e/document-agent-command.test.mjs
+++ b/rhwp-studio/e2e/document-agent-command.test.mjs
@@ -1,0 +1,348 @@
+import { resolve } from 'node:path';
+
+import { runTest, assert } from './helpers.mjs';
+
+const EDITOR_MODULE_PATH = resolve(import.meta.dirname, '../../npm/editor/index.js').replace(/\\/g, '/');
+const EDITOR_MODULE_URL = EDITOR_MODULE_PATH.startsWith('/')
+  ? `/@fs${EDITOR_MODULE_PATH}`
+  : `/@fs/${EDITOR_MODULE_PATH}`;
+const VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+const FIXTURES = [
+  { file: 'para-001.hwp', format: 'hwp' },
+  { file: 'hwpx/para-001.hwpx', format: 'hwpx' },
+];
+
+runTest('document-agent exact command HWP/HWPX browser gate', async ({ page }) => {
+  await page.goto(`${VITE_URL}/e2e/embed-harness.html`, { waitUntil: 'domcontentloaded' });
+
+  for (const fixture of FIXTURES) {
+    const setup = await page.evaluate(async ({ editorModuleUrl, sampleFile, expectedFormat }) => {
+      const { createEditor } = await import(editorModuleUrl);
+      const host = document.createElement('div');
+      host.style.cssText = 'width: 100vw; height: 100vh';
+      document.body.replaceChildren(host);
+      const editor = await createEditor(host, {
+        studioUrl: `${location.origin}/`,
+        renderer: 'canvas2d',
+        handshakeTimeoutMs: 10_000,
+      });
+      const sampleUrl = `/samples/${sampleFile.split('/').map(encodeURIComponent).join('/')}`;
+      const bytes = await fetch(sampleUrl).then(response => response.arrayBuffer());
+      await editor.loadFile(bytes, sampleFile, { suppressDialogs: true });
+      const studioWindow = editor.element.contentWindow;
+      const wasm = studioWindow.__wasm;
+      if (!wasm) throw new Error('Studio WasmBridge is unavailable');
+
+      const sha = async (value) => {
+        const data = typeof value === 'string' ? new TextEncoder().encode(value) : value;
+        const digest = await crypto.subtle.digest('SHA-256', data);
+        return [...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, '0')).join('');
+      };
+      const safeId = (value, label) => {
+        if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${label} unavailable`);
+        return value;
+      };
+      const charShapeIds = (section, paragraph, length) => Array.from(
+        { length: Math.max(length, 1) },
+        (_, offset) => safeId(
+          wasm.getCharPropertiesAt(section, paragraph, offset).charShapeId,
+          'charShapeId',
+        ),
+      );
+      const semantic = async (section, paragraph) => {
+        const length = wasm.getParagraphLength(section, paragraph);
+        const text = length > 0 ? wasm.getTextRange(section, paragraph, 0, length) : '';
+        return {
+          section,
+          paragraph,
+          length,
+          textSha256: await sha(text),
+          paraShapeId: safeId(
+            wasm.getParaPropertiesAt(section, paragraph).paraShapeId,
+            'paraShapeId',
+          ),
+          styleId: safeId(wasm.getStyleAt(section, paragraph).id, 'styleId'),
+          charShapeIds: charShapeIds(section, paragraph, length),
+          controls: wasm.getControlTextPositions(section, paragraph),
+        };
+      };
+      const evidence = async (target) => {
+        const text = target.length > 0
+          ? wasm.getTextRange(target.section, target.paragraph, 0, target.length)
+          : '';
+        const shapes = charShapeIds(target.section, target.paragraph, target.length);
+        if (!shapes.every(id => id === shapes[0])) throw new Error('mixed target format');
+        const charShapeId = shapes[0];
+        const paraShapeId = safeId(
+          wasm.getParaPropertiesAt(target.section, target.paragraph).paraShapeId,
+          'paraShapeId',
+        );
+        const styleId = safeId(wasm.getStyleAt(target.section, target.paragraph).id, 'styleId');
+        const previous = target.paragraph > 0
+          ? await semantic(target.section, target.paragraph - 1)
+          : null;
+        const next = target.paragraph + 1 < wasm.getParagraphCount(target.section)
+          ? await semantic(target.section, target.paragraph + 1)
+          : null;
+        return {
+          text,
+          textSha256: await sha(text),
+          formatSha256: await sha(JSON.stringify({
+            schemaVersion: 1, charShapeId, paraShapeId, styleId,
+          })),
+          adjacentContextSha256: await sha(JSON.stringify({
+            schemaVersion: 1, previous, next,
+          })),
+        };
+      };
+      const manifest = async (target) => {
+        const sectionCount = wasm.getSectionCount();
+        const paragraphCounts = Array.from(
+          { length: sectionCount },
+          (_, section) => wasm.getParagraphCount(section),
+        );
+        const paragraphs = [];
+        for (let section = 0; section < sectionCount; section += 1) {
+          for (let paragraph = 0; paragraph < paragraphCounts[section]; paragraph += 1) {
+            if (section === target.section && paragraph === target.paragraph) continue;
+            paragraphs.push(await semantic(section, paragraph));
+          }
+        }
+        return sha(JSON.stringify({ schemaVersion: 1, sectionCount, paragraphCounts, paragraphs }));
+      };
+      const targetHasField = (target) => {
+        for (let offset = 0; offset <= target.length; offset += 1) {
+          if (wasm.getFieldInfoAt({
+            sectionIndex: target.section,
+            paragraphIndex: target.paragraph,
+            charOffset: offset,
+          }).inField) return true;
+        }
+        return false;
+      };
+      const findCandidate = async () => {
+        for (let section = 0; section < wasm.getSectionCount(); section += 1) {
+          for (let paragraph = 0; paragraph < wasm.getParagraphCount(section); paragraph += 1) {
+            const length = wasm.getParagraphLength(section, paragraph);
+            if (length < 2 || length > 160) continue;
+            const target = { kind: 'body_paragraph', section, paragraph, charOffset: 0, length };
+            const text = wasm.getTextRange(section, paragraph, 0, length);
+            if (!text.trim() || wasm.getControlTextPositions(section, paragraph).length > 0
+                || targetHasField(target)) continue;
+            try {
+              return { target, evidence: await evidence(target) };
+            } catch {
+              // 다음 plain body paragraph를 찾는다.
+            }
+          }
+        }
+        throw new Error(`safe body paragraph candidate not found: ${sampleFile}`);
+      };
+
+      const state = await editor.getDocumentState();
+      if (state.format !== expectedFormat) {
+        throw new Error(`unexpected source format: ${state.format}`);
+      }
+      const candidate = await findCandidate();
+      const beforeManifest = await manifest(candidate.target);
+      const chars = Array.from(candidate.evidence.text);
+      const replacement = `${chars[0] === '가' ? '나' : '가'}${chars.slice(1).join('')}`;
+      const events = [];
+      const off = editor.onDocumentChanged(event => events.push(event));
+      const apply = async (commandId, currentState, currentEvidence) => {
+        const startedAt = performance.now();
+        const receipt = await editor.applyTextCommand({
+          schemaVersion: 1,
+          commandId,
+          expectedDocumentEpoch: currentState.documentEpoch,
+          expectedChangeSeq: currentState.changeSeq,
+          expectedDocumentSha256: currentState.documentSha256,
+          target: candidate.target,
+          expectedBeforeSha256: currentEvidence.textSha256,
+          expectedFormatSha256: currentEvidence.formatSha256,
+          expectedAdjacentContextSha256: currentEvidence.adjacentContextSha256,
+          replacement,
+        });
+        return { receipt, elapsedMs: performance.now() - startedAt };
+      };
+
+      const first = await apply(crypto.randomUUID(), state, candidate.evidence);
+      const afterTarget = { ...candidate.target, length: Array.from(replacement).length };
+      const afterEvidence = await evidence(afterTarget);
+      const manifestAfterApply = await manifest(afterTarget);
+      const afterApplyState = await editor.getDocumentState();
+      const focus = await editor.focusTarget(afterTarget);
+      const selection = await editor.getSelectionContext();
+      await editor.revertTextCommand({
+        schemaVersion: 1,
+        commandId: first.receipt.commandId,
+        expectedDocumentEpoch: first.receipt.documentEpoch,
+        expectedChangeSeq: first.receipt.afterChangeSeq,
+        expectedAfterDocumentSha256: first.receipt.afterDocumentSha256,
+        expectedAfterSha256: first.receipt.afterTextSha256,
+      });
+      const restoredEvidence = await evidence(candidate.target);
+      const stateAfterRevert = await editor.getDocumentState();
+      const second = await apply(crypto.randomUUID(), stateAfterRevert, restoredEvidence);
+      await editor.focusTarget(afterTarget);
+
+      window.__agentCommandE2E = {
+        editor,
+        off,
+        wasm,
+        target: candidate.target,
+        afterTarget,
+        original: candidate.evidence.text,
+        replacement,
+        beforeManifest,
+        manifest,
+        evidence,
+        receipt: second.receipt,
+        events,
+        expectedFormat,
+      };
+      return {
+        pageCountBefore: state.pageCount,
+        pageCountAfter: afterApplyState.pageCount,
+        applyElapsedMs: first.elapsedMs,
+        appliedText: afterEvidence.text,
+        formatStable: afterEvidence.formatSha256 === candidate.evidence.formatSha256,
+        contextStable:
+          afterEvidence.adjacentContextSha256 === candidate.evidence.adjacentContextSha256,
+        nonTargetStable: manifestAfterApply === beforeManifest,
+        revertedText: restoredEvidence.text,
+        focus,
+        selection,
+        modalCount: studioWindow.document.querySelectorAll('.modal-overlay').length,
+      };
+    }, {
+      editorModuleUrl: EDITOR_MODULE_URL,
+      sampleFile: fixture.file,
+      expectedFormat: fixture.format,
+    });
+
+    assert(setup.applyElapsedMs <= 3000, `${fixture.file}: apply+strict render 3초 이내`);
+    assert(setup.pageCountBefore === setup.pageCountAfter, `${fixture.file}: page count 보존`);
+    assert(setup.formatStable && setup.contextStable, `${fixture.file}: target format/context 보존`);
+    assert(setup.nonTargetStable, `${fixture.file}: target 밖 semantic manifest 보존`);
+    assert(setup.appliedText !== setup.revertedText, `${fixture.file}: apply와 exact revert 동작`);
+    assert(setup.focus.focused && setup.focus.page === setup.selection.page,
+      `${fixture.file}: exact target focus와 selection context 동기화`);
+    assert(setup.modalCount === 0, `${fixture.file}: apply/revert 추가 modal 0회`);
+
+    // focusTarget은 exact target 전체를 선택하고 focus는 문단 끝에 둔다. 일반 입력의
+    // undo를 단일 history entry로 검증하기 위해 End로 같은 위치에서 선택만 접는다.
+    await page.keyboard.press('End');
+    await page.waitForFunction(async () => {
+      const e2e = window.__agentCommandE2E;
+      return e2e && (await e2e.editor.getSelectionContext()).collapsed;
+    }, { timeout: 5000 });
+    await page.keyboard.type('Z');
+    await page.waitForFunction(() => {
+      const e2e = window.__agentCommandE2E;
+      const text = e2e?.wasm.getTextRange(
+        e2e.afterTarget.section,
+        e2e.afterTarget.paragraph,
+        0,
+        e2e.wasm.getParagraphLength(e2e.afterTarget.section, e2e.afterTarget.paragraph),
+      );
+      return typeof text === 'string' && text.endsWith('Z');
+    }, { timeout: 5000 });
+
+    const nativeText = await page.evaluate(() => {
+      const e2e = window.__agentCommandE2E;
+      return {
+        actual: e2e.wasm.getTextRange(
+          e2e.afterTarget.section,
+          e2e.afterTarget.paragraph,
+          0,
+          e2e.wasm.getParagraphLength(e2e.afterTarget.section, e2e.afterTarget.paragraph),
+        ),
+        expected: `${e2e.replacement}Z`,
+      };
+    });
+    assert(nativeText.actual === nativeText.expected,
+      `${fixture.file}: collapsed target 끝 native typing`);
+
+    const typed = await page.evaluate(async () => {
+      const e2e = window.__agentCommandE2E;
+      const state = await e2e.editor.getDocumentState();
+      let revertError = null;
+      try {
+        await e2e.editor.revertTextCommand({
+          schemaVersion: 1,
+          commandId: e2e.receipt.commandId,
+          expectedDocumentEpoch: e2e.receipt.documentEpoch,
+          expectedChangeSeq: state.changeSeq,
+          expectedAfterDocumentSha256: state.documentSha256,
+          expectedAfterSha256: e2e.receipt.afterTextSha256,
+        });
+      } catch (error) {
+        revertError = error?.code ?? String(error);
+      }
+      return { changeSeq: state.changeSeq, revertError };
+    });
+    assert(typed.revertError === 'COMMAND_NOT_LATEST',
+      `${fixture.file}: native typing 뒤 agent revert fail-closed`);
+
+    await page.keyboard.down('Control');
+    await page.keyboard.press('KeyZ');
+    await page.keyboard.up('Control');
+    await page.waitForFunction(() => {
+      const e2e = window.__agentCommandE2E;
+      return e2e?.wasm.getTextRange(
+        e2e.afterTarget.section,
+        e2e.afterTarget.paragraph,
+        0,
+        e2e.wasm.getParagraphLength(e2e.afterTarget.section, e2e.afterTarget.paragraph),
+      ) === e2e.replacement;
+    }, { timeout: 5000 });
+    await page.keyboard.down('Control');
+    await page.keyboard.press('KeyZ');
+    await page.keyboard.up('Control');
+    await page.waitForFunction(() => {
+      const e2e = window.__agentCommandE2E;
+      return e2e?.wasm.getTextRange(
+        e2e.target.section,
+        e2e.target.paragraph,
+        0,
+        e2e.wasm.getParagraphLength(e2e.target.section, e2e.target.paragraph),
+      ) === e2e.original;
+    }, { timeout: 5000 });
+
+    const final = await page.evaluate(async () => {
+      const e2e = window.__agentCommandE2E;
+      const finalManifest = await e2e.manifest(e2e.target);
+      const state = await e2e.editor.getDocumentState();
+      const bytes = e2e.expectedFormat === 'hwpx'
+        ? await e2e.editor.exportHwpx()
+        : await e2e.editor.exportHwp();
+      const result = {
+        finalText: e2e.wasm.getTextRange(
+          e2e.target.section,
+          e2e.target.paragraph,
+          0,
+          e2e.wasm.getParagraphLength(e2e.target.section, e2e.target.paragraph),
+        ),
+        original: e2e.original,
+        manifestStable: finalManifest === e2e.beforeManifest,
+        pageCount: state.pageCount,
+        exportLength: bytes.byteLength,
+        eventReasons: e2e.events.map(event => event.reason),
+        modalCount: e2e.editor.element.contentDocument.querySelectorAll('.modal-overlay').length,
+      };
+      e2e.off();
+      e2e.editor.destroy();
+      delete window.__agentCommandE2E;
+      return result;
+    });
+    assert(final.finalText === final.original, `${fixture.file}: native Ctrl+Z 2회로 원문 복원`);
+    assert(final.manifestStable, `${fixture.file}: 일반 undo 뒤 target 밖 manifest 보존`);
+    assert(final.pageCount === setup.pageCountBefore, `${fixture.file}: 일반 undo 뒤 page count 보존`);
+    assert(final.exportLength > 0, `${fixture.file}: 현재 source format 다운로드 bytes 생성`);
+    assert(final.modalCount === 0, `${fixture.file}: native typing/undo 중 modal 0회`);
+    assert(JSON.stringify(final.eventReasons) === JSON.stringify([
+      'agent_apply', 'agent_revert', 'agent_apply',
+    ]), `${fixture.file}: public agent event exact 3회`);
+  }
+}, { skipLoadApp: true });

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.3.0",
@@ -1848,9 +1848,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4859,9 +4856,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "license": "MIT",
   "type": "module",
   "scripts": {
@@ -48,6 +48,7 @@
     "e2e:issue-4224": "node e2e/issue-4224-pua-f02fb-small-right-triangle-canvas2d.test.mjs --mode=headless",
     "e2e:canvaskit-font-coverage": "node e2e/canvaskit-font-coverage.test.mjs",
     "e2e:embed": "node e2e/embed-transport.test.mjs --mode=headless",
+    "e2e:document-agent": "node e2e/document-agent-command.test.mjs --mode=headless",
     "e2e:baseline:headless": "node e2e/renderer-baseline.mjs --mode=headless --manifest=../scripts/renderer_baseline_manifest.json --output=../output/renderer-baseline/studio-headless",
     "e2e:render-diff": "node e2e/canvas-render-diff.test.mjs --mode=headless",
     "e2e:pdf-render-diff": "node e2e/pdf-render-diff-report.mjs --mode=headless",

--- a/rhwp-studio/src/document-agent/contract.ts
+++ b/rhwp-studio/src/document-agent/contract.ts
@@ -1,0 +1,118 @@
+import {
+  DocumentAgentError,
+  type RhwpApplyTextCommandV1,
+  type RhwpBodyParagraphTargetV1,
+  type RhwpRevertTextCommandV1,
+} from './types.ts';
+
+const SHA256 = /^[0-9a-f]{64}$/;
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new DocumentAgentError('INVALID_COMMAND', `${label}은 객체여야 합니다.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...allowed].sort();
+  if (actual.length !== expected.length
+      || actual.some((key, index) => key !== expected[index])) {
+    throw new DocumentAgentError('INVALID_COMMAND', `${label} 필드가 strict schema와 다릅니다.`);
+  }
+}
+
+function safeInteger(value: unknown, minimum: number, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    throw new DocumentAgentError('INVALID_COMMAND', `${label}은 ${minimum} 이상의 safe integer여야 합니다.`);
+  }
+}
+
+function digest(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !SHA256.test(value)) {
+    throw new DocumentAgentError('INVALID_COMMAND', `${label}은 lowercase SHA-256 hex여야 합니다.`);
+  }
+}
+
+function commandId(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || value.length < 1 || value.length > 128) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'commandId 길이는 1..=128이어야 합니다.');
+  }
+}
+
+export function parseBodyParagraphTarget(value: unknown): RhwpBodyParagraphTargetV1 {
+  const target = record(value, 'target');
+  exactKeys(target, ['kind', 'section', 'paragraph', 'charOffset', 'length'], 'target');
+  if (target.kind !== 'body_paragraph') {
+    throw new DocumentAgentError('INVALID_COMMAND', 'target.kind는 body_paragraph여야 합니다.');
+  }
+  safeInteger(target.section, 0, 'target.section');
+  safeInteger(target.paragraph, 0, 'target.paragraph');
+  if (target.charOffset !== 0) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'target.charOffset은 0이어야 합니다.');
+  }
+  safeInteger(target.length, 0, 'target.length');
+  if (target.length > 4000) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'target.length는 4000 이하여야 합니다.');
+  }
+  return target as unknown as RhwpBodyParagraphTargetV1;
+}
+
+export function parseApplyTextCommand(value: unknown): RhwpApplyTextCommandV1 {
+  const command = record(value, 'command');
+  exactKeys(command, [
+    'schemaVersion', 'commandId', 'expectedDocumentEpoch', 'expectedChangeSeq',
+    'expectedDocumentSha256', 'target', 'expectedBeforeSha256',
+    'expectedFormatSha256', 'expectedAdjacentContextSha256', 'replacement',
+  ], 'command');
+  if (command.schemaVersion !== 1) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'schemaVersion은 1이어야 합니다.');
+  }
+  commandId(command.commandId);
+  safeInteger(command.expectedDocumentEpoch, 1, 'expectedDocumentEpoch');
+  safeInteger(command.expectedChangeSeq, 0, 'expectedChangeSeq');
+  digest(command.expectedDocumentSha256, 'expectedDocumentSha256');
+  const target = parseBodyParagraphTarget(command.target);
+  digest(command.expectedBeforeSha256, 'expectedBeforeSha256');
+  digest(command.expectedFormatSha256, 'expectedFormatSha256');
+  digest(command.expectedAdjacentContextSha256, 'expectedAdjacentContextSha256');
+  if (typeof command.replacement !== 'string'
+      || Array.from(command.replacement).length > 4000) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'replacement는 4000자 이하 문자열이어야 합니다.');
+  }
+  if (/[\u0000-\u001f\u007f]/u.test(command.replacement)) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'replacement에 control 문자를 넣을 수 없습니다.');
+  }
+  return { ...command, target } as unknown as RhwpApplyTextCommandV1;
+}
+
+export function parseRevertTextCommand(value: unknown): RhwpRevertTextCommandV1 {
+  const command = record(value, 'command');
+  exactKeys(command, [
+    'schemaVersion', 'commandId', 'expectedDocumentEpoch', 'expectedChangeSeq',
+    'expectedAfterDocumentSha256', 'expectedAfterSha256',
+  ], 'command');
+  if (command.schemaVersion !== 1) {
+    throw new DocumentAgentError('INVALID_COMMAND', 'schemaVersion은 1이어야 합니다.');
+  }
+  commandId(command.commandId);
+  safeInteger(command.expectedDocumentEpoch, 1, 'expectedDocumentEpoch');
+  safeInteger(command.expectedChangeSeq, 0, 'expectedChangeSeq');
+  digest(command.expectedAfterDocumentSha256, 'expectedAfterDocumentSha256');
+  digest(command.expectedAfterSha256, 'expectedAfterSha256');
+  return command as unknown as RhwpRevertTextCommandV1;
+}
+
+export function assertEmptyParams(value: Record<string, unknown>, label: string): void {
+  exactKeys(value, [], label);
+}
+
+export function assertOnlyParam(
+  value: Record<string, unknown>,
+  key: string,
+  label: string,
+): unknown {
+  exactKeys(value, [key], label);
+  return value[key];
+}

--- a/rhwp-studio/src/document-agent/controller.ts
+++ b/rhwp-studio/src/document-agent/controller.ts
@@ -1,0 +1,890 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex } from '@noble/hashes/utils.js';
+
+import type { EventBus } from '../core/event-bus.ts';
+import type { DocumentPosition, FieldInfoResult } from '../core/types.ts';
+import {
+  DocumentAgentError,
+  isDocumentAgentError,
+  type RhwpApplyTextCommandV1,
+  type RhwpBodyParagraphTargetV1,
+  type RhwpDocumentStateV1,
+  type RhwpRevertTextCommandV1,
+  type RhwpSelectionContextV1,
+  type RhwpTextCommandReceiptV1,
+} from './types.ts';
+
+const MAX_PARAGRAPH_LENGTH = 4000;
+const COMMAND_BUDGET_MS = 3000;
+const encoder = new TextEncoder();
+
+type ExportableDocument = {
+  exportHwp(): Uint8Array;
+  exportHwpx(): Uint8Array;
+};
+
+export interface DocumentAgentWasm {
+  readonly documentGeneration: number;
+  readonly pageCount: number;
+  getSourceFormat(): string;
+  getSectionCount(): number;
+  getParagraphCount(section: number): number;
+  getParagraphLength(section: number, paragraph: number): number;
+  getTextRange(section: number, paragraph: number, offset: number, count: number): string;
+  getControlTextPositions(section: number, paragraph: number): number[];
+  getCharPropertiesAt(section: number, paragraph: number, offset: number): { charShapeId?: number };
+  getParaPropertiesAt(section: number, paragraph: number): { paraShapeId?: number };
+  getStyleAt(section: number, paragraph: number): { id: number; name: string };
+  getFieldInfoAt(position: DocumentPosition): FieldInfoResult;
+  replaceText(
+    section: number,
+    paragraph: number,
+    offset: number,
+    length: number,
+    text: string,
+  ): { ok: boolean; charOffset?: number; newLength?: number };
+  setCharShapeId(
+    section: number,
+    paragraph: number,
+    start: number,
+    end: number,
+    charShapeId: number,
+  ): string;
+  setParaShapeId(section: number, paragraph: number, paraShapeId: number): string;
+  getPageOfPosition(section: number, paragraph: number): { ok: boolean; page?: number };
+  borrowDocumentHandle(): ExportableDocument | null;
+  beginDeferredPagination?(): void;
+  flushDeferredPagination?(): void;
+  cancelDeferredPagination?(): void;
+}
+
+export interface DocumentAgentInput {
+  getCursorPosition(): DocumentPosition;
+  getSelection(): { start: DocumentPosition; end: DocumentPosition } | null;
+  executeDocumentAgentOperation(desc: {
+    kind: 'snapshot';
+    operationType: string;
+    operation: (wasm: DocumentAgentWasm) => DocumentPosition | null;
+    meta?: {
+      actionId?: string;
+      domain?: 'text';
+      refresh?: 'full';
+      dirtyScope?: 'paragraph';
+      selection?: 'moveToResult';
+    };
+  }, render: () => Promise<void>): Promise<void>;
+  focusBodyParagraph(section: number, paragraph: number, length: number): boolean;
+}
+
+export interface TargetEvidence {
+  text: string;
+  textSha256: string;
+  formatSha256: string;
+  adjacentContextSha256: string;
+  charShapeId: number;
+  paraShapeId: number;
+  styleId: number;
+}
+
+interface AgentJournalEntry {
+  command: RhwpApplyTextCommandV1;
+  applyBindingSha256: string;
+  applyReceipt: RhwpTextCommandReceiptV1;
+  beforeText: string;
+  beforeTarget: RhwpBodyParagraphTargetV1;
+  afterTarget: RhwpBodyParagraphTargetV1;
+  beforeEvidence: TargetEvidence;
+  afterEvidence: TargetEvidence;
+  nonTargetManifestSha256: string;
+  status: 'applied' | 'reverted';
+  revertBindingSha256?: string;
+  revertReceipt?: RhwpTextCommandReceiptV1;
+}
+
+interface DocumentAgentControllerDeps {
+  wasm: DocumentAgentWasm;
+  input: DocumentAgentInput;
+  eventBus: EventBus;
+  isDirty(): boolean;
+  render(): Promise<void>;
+  now?: () => number;
+}
+
+function digestBytes(value: Uint8Array): string {
+  return bytesToHex(sha256(value));
+}
+
+function digestText(value: string): string {
+  return digestBytes(encoder.encode(value));
+}
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function safeId(value: number | undefined, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new DocumentAgentError('TARGET_FORMAT_MISMATCH', `${label}을 확인할 수 없습니다.`);
+  }
+  return value as number;
+}
+
+function assertTargetCoordinates(wasm: DocumentAgentWasm, target: RhwpBodyParagraphTargetV1): void {
+  if (target.kind !== 'body_paragraph'
+      || target.charOffset !== 0
+      || !Number.isSafeInteger(target.section)
+      || !Number.isSafeInteger(target.paragraph)
+      || !Number.isSafeInteger(target.length)
+      || target.section < 0
+      || target.paragraph < 0
+      || target.length < 0
+      || target.length > MAX_PARAGRAPH_LENGTH
+      || target.section >= wasm.getSectionCount()
+      || target.paragraph >= wasm.getParagraphCount(target.section)
+      || wasm.getParagraphLength(target.section, target.paragraph) !== target.length) {
+    throw new DocumentAgentError('TARGET_NOT_FOUND', 'exact body paragraph target을 찾을 수 없습니다.');
+  }
+}
+
+function charShapeRuns(wasm: DocumentAgentWasm, section: number, paragraph: number, length: number): number[] {
+  const ids: number[] = [];
+  const count = Math.max(length, 1);
+  for (let offset = 0; offset < count; offset += 1) {
+    ids.push(safeId(
+      wasm.getCharPropertiesAt(section, paragraph, offset).charShapeId,
+      'charShapeId',
+    ));
+  }
+  return ids;
+}
+
+function paragraphSemantic(
+  wasm: DocumentAgentWasm,
+  section: number,
+  paragraph: number,
+): Record<string, unknown> {
+  const length = wasm.getParagraphLength(section, paragraph);
+  const text = length > 0 ? wasm.getTextRange(section, paragraph, 0, length) : '';
+  return {
+    section,
+    paragraph,
+    length,
+    textSha256: digestText(text),
+    paraShapeId: safeId(
+      wasm.getParaPropertiesAt(section, paragraph).paraShapeId,
+      'paraShapeId',
+    ),
+    styleId: safeId(wasm.getStyleAt(section, paragraph).id, 'styleId'),
+    charShapeIds: charShapeRuns(wasm, section, paragraph, length),
+    controls: wasm.getControlTextPositions(section, paragraph),
+  };
+}
+
+function adjacentContextSha256(
+  wasm: DocumentAgentWasm,
+  target: RhwpBodyParagraphTargetV1,
+): string {
+  const previous = target.paragraph > 0
+    ? paragraphSemantic(wasm, target.section, target.paragraph - 1)
+    : null;
+  const next = target.paragraph + 1 < wasm.getParagraphCount(target.section)
+    ? paragraphSemantic(wasm, target.section, target.paragraph + 1)
+    : null;
+  return digestText(JSON.stringify({ schemaVersion: 1, previous, next }));
+}
+
+function hasField(
+  wasm: DocumentAgentWasm,
+  target: RhwpBodyParagraphTargetV1,
+): boolean {
+  for (let offset = 0; offset <= target.length; offset += 1) {
+    if (wasm.getFieldInfoAt({
+      sectionIndex: target.section,
+      paragraphIndex: target.paragraph,
+      charOffset: offset,
+    }).inField) return true;
+  }
+  return false;
+}
+
+export function collectTargetEvidence(
+  wasm: DocumentAgentWasm,
+  target: RhwpBodyParagraphTargetV1,
+): TargetEvidence {
+  assertTargetCoordinates(wasm, target);
+  if (wasm.getControlTextPositions(target.section, target.paragraph).length > 0 || hasField(wasm, target)) {
+    throw new DocumentAgentError(
+      'TARGET_FORMAT_MISMATCH',
+      '컨트롤 또는 필드가 포함된 문단은 에이전트 명령으로 편집할 수 없습니다.',
+    );
+  }
+  const charShapeIds = charShapeRuns(wasm, target.section, target.paragraph, target.length);
+  const charShapeId = charShapeIds[0];
+  if (!charShapeIds.every(id => id === charShapeId)) {
+    throw new DocumentAgentError(
+      'TARGET_FORMAT_MISMATCH',
+      '혼합 글자 서식 문단은 에이전트 명령으로 편집할 수 없습니다.',
+    );
+  }
+  const paraShapeId = safeId(
+    wasm.getParaPropertiesAt(target.section, target.paragraph).paraShapeId,
+    'paraShapeId',
+  );
+  const styleId = safeId(wasm.getStyleAt(target.section, target.paragraph).id, 'styleId');
+  const text = target.length > 0
+    ? wasm.getTextRange(target.section, target.paragraph, 0, target.length)
+    : '';
+  return {
+    text,
+    textSha256: digestText(text),
+    formatSha256: digestText(JSON.stringify({
+      schemaVersion: 1,
+      charShapeId,
+      paraShapeId,
+      styleId,
+    })),
+    adjacentContextSha256: adjacentContextSha256(wasm, target),
+    charShapeId,
+    paraShapeId,
+    styleId,
+  };
+}
+
+function nonTargetManifestSha256(
+  wasm: DocumentAgentWasm,
+  target: RhwpBodyParagraphTargetV1,
+): string {
+  const paragraphs: Array<Record<string, unknown>> = [];
+  for (let section = 0; section < wasm.getSectionCount(); section += 1) {
+    for (let paragraph = 0; paragraph < wasm.getParagraphCount(section); paragraph += 1) {
+      if (section === target.section && paragraph === target.paragraph) continue;
+      paragraphs.push(paragraphSemantic(wasm, section, paragraph));
+    }
+  }
+  return digestText(JSON.stringify({
+    schemaVersion: 1,
+    sectionCount: wasm.getSectionCount(),
+    paragraphCounts: Array.from(
+      { length: wasm.getSectionCount() },
+      (_, section) => wasm.getParagraphCount(section),
+    ),
+    paragraphs,
+  }));
+}
+
+function exportDocumentSha256(wasm: DocumentAgentWasm, format: 'hwp' | 'hwpx'): string {
+  const document = wasm.borrowDocumentHandle();
+  if (!document) throw new DocumentAgentError('TARGET_NOT_FOUND', '문서가 로드되지 않았습니다.');
+  return digestBytes(format === 'hwpx' ? document.exportHwpx() : document.exportHwp());
+}
+
+function commandBinding(command: RhwpApplyTextCommandV1): string {
+  return digestText(JSON.stringify({
+    schemaVersion: command.schemaVersion,
+    commandId: command.commandId,
+    expectedDocumentEpoch: command.expectedDocumentEpoch,
+    expectedChangeSeq: command.expectedChangeSeq,
+    expectedDocumentSha256: command.expectedDocumentSha256,
+    target: command.target,
+    expectedBeforeSha256: command.expectedBeforeSha256,
+    expectedFormatSha256: command.expectedFormatSha256,
+    expectedAdjacentContextSha256: command.expectedAdjacentContextSha256,
+    replacement: command.replacement,
+  }));
+}
+
+function revertBinding(command: RhwpRevertTextCommandV1): string {
+  return digestText(JSON.stringify({
+    schemaVersion: command.schemaVersion,
+    commandId: command.commandId,
+    expectedDocumentEpoch: command.expectedDocumentEpoch,
+    expectedChangeSeq: command.expectedChangeSeq,
+    expectedAfterDocumentSha256: command.expectedAfterDocumentSha256,
+    expectedAfterSha256: command.expectedAfterSha256,
+  }));
+}
+
+function sameBodyPosition(a: DocumentPosition, b: DocumentPosition): boolean {
+  return a.parentParaIndex === undefined
+    && b.parentParaIndex === undefined
+    && a.sectionIndex === b.sectionIndex
+    && a.paragraphIndex === b.paragraphIndex;
+}
+
+function samePosition(a: DocumentPosition, b: DocumentPosition): boolean {
+  return sameBodyPosition(a, b) && a.charOffset === b.charOffset;
+}
+
+export class DocumentAgentController {
+  private readonly deps: DocumentAgentControllerDeps;
+  private readonly now: () => number;
+  private documentEpoch: number;
+  private changeSeq = 0;
+  private latest: AgentJournalEntry | null = null;
+  private readonly journal = new Map<string, AgentJournalEntry>();
+  private readonly offMutation: () => void;
+
+  constructor(deps: DocumentAgentControllerDeps) {
+    this.deps = deps;
+    this.now = deps.now ?? (() => performance.now());
+    this.documentEpoch = deps.wasm.documentGeneration;
+    this.offMutation = deps.eventBus.on('document-mutated', () => {
+      this.syncGeneration();
+      this.changeSeq += 1;
+    });
+  }
+
+  dispose(): void {
+    this.offMutation();
+  }
+
+  getDocumentState(): RhwpDocumentStateV1 {
+    this.syncGeneration();
+    const format = this.currentFormat();
+    return {
+      schemaVersion: 1,
+      format,
+      documentEpoch: this.documentEpoch,
+      changeSeq: this.changeSeq,
+      dirty: this.deps.isDirty(),
+      pageCount: this.deps.wasm.pageCount,
+      documentSha256: exportDocumentSha256(this.deps.wasm, format),
+    };
+  }
+
+  getSelectionContext(): RhwpSelectionContextV1 {
+    this.syncGeneration();
+    const position = this.deps.input.getCursorPosition();
+    const page = this.pageFor(position.sectionIndex, position.paragraphIndex);
+    const selection = this.deps.input.getSelection();
+    const collapsed = !selection || samePosition(selection.start, selection.end);
+    let target: RhwpBodyParagraphTargetV1 | null = null;
+    let editable = false;
+    let selectedTextSha256: string | null = null;
+
+    if (position.parentParaIndex === undefined
+        && position.sectionIndex >= 0
+        && position.paragraphIndex >= 0
+        && position.sectionIndex < this.deps.wasm.getSectionCount()
+        && position.paragraphIndex < this.deps.wasm.getParagraphCount(position.sectionIndex)) {
+      const length = this.deps.wasm.getParagraphLength(
+        position.sectionIndex,
+        position.paragraphIndex,
+      );
+      if (length <= MAX_PARAGRAPH_LENGTH) {
+        target = {
+          kind: 'body_paragraph',
+          section: position.sectionIndex,
+          paragraph: position.paragraphIndex,
+          charOffset: 0,
+          length,
+        };
+        try {
+          collectTargetEvidence(this.deps.wasm, target);
+          this.currentFormat();
+          editable = true;
+        } catch {
+          editable = false;
+        }
+      }
+    }
+
+    if (!collapsed && selection && sameBodyPosition(selection.start, selection.end)) {
+      const length = selection.end.charOffset - selection.start.charOffset;
+      if (length >= 0) {
+        selectedTextSha256 = digestText(this.deps.wasm.getTextRange(
+          selection.start.sectionIndex,
+          selection.start.paragraphIndex,
+          selection.start.charOffset,
+          length,
+        ));
+      }
+    }
+
+    return {
+      schemaVersion: 1,
+      documentEpoch: this.documentEpoch,
+      changeSeq: this.changeSeq,
+      page,
+      editable,
+      collapsed,
+      target,
+      selectedTextSha256,
+    };
+  }
+
+  async applyTextCommand(command: RhwpApplyTextCommandV1): Promise<RhwpTextCommandReceiptV1> {
+    this.syncGeneration();
+    const binding = commandBinding(command);
+    const replay = this.journal.get(command.commandId);
+    if (replay) {
+      if (replay.status === 'applied'
+          && replay.applyBindingSha256 === binding
+          && this.isCurrentReceiptState(
+            replay.applyReceipt,
+            replay.afterTarget,
+            replay.applyReceipt.afterTextSha256,
+          )) {
+        return replay.applyReceipt;
+      }
+      throw new DocumentAgentError(
+        'COMMAND_REPLAY_MISMATCH',
+        '같은 commandId가 다른 binding 또는 terminal 상태로 이미 사용되었습니다.',
+      );
+    }
+
+    const startedAt = this.now();
+    const state = this.getDocumentState();
+    this.assertApplyFence(command, state);
+    const beforeEvidence = collectTargetEvidence(this.deps.wasm, command.target);
+    if (beforeEvidence.textSha256 !== command.expectedBeforeSha256) {
+      throw new DocumentAgentError('TARGET_PREIMAGE_MISMATCH', 'target before SHA가 다릅니다.');
+    }
+    if (beforeEvidence.formatSha256 !== command.expectedFormatSha256) {
+      throw new DocumentAgentError('TARGET_FORMAT_MISMATCH', 'target format SHA가 다릅니다.');
+    }
+    if (beforeEvidence.adjacentContextSha256 !== command.expectedAdjacentContextSha256) {
+      throw new DocumentAgentError('TARGET_CONTEXT_MISMATCH', 'target adjacent context SHA가 다릅니다.');
+    }
+    const beforeNonTarget = nonTargetManifestSha256(this.deps.wasm, command.target);
+    this.assertWithinBudget(startedAt);
+
+    const afterTarget: RhwpBodyParagraphTargetV1 = {
+      ...command.target,
+      length: codePointLength(command.replacement),
+    };
+    let afterEvidence!: TargetEvidence;
+    let afterDocumentSha256 = '';
+    const beforeSeq = this.changeSeq;
+
+    try {
+      await this.deps.input.executeDocumentAgentOperation({
+        kind: 'snapshot',
+        operationType: 'document-agent:apply',
+        operation: (wasm) => {
+          this.assertRuntimeFence(command.expectedDocumentEpoch, beforeSeq);
+          let deferred = false;
+          try {
+            wasm.beginDeferredPagination?.();
+            deferred = true;
+            const result = wasm.replaceText(
+              command.target.section,
+              command.target.paragraph,
+              0,
+              command.target.length,
+              command.replacement,
+            );
+            if (!result.ok || result.newLength !== afterTarget.length) {
+              throw new DocumentAgentError('TRANSACTION_FAILED', 'replaceText가 target을 교체하지 못했습니다.');
+            }
+            if (afterTarget.length > 0) {
+              wasm.setCharShapeId(
+                command.target.section,
+                command.target.paragraph,
+                0,
+                afterTarget.length,
+                beforeEvidence.charShapeId,
+              );
+            }
+            wasm.setParaShapeId(
+              command.target.section,
+              command.target.paragraph,
+              beforeEvidence.paraShapeId,
+            );
+            wasm.flushDeferredPagination?.();
+            deferred = false;
+
+            afterEvidence = collectTargetEvidence(wasm, afterTarget);
+            if (afterEvidence.text !== command.replacement) {
+              throw new DocumentAgentError('TARGET_PREIMAGE_MISMATCH', 'target postimage가 replacement와 다릅니다.');
+            }
+            if (afterEvidence.formatSha256 !== beforeEvidence.formatSha256) {
+              throw new DocumentAgentError('TARGET_FORMAT_MISMATCH', 'target format이 변경되었습니다.');
+            }
+            if (afterEvidence.adjacentContextSha256 !== beforeEvidence.adjacentContextSha256) {
+              throw new DocumentAgentError('TARGET_CONTEXT_MISMATCH', 'adjacent context가 변경되었습니다.');
+            }
+            if (nonTargetManifestSha256(wasm, afterTarget) !== beforeNonTarget) {
+              throw new DocumentAgentError('NON_TARGET_CHANGED', 'target 밖 semantic manifest가 변경되었습니다.');
+            }
+            if (wasm.pageCount !== state.pageCount) {
+              throw new DocumentAgentError('PAGE_COUNT_CHANGED', '문서 페이지 수가 변경되었습니다.');
+            }
+            afterDocumentSha256 = exportDocumentSha256(wasm, state.format);
+            this.assertWithinBudget(startedAt);
+            return {
+              sectionIndex: afterTarget.section,
+              paragraphIndex: afterTarget.paragraph,
+              charOffset: afterTarget.length,
+            };
+          } catch (error) {
+            if (deferred) {
+              try { wasm.cancelDeferredPagination?.(); } catch { /* snapshot rollback이 최종 복구한다. */ }
+            }
+            throw error;
+          }
+        },
+        meta: {
+          actionId: 'document-agent:apply',
+          domain: 'text',
+          refresh: 'full',
+          dirtyScope: 'paragraph',
+          selection: 'moveToResult',
+        },
+      }, async () => {
+        await this.deps.render();
+        this.assertWithinBudget(startedAt);
+      });
+    } catch (error) {
+      throw this.normalizeExecutionError(error);
+    }
+
+    if (this.changeSeq !== beforeSeq + 1) {
+      throw new DocumentAgentError(
+        'TRANSACTION_FAILED',
+        'changeSeq가 정확히 1 증가하지 않았습니다.',
+        false,
+      );
+    }
+    const receipt: RhwpTextCommandReceiptV1 = {
+      schemaVersion: 1,
+      commandId: command.commandId,
+      operation: 'apply',
+      documentEpoch: this.documentEpoch,
+      beforeChangeSeq: beforeSeq,
+      afterChangeSeq: this.changeSeq,
+      beforeDocumentSha256: state.documentSha256,
+      afterDocumentSha256,
+      beforeTextSha256: beforeEvidence.textSha256,
+      afterTextSha256: afterEvidence.textSha256,
+      formatSha256: afterEvidence.formatSha256,
+      adjacentContextSha256: afterEvidence.adjacentContextSha256,
+      pageCountBefore: state.pageCount,
+      pageCountAfter: this.deps.wasm.pageCount,
+      target: command.target,
+    };
+    const entry: AgentJournalEntry = {
+      command: structuredClone(command),
+      applyBindingSha256: binding,
+      applyReceipt: receipt,
+      beforeText: beforeEvidence.text,
+      beforeTarget: command.target,
+      afterTarget,
+      beforeEvidence,
+      afterEvidence,
+      nonTargetManifestSha256: beforeNonTarget,
+      status: 'applied',
+    };
+    this.journal.set(command.commandId, entry);
+    this.latest = entry;
+    this.emitDocumentAgentChanged({
+      schemaVersion: 1,
+      reason: 'agent_apply',
+      documentEpoch: this.documentEpoch,
+      changeSeq: this.changeSeq,
+      commandId: command.commandId,
+    });
+    return receipt;
+  }
+
+  async revertTextCommand(command: RhwpRevertTextCommandV1): Promise<RhwpTextCommandReceiptV1> {
+    this.syncGeneration();
+    const binding = revertBinding(command);
+    const entry = this.journal.get(command.commandId);
+    if (entry?.status === 'reverted') {
+      if (entry.revertBindingSha256 === binding
+          && entry.revertReceipt
+          && this.isCurrentReceiptState(
+            entry.revertReceipt,
+            entry.beforeTarget,
+            entry.revertReceipt.afterTextSha256,
+          )) return entry.revertReceipt;
+      throw new DocumentAgentError(
+        'COMMAND_REPLAY_MISMATCH',
+        'revert command binding 또는 현재 terminal receipt 상태가 다릅니다.',
+      );
+    }
+    if (!entry || this.latest !== entry || entry.status !== 'applied'
+        || this.changeSeq !== entry.applyReceipt.afterChangeSeq) {
+      throw new DocumentAgentError('COMMAND_NOT_LATEST', '가장 최근 exact command만 되돌릴 수 있습니다.');
+    }
+
+    const startedAt = this.now();
+    const state = this.getDocumentState();
+    if (command.expectedDocumentEpoch !== state.documentEpoch) {
+      throw new DocumentAgentError('DOCUMENT_EPOCH_MISMATCH', 'document epoch가 다릅니다.');
+    }
+    if (command.expectedChangeSeq !== state.changeSeq) {
+      throw new DocumentAgentError('CHANGE_SEQ_MISMATCH', 'changeSeq가 다릅니다.');
+    }
+    if (command.expectedAfterDocumentSha256 !== state.documentSha256) {
+      throw new DocumentAgentError('DOCUMENT_SHA_MISMATCH', 'after document SHA가 다릅니다.');
+    }
+    const currentEvidence = collectTargetEvidence(this.deps.wasm, entry.afterTarget);
+    if (currentEvidence.textSha256 !== command.expectedAfterSha256
+        || currentEvidence.textSha256 !== entry.applyReceipt.afterTextSha256) {
+      throw new DocumentAgentError('TARGET_PREIMAGE_MISMATCH', 'revert target after SHA가 다릅니다.');
+    }
+    if (nonTargetManifestSha256(this.deps.wasm, entry.afterTarget)
+        !== entry.nonTargetManifestSha256) {
+      throw new DocumentAgentError('COMMAND_NOT_LATEST', 'target 밖 변경이 있어 되돌릴 수 없습니다.');
+    }
+    this.assertWithinBudget(startedAt);
+
+    let afterDocumentSha256 = '';
+    let revertedEvidence!: TargetEvidence;
+    const beforeSeq = this.changeSeq;
+    try {
+      await this.deps.input.executeDocumentAgentOperation({
+        kind: 'snapshot',
+        operationType: 'document-agent:revert',
+        operation: (wasm) => {
+          this.assertRuntimeFence(command.expectedDocumentEpoch, beforeSeq);
+          let deferred = false;
+          try {
+            wasm.beginDeferredPagination?.();
+            deferred = true;
+            const result = wasm.replaceText(
+              entry.afterTarget.section,
+              entry.afterTarget.paragraph,
+              0,
+              entry.afterTarget.length,
+              entry.beforeText,
+            );
+            if (!result.ok || result.newLength !== entry.beforeTarget.length) {
+              throw new DocumentAgentError('TRANSACTION_FAILED', 'inverse replaceText가 실패했습니다.');
+            }
+            if (entry.beforeTarget.length > 0) {
+              wasm.setCharShapeId(
+                entry.beforeTarget.section,
+                entry.beforeTarget.paragraph,
+                0,
+                entry.beforeTarget.length,
+                entry.beforeEvidence.charShapeId,
+              );
+            }
+            wasm.setParaShapeId(
+              entry.beforeTarget.section,
+              entry.beforeTarget.paragraph,
+              entry.beforeEvidence.paraShapeId,
+            );
+            wasm.flushDeferredPagination?.();
+            deferred = false;
+
+            revertedEvidence = collectTargetEvidence(wasm, entry.beforeTarget);
+            if (revertedEvidence.textSha256 !== entry.beforeEvidence.textSha256) {
+              throw new DocumentAgentError('TARGET_PREIMAGE_MISMATCH', 'before target 복원이 일치하지 않습니다.');
+            }
+            if (revertedEvidence.formatSha256 !== entry.beforeEvidence.formatSha256) {
+              throw new DocumentAgentError('TARGET_FORMAT_MISMATCH', 'before format 복원이 일치하지 않습니다.');
+            }
+            if (revertedEvidence.adjacentContextSha256
+                !== entry.beforeEvidence.adjacentContextSha256) {
+              throw new DocumentAgentError('TARGET_CONTEXT_MISMATCH', 'before context 복원이 일치하지 않습니다.');
+            }
+            if (nonTargetManifestSha256(wasm, entry.beforeTarget)
+                !== entry.nonTargetManifestSha256) {
+              throw new DocumentAgentError('NON_TARGET_CHANGED', 'revert가 target 밖을 변경했습니다.');
+            }
+            if (wasm.pageCount !== entry.applyReceipt.pageCountBefore) {
+              throw new DocumentAgentError('PAGE_COUNT_CHANGED', 'revert 뒤 페이지 수가 다릅니다.');
+            }
+            afterDocumentSha256 = exportDocumentSha256(wasm, state.format);
+            this.assertWithinBudget(startedAt);
+            return {
+              sectionIndex: entry.beforeTarget.section,
+              paragraphIndex: entry.beforeTarget.paragraph,
+              charOffset: entry.beforeTarget.length,
+            };
+          } catch (error) {
+            if (deferred) {
+              try { wasm.cancelDeferredPagination?.(); } catch { /* snapshot rollback이 최종 복구한다. */ }
+            }
+            throw error;
+          }
+        },
+        meta: {
+          actionId: 'document-agent:revert',
+          domain: 'text',
+          refresh: 'full',
+          dirtyScope: 'paragraph',
+          selection: 'moveToResult',
+        },
+      }, async () => {
+        await this.deps.render();
+        this.assertWithinBudget(startedAt);
+      });
+    } catch (error) {
+      throw this.normalizeExecutionError(error);
+    }
+
+    if (this.changeSeq !== beforeSeq + 1) {
+      throw new DocumentAgentError(
+        'TRANSACTION_FAILED',
+        'revert changeSeq가 정확히 1 증가하지 않았습니다.',
+        false,
+      );
+    }
+    const receipt: RhwpTextCommandReceiptV1 = {
+      schemaVersion: 1,
+      commandId: command.commandId,
+      operation: 'revert',
+      documentEpoch: this.documentEpoch,
+      beforeChangeSeq: beforeSeq,
+      afterChangeSeq: this.changeSeq,
+      beforeDocumentSha256: state.documentSha256,
+      afterDocumentSha256,
+      beforeTextSha256: currentEvidence.textSha256,
+      afterTextSha256: revertedEvidence.textSha256,
+      formatSha256: revertedEvidence.formatSha256,
+      adjacentContextSha256: revertedEvidence.adjacentContextSha256,
+      pageCountBefore: state.pageCount,
+      pageCountAfter: this.deps.wasm.pageCount,
+      target: entry.beforeTarget,
+    };
+    entry.status = 'reverted';
+    entry.revertBindingSha256 = binding;
+    entry.revertReceipt = receipt;
+    this.emitDocumentAgentChanged({
+      schemaVersion: 1,
+      reason: 'agent_revert',
+      documentEpoch: this.documentEpoch,
+      changeSeq: this.changeSeq,
+      commandId: command.commandId,
+    });
+    return receipt;
+  }
+
+  focusTarget(target: RhwpBodyParagraphTargetV1): { focused: boolean; page: number } {
+    this.syncGeneration();
+    assertTargetCoordinates(this.deps.wasm, target);
+    const page = this.pageFor(target.section, target.paragraph);
+    return {
+      focused: this.deps.input.focusBodyParagraph(target.section, target.paragraph, target.length),
+      page,
+    };
+  }
+
+  private currentFormat(): 'hwp' | 'hwpx' {
+    const format = this.deps.wasm.getSourceFormat();
+    if (format !== 'hwp' && format !== 'hwpx') {
+      throw new DocumentAgentError(
+        'CAPABILITY_UNSUPPORTED',
+        `document agent는 HWP/HWPX만 지원합니다: ${format}`,
+      );
+    }
+    return format;
+  }
+
+  private pageFor(section: number, paragraph: number): number {
+    const result = this.deps.wasm.getPageOfPosition(section, paragraph);
+    if (!result.ok || !Number.isSafeInteger(result.page) || (result.page as number) < 0) {
+      return 1;
+    }
+    return (result.page as number) + 1;
+  }
+
+  private assertApplyFence(command: RhwpApplyTextCommandV1, state: RhwpDocumentStateV1): void {
+    if (command.expectedDocumentEpoch !== state.documentEpoch) {
+      throw new DocumentAgentError('DOCUMENT_EPOCH_MISMATCH', 'document epoch가 다릅니다.');
+    }
+    if (command.expectedChangeSeq !== state.changeSeq) {
+      throw new DocumentAgentError('CHANGE_SEQ_MISMATCH', 'changeSeq가 다릅니다.');
+    }
+    if (command.expectedDocumentSha256 !== state.documentSha256) {
+      throw new DocumentAgentError('DOCUMENT_SHA_MISMATCH', 'document SHA가 다릅니다.');
+    }
+  }
+
+  private assertRuntimeFence(expectedEpoch: number, expectedSeq: number): void {
+    this.syncGeneration();
+    if (this.documentEpoch !== expectedEpoch) {
+      throw new DocumentAgentError('DOCUMENT_EPOCH_MISMATCH', 'transaction 직전 epoch가 바뀌었습니다.');
+    }
+    if (this.changeSeq !== expectedSeq) {
+      throw new DocumentAgentError('CHANGE_SEQ_MISMATCH', 'transaction 직전 changeSeq가 바뀌었습니다.');
+    }
+  }
+
+  private assertWithinBudget(startedAt: number): void {
+    if (this.now() - startedAt > COMMAND_BUDGET_MS) {
+      throw new DocumentAgentError('COMMAND_TOO_SLOW', '문서 명령이 3초 상한을 넘었습니다.');
+    }
+  }
+
+  private syncGeneration(): void {
+    const generation = this.deps.wasm.documentGeneration;
+    if (generation === this.documentEpoch) return;
+    this.documentEpoch = generation;
+    this.changeSeq = 0;
+    this.latest = null;
+    this.journal.clear();
+  }
+
+  private normalizeExecutionError(error: unknown): DocumentAgentError {
+    if (isDocumentAgentError(error)) {
+      if (error.code === 'TRANSACTION_FAILED' && error.recovered === undefined) {
+        return new DocumentAgentError(error.code, error.message, true);
+      }
+      return error;
+    }
+    const executionError = error as {
+      code?: unknown;
+      recovered?: unknown;
+      cause?: unknown;
+      message?: unknown;
+    };
+    const nestedCause = executionError.cause as { code?: unknown; message?: unknown } | undefined;
+    if (executionError.code === 'RENDER_FAILED'
+        && typeof executionError.recovered === 'boolean') {
+      if (nestedCause?.code === 'COMMAND_TOO_SLOW') {
+        return new DocumentAgentError(
+          'COMMAND_TOO_SLOW',
+          typeof nestedCause.message === 'string' ? nestedCause.message : 'command time budget을 초과했습니다.',
+          executionError.recovered,
+        );
+      }
+      return new DocumentAgentError(
+        'RENDER_FAILED',
+        typeof executionError.message === 'string' ? executionError.message : 'render commit이 실패했습니다.',
+        executionError.recovered,
+      );
+    }
+    return new DocumentAgentError(
+      'TRANSACTION_FAILED',
+      error instanceof Error ? error.message : String(error),
+      !(error instanceof AggregateError),
+    );
+  }
+
+  private isCurrentReceiptState(
+    receipt: RhwpTextCommandReceiptV1,
+    target: RhwpBodyParagraphTargetV1,
+    expectedTextSha256: string,
+  ): boolean {
+    try {
+      const state = this.getDocumentState();
+      if (state.documentEpoch !== receipt.documentEpoch
+          || state.changeSeq !== receipt.afterChangeSeq
+          || state.documentSha256 !== receipt.afterDocumentSha256) return false;
+      return collectTargetEvidence(this.deps.wasm, target).textSha256 === expectedTextSha256;
+    } catch {
+      return false;
+    }
+  }
+
+  private emitDocumentAgentChanged(event: {
+    schemaVersion: 1;
+    reason: 'agent_apply' | 'agent_revert';
+    documentEpoch: number;
+    changeSeq: number;
+    commandId: string;
+  }): void {
+    try {
+      this.deps.eventBus.emit('document-agent-changed', event);
+    } catch (error) {
+      // transaction과 journal은 이미 commit됐다. 관측자 한 곳의 실패로 RPC 성공을 뒤집지 않는다.
+      console.error('[DocumentAgentController] documentChanged observer 실패:', error);
+    }
+  }
+}

--- a/rhwp-studio/src/document-agent/types.ts
+++ b/rhwp-studio/src/document-agent/types.ts
@@ -1,0 +1,107 @@
+export interface RhwpBodyParagraphTargetV1 {
+  kind: 'body_paragraph';
+  section: number;
+  paragraph: number;
+  charOffset: 0;
+  length: number;
+}
+
+export interface RhwpDocumentStateV1 {
+  schemaVersion: 1;
+  format: 'hwp' | 'hwpx';
+  documentEpoch: number;
+  changeSeq: number;
+  dirty: boolean;
+  pageCount: number;
+  documentSha256: string;
+}
+
+export interface RhwpSelectionContextV1 {
+  schemaVersion: 1;
+  documentEpoch: number;
+  changeSeq: number;
+  page: number;
+  editable: boolean;
+  collapsed: boolean;
+  target: RhwpBodyParagraphTargetV1 | null;
+  selectedTextSha256: string | null;
+}
+
+export interface RhwpApplyTextCommandV1 {
+  schemaVersion: 1;
+  commandId: string;
+  expectedDocumentEpoch: number;
+  expectedChangeSeq: number;
+  expectedDocumentSha256: string;
+  target: RhwpBodyParagraphTargetV1;
+  expectedBeforeSha256: string;
+  expectedFormatSha256: string;
+  expectedAdjacentContextSha256: string;
+  replacement: string;
+}
+
+export interface RhwpRevertTextCommandV1 {
+  schemaVersion: 1;
+  commandId: string;
+  expectedDocumentEpoch: number;
+  expectedChangeSeq: number;
+  expectedAfterDocumentSha256: string;
+  expectedAfterSha256: string;
+}
+
+export interface RhwpTextCommandReceiptV1 {
+  schemaVersion: 1;
+  commandId: string;
+  operation: 'apply' | 'revert';
+  documentEpoch: number;
+  beforeChangeSeq: number;
+  afterChangeSeq: number;
+  beforeDocumentSha256: string;
+  afterDocumentSha256: string;
+  beforeTextSha256: string;
+  afterTextSha256: string;
+  formatSha256: string;
+  adjacentContextSha256: string;
+  pageCountBefore: number;
+  pageCountAfter: number;
+  target: RhwpBodyParagraphTargetV1;
+}
+
+export const DOCUMENT_AGENT_ERROR_CODES = [
+  'CAPABILITY_UNSUPPORTED',
+  'INVALID_COMMAND',
+  'DOCUMENT_EPOCH_MISMATCH',
+  'CHANGE_SEQ_MISMATCH',
+  'DOCUMENT_SHA_MISMATCH',
+  'TARGET_NOT_FOUND',
+  'TARGET_PREIMAGE_MISMATCH',
+  'TARGET_FORMAT_MISMATCH',
+  'TARGET_CONTEXT_MISMATCH',
+  'PAGE_COUNT_CHANGED',
+  'NON_TARGET_CHANGED',
+  'COMMAND_NOT_LATEST',
+  'COMMAND_REPLAY_MISMATCH',
+  'COMMAND_TOO_SLOW',
+  'TRANSACTION_FAILED',
+  'RENDER_FAILED',
+] as const;
+
+export type DocumentAgentErrorCode = typeof DOCUMENT_AGENT_ERROR_CODES[number];
+
+export class DocumentAgentError extends Error {
+  readonly code: DocumentAgentErrorCode;
+  readonly recovered?: boolean;
+
+  constructor(code: DocumentAgentErrorCode, message: string, recovered?: boolean) {
+    super(message);
+    this.name = 'DocumentAgentError';
+    this.code = code;
+    if (recovered !== undefined) this.recovered = recovered;
+  }
+}
+
+export function isDocumentAgentError(value: unknown): value is DocumentAgentError {
+  return value instanceof Error && DOCUMENT_AGENT_ERROR_CODES.includes(
+    (value as { code?: DocumentAgentErrorCode }).code as DocumentAgentErrorCode,
+  );
+}

--- a/rhwp-studio/src/embed/protocol.ts
+++ b/rhwp-studio/src/embed/protocol.ts
@@ -11,6 +11,11 @@ export const EMBED_CAPABILITIES = [
   'plugin-loader-v1',
   'hwpctrl-v1',
   'chrome-v1',
+  'document-state-v1',
+  'selection-context-v1',
+  'document-agent-command-v1',
+  'target-navigation-v1',
+  'document-change-events-v1',
 ] as const;
 
 export interface EmbedConnectAttempt {
@@ -58,6 +63,7 @@ export interface EmbedProtocolError {
   code: string;
   message: string;
   supportedVersions?: number[];
+  recovered?: boolean;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/rhwp-studio/src/embed/rpc-router.ts
+++ b/rhwp-studio/src/embed/rpc-router.ts
@@ -1,5 +1,20 @@
 import type { HmlSaveState } from '../core/hml-save-capability.ts';
 import type { EmbedFontDecisionTraceV1 } from '../core/font-decision-trace.ts';
+import {
+  assertEmptyParams,
+  assertOnlyParam,
+  parseApplyTextCommand,
+  parseBodyParagraphTarget,
+  parseRevertTextCommand,
+} from '../document-agent/contract.ts';
+import type {
+  RhwpApplyTextCommandV1,
+  RhwpBodyParagraphTargetV1,
+  RhwpDocumentStateV1,
+  RhwpRevertTextCommandV1,
+  RhwpSelectionContextV1,
+  RhwpTextCommandReceiptV1,
+} from '../document-agent/types.ts';
 import type {
   CanvasKitRenderModeRequest,
   CanvasKitSurfaceRequest,
@@ -31,6 +46,11 @@ export interface EmbedRpcHandlers {
   getHmlSaveState(): Promise<HmlSaveState>;
   exportHwpVerify(): Promise<unknown>;
   notifySaved(fileName?: string): Promise<EmbedNotifySavedResult>;
+  getDocumentState(): Promise<RhwpDocumentStateV1>;
+  getSelectionContext(): Promise<RhwpSelectionContextV1>;
+  applyTextCommand(command: RhwpApplyTextCommandV1): Promise<RhwpTextCommandReceiptV1>;
+  revertTextCommand(command: RhwpRevertTextCommandV1): Promise<RhwpTextCommandReceiptV1>;
+  focusTarget(target: RhwpBodyParagraphTargetV1): Promise<{ focused: boolean; page: number }>;
 
   // ── 브리지 확장 (P4) ────────────────────────────────────
   // 자동화·플러그인·창 제어. 부모는 **구조화 복제 가능한 값만** 보낼 수 있으므로 함수를 받는
@@ -150,6 +170,21 @@ export async function routeEmbedRequest(
         ? params.fileName
         : undefined,
     );
+    case 'getDocumentState':
+      assertEmptyParams(params, 'getDocumentState params');
+      return handlers.getDocumentState();
+    case 'getSelectionContext':
+      assertEmptyParams(params, 'getSelectionContext params');
+      return handlers.getSelectionContext();
+    case 'applyTextCommand': return handlers.applyTextCommand(parseApplyTextCommand(
+      assertOnlyParam(params, 'command', 'applyTextCommand params'),
+    ));
+    case 'revertTextCommand': return handlers.revertTextCommand(parseRevertTextCommand(
+      assertOnlyParam(params, 'command', 'revertTextCommand params'),
+    ));
+    case 'focusTarget': return handlers.focusTarget(parseBodyParagraphTarget(
+      assertOnlyParam(params, 'target', 'focusTarget params'),
+    ));
     // ── 브리지 확장 (P4) ──────────────────────────────────
     case 'automation.list': return handlers.automationList();
     case 'automation.menuModel': return handlers.automationMenuModel();

--- a/rhwp-studio/src/embed/runtime.ts
+++ b/rhwp-studio/src/embed/runtime.ts
@@ -9,11 +9,13 @@ import {
   type EmbedResponseEnvelope,
 } from './protocol.ts';
 import { routeEmbedRequest, type EmbedRpcHandlers } from './rpc-router.ts';
+import { isDocumentAgentError } from '../document-agent/types.ts';
 
 interface EmbedRuntimeOptions {
   hostWindow: Window;
   parentWindow: Window;
   handlers: EmbedRpcHandlers;
+  subscribeDocumentChanged?: (listener: (payload: unknown) => void) => () => void;
 }
 
 function errorText(error: unknown): string {
@@ -39,7 +41,13 @@ function releasePorts(ports: readonly MessagePort[]): void {
   for (const port of ports) releasePort(port);
 }
 
-function bindPort(port: MessagePort, sessionId: string, handlers: EmbedRpcHandlers): void {
+function bindPort(
+  port: MessagePort,
+  sessionId: string,
+  clientCapabilities: readonly string[],
+  handlers: EmbedRpcHandlers,
+  subscribeDocumentChanged?: (listener: (payload: unknown) => void) => () => void,
+): () => void {
   port.onmessage = async ({ data }) => {
     if (!isRequestAttempt(data, sessionId)) return;
     const response: EmbedResponseEnvelope = {
@@ -58,10 +66,32 @@ function bindPort(port: MessagePort, sessionId: string, handlers: EmbedRpcHandle
       postPortResponse(port, response);
       return;
     }
+    const requiredCapability = {
+      getDocumentState: 'document-state-v1',
+      getSelectionContext: 'selection-context-v1',
+      applyTextCommand: 'document-agent-command-v1',
+      revertTextCommand: 'document-agent-command-v1',
+      focusTarget: 'target-navigation-v1',
+    }[data.method];
+    if (requiredCapability && !clientCapabilities.includes(requiredCapability)) {
+      response.error = {
+        code: 'UNSUPPORTED_CAPABILITY',
+        message: `${requiredCapability} was not negotiated by the client.`,
+      };
+      postPortResponse(port, response);
+      return;
+    }
     try {
       response.result = await routeEmbedRequest(data.method, data.params, handlers);
     } catch (error) {
-      response.error = { code: 'RPC_ERROR', message: errorText(error) };
+      const documentAgentError = isDocumentAgentError(error) ? error : null;
+      response.error = {
+        code: documentAgentError?.code ?? 'RPC_ERROR',
+        message: errorText(error),
+        ...(typeof documentAgentError?.recovered === 'boolean'
+          ? { recovered: documentAgentError.recovered }
+          : {}),
+      };
     }
     postPortResponse(port, response);
   };
@@ -70,6 +100,15 @@ function bindPort(port: MessagePort, sessionId: string, handlers: EmbedRpcHandle
     type: 'rhwp-connected', version: EMBED_PROTOCOL_VERSION, sessionId,
     capabilities: EMBED_CAPABILITIES,
   });
+  return subscribeDocumentChanged?.((payload) => {
+    port.postMessage({
+      type: 'rhwp-event',
+      version: EMBED_PROTOCOL_VERSION,
+      sessionId,
+      event: 'documentChanged',
+      payload,
+    });
+  }) ?? (() => {});
 }
 
 function rejectConnect(port: MessagePort, attempt: { version: number; sessionId: string }): void {
@@ -102,6 +141,9 @@ async function handleLegacy(
   const params = isHwpctl ? message : message.params;
   const response: Record<string, unknown> = { type: 'rhwp-response', id: message.id };
   try {
+    if (method === 'applyTextCommand' || method === 'revertTextCommand') {
+      throw new Error('Legacy embed transport cannot execute document mutations.');
+    }
     const result = await routeEmbedRequest(method, params, handlers, true);
     response.result = result instanceof Uint8Array ? Array.from(result) : result;
   } catch (error) {
@@ -113,7 +155,12 @@ async function handleLegacy(
 export function installEmbedRuntime(options: EmbedRuntimeOptions): () => void {
   const ports = new Set<MessagePort>();
   const isTopLevelSameWindow = options.parentWindow === options.hostWindow;
-  let binding: { origin: string; sessionId: string; port: MessagePort } | null = null;
+  let binding: {
+    origin: string;
+    sessionId: string;
+    port: MessagePort;
+    offDocumentChanged: () => void;
+  } | null = null;
   const onMessage = (event: MessageEvent) => {
     const transferredPorts = Array.from(event.ports);
     const isTopLevelLegacyRequest = isTopLevelSameWindow
@@ -144,9 +191,17 @@ export function installEmbedRuntime(options: EmbedRuntimeOptions): () => void {
         releasePort(port);
         return;
       }
-      binding = { origin: event.origin, sessionId: event.data.sessionId, port };
       ports.add(port);
-      bindPort(port, event.data.sessionId, options.handlers);
+      const offDocumentChanged = bindPort(
+        port,
+        event.data.sessionId,
+        event.data.capabilities,
+        options.handlers,
+        event.data.capabilities.includes('document-change-events-v1')
+          ? options.subscribeDocumentChanged
+          : undefined,
+      );
+      binding = { origin: event.origin, sessionId: event.data.sessionId, port, offDocumentChanged };
       return;
     }
     if (binding) return;
@@ -155,6 +210,7 @@ export function installEmbedRuntime(options: EmbedRuntimeOptions): () => void {
   options.hostWindow.addEventListener('message', onMessage);
   return () => {
     options.hostWindow.removeEventListener('message', onMessage);
+    binding?.offDocumentChanged();
     for (const port of ports) releasePort(port);
     ports.clear();
     binding = null;

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -123,6 +123,25 @@ export class CommandHistory {
     return cursorAfter;
   }
 
+  /**
+   * 아직 외부 commit event를 내보내지 않은 최신 snapshot 실행만 폐기한다.
+   * document-agent의 strict render gate 실패 복구 전용이며 redo에는 남기지 않는다.
+   */
+  rollbackUncommittedSnapshot(
+    expectedType: string,
+    wasm: WasmBridge,
+  ): DocumentPosition | null {
+    this.lastExecutionEffects = NO_TEXT_MUTATION_EFFECTS;
+    const command = this.undoStack[this.undoStack.length - 1];
+    if (!command || command.type !== expectedType || command.snapshotResourceCount?.() !== 2) {
+      return null;
+    }
+    const cursorAfter = command.undo(wasm);
+    this.undoStack.pop();
+    command.discard?.(wasm);
+    return cursorAfter;
+  }
+
   /** Undo — 성공 시 커서 위치 반환, 스택 비었으면 null */
   undo(wasm: WasmBridge): DocumentPosition | null {
     this.lastExecutionEffects = NO_TEXT_MUTATION_EFFECTS;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -60,6 +60,21 @@ const DOCUMENT_PAGINATION_INITIAL_START_DELAY_MS = 100;
 const DOCUMENT_PAGINATION_RESTART_COALESCE_DELAY_MS = 200;
 // 첫 fragment 하나 뒤 다음 입력과 후속 step이 겹치지 않게 하는 짧은 settle gap.
 const DOCUMENT_PAGINATION_POST_FIRST_STEP_DELAY_MS = 25;
+
+export class DocumentAgentRenderCommitError extends Error {
+  readonly code = 'RENDER_FAILED';
+  readonly recovered: boolean;
+  override readonly cause: unknown;
+
+  constructor(cause: unknown, recovered: boolean) {
+    super(recovered
+      ? 'document-agent render 실패 후 snapshot을 복구했습니다.'
+      : 'document-agent render 실패 후 snapshot 복구도 실패했습니다.');
+    this.name = 'DocumentAgentRenderCommitError';
+    this.recovered = recovered;
+    this.cause = cause;
+  }
+}
 /**
  * [#3412] idle 자동 flush 대상 문서 크기 상한.
  *
@@ -2704,6 +2719,72 @@ export class InputHandler {
     }
   }
 
+  /**
+   * document-agent 전용 two-phase snapshot 경로.
+   *
+   * 기존 executeOperation은 history commit 직후 document event로 비동기 render를 예약한다.
+   * exact command는 host 응답 전에 실제 visible page render가 성공해야 하므로, snapshot을
+   * history에 올린 뒤 strict render를 먼저 기다리고 성공할 때만 mutation event를 commit한다.
+   */
+  async executeDocumentAgentOperation(
+    desc: Extract<OperationDescriptor, { kind: 'snapshot' }>,
+    render: () => Promise<void>,
+  ): Promise<void> {
+    if (!this.isOperationAllowedInEditMode(desc)) {
+      throw new Error('현재 편집 모드에서는 document-agent snapshot을 실행할 수 없습니다.');
+    }
+    const cursorBefore = this.cursor.getPosition();
+    const command = new SnapshotCommand(
+      desc.operationType,
+      cursorBefore,
+      cursorBefore,
+      desc.operation,
+    );
+    const newPos = this.history.execute(command, this.wasm);
+    if (command.isNoOp()) {
+      throw new Error('document-agent snapshot이 mutation 없이 종료되었습니다.');
+    }
+    this.cursor.moveTo(newPos);
+    this.cursor.resetPreferredX();
+    this.pendingFocusedPagePatch = null;
+    this.lastCellKey = null;
+    this.protectedCellHitCache = null;
+    this.clearTableResizeRuntimeCache();
+
+    try {
+      await render();
+      this.updateCaret();
+    } catch (renderError) {
+      try {
+        const restored = this.history.rollbackUncommittedSnapshot(command.type, this.wasm);
+        if (!restored) throw new Error('복구할 최신 snapshot을 찾을 수 없습니다.');
+        this.cursor.moveTo(restored);
+        this.cursor.resetPreferredX();
+        await render();
+        this.updateCaret();
+      } catch (rollbackError) {
+        throw new DocumentAgentRenderCommitError(
+          new AggregateError([renderError, rollbackError]),
+          false,
+        );
+      }
+      throw new DocumentAgentRenderCommitError(renderError, true);
+    }
+
+    // commit 통지는 strict render 뒤에만 낸다. EventBus는 모든 subscriber를 실행한 뒤 첫
+    // 예외를 되던지므로, 개별 observer 실패가 이미 성공한 문서 transaction을 뒤집지 않게 한다.
+    try {
+      this.eventBus.emit('document-mutated', 'document-agent');
+    } catch (error) {
+      console.error('[InputHandler] document-agent mutation observer 실패:', error);
+    }
+    try {
+      this.eventBus.emit('document-changed', 'document-agent-rendered');
+    } catch (error) {
+      console.error('[InputHandler] document-agent change observer 실패:', error);
+    }
+  }
+
   /** Backspace 처리 */
   private handleBackspace(pos: DocumentPosition, inCell: boolean): void {
     _text.handleBackspace.call(this, pos, inCell);
@@ -4037,6 +4118,45 @@ export class InputHandler {
     }
     this.focusTextarea();
     return false;
+  }
+
+  /**
+   * 문서 에이전트의 exact body paragraph target을 선택하고 해당 쪽을 뷰포트 중앙에 둔다.
+   * 문서를 바꾸지 않는 navigation 전용 경계이며 셀·각주·머리말 좌표는 받지 않는다.
+   */
+  focusBodyParagraph(section: number, paragraph: number, length: number): boolean {
+    if (!Number.isSafeInteger(section) || section < 0
+        || !Number.isSafeInteger(paragraph) || paragraph < 0
+        || !Number.isSafeInteger(length) || length < 0) return false;
+    try {
+      if (this.wasm.getParagraphLength(section, paragraph) !== length) return false;
+      this.wasm.getCursorRect(section, paragraph, 0);
+      this.wasm.getCursorRect(section, paragraph, length);
+
+      this.exitFootnoteModeForBodyNavigation();
+      this.cursor.clearSelection();
+      this.cursor.moveTo({ sectionIndex: section, paragraphIndex: paragraph, charOffset: 0 });
+      this.cursor.setAnchor();
+      this.cursor.moveTo({ sectionIndex: section, paragraphIndex: paragraph, charOffset: length });
+      this.cursor.resetPreferredX();
+      this.active = true;
+      this.updateCaret(true);
+      this.focusTextarea();
+
+      const rect = this.cursor.getRect();
+      if (rect) {
+        const zoom = this.viewportManager.getZoom();
+        const centerY = this.virtualScroll.getPageOffset(rect.pageIndex) + rect.y * zoom;
+        const maxScrollTop = Math.max(0, this.container.scrollHeight - this.container.clientHeight);
+        this.container.scrollTop = Math.max(
+          0,
+          Math.min(maxScrollTop, centerY - this.container.clientHeight / 2),
+        );
+      }
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /** 현재 커서 위치의 누름틀 필드와 내용을 제거한다. */

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -80,6 +80,7 @@ import { calculateFitPageZoom, calculateFitWidthZoom } from '@/view/zoom-fit';
 import { installEmbedRuntime } from '@/embed/runtime';
 import type { EmbedRendererRuntimeRequestV1 } from '@/embed/rpc-router';
 import { enrichFontDecisionTrace } from '@/core/font-decision-trace';
+import { DocumentAgentController } from '@/document-agent/controller';
 
 const wasm = new WasmBridge();
 const eventBus = new EventBus();
@@ -134,6 +135,7 @@ if (import.meta.env.DEV) {
 }
 let canvasView: CanvasView | null = null;
 let inputHandler: InputHandler | null = null;
+let documentAgent: DocumentAgentController | null = null;
 let toolbar: Toolbar | null = null;
 let ruler: Ruler | null = null;
 let rendererSession: RendererSession | null = null;
@@ -571,6 +573,14 @@ async function initialize(): Promise<void> {
       canvasView.getViewportManager(),
     );
     inputHandler.setEditMode(editMode);
+    documentAgent?.dispose();
+    documentAgent = new DocumentAgentController({
+      wasm,
+      input: inputHandler,
+      eventBus,
+      isDirty: () => documentState.isDirty(),
+      render: () => canvasView!.refreshDocumentAgentMutation(),
+    });
 
     // 눈금자 핀 드래그 커밋 — 종류(문단 서식/쪽 여백)에 따라 InputHandler 호출은 다르지만
     // 진입점은 하나다. 콜백 두 개로 나뉘어 있었을 때 한쪽만 executeOperation 커밋 경로를
@@ -1683,6 +1693,7 @@ const initPromise = initialize();
 installEmbedRuntime({
   hostWindow: window,
   parentWindow: window.parent,
+  subscribeDocumentChanged: (listener) => eventBus.on('document-agent-changed', listener),
   handlers: {
     async ready() {
       await initPromise;
@@ -1754,6 +1765,31 @@ installEmbedRuntime({
     async notifySaved(fileName) {
       await initPromise;
       return completeHostSave(fileName);
+    },
+    async getDocumentState() {
+      await initPromise;
+      if (!documentAgent) throw new Error('Document agent is not initialized');
+      return documentAgent.getDocumentState();
+    },
+    async getSelectionContext() {
+      await initPromise;
+      if (!documentAgent) throw new Error('Document agent is not initialized');
+      return documentAgent.getSelectionContext();
+    },
+    async applyTextCommand(command) {
+      await initPromise;
+      if (!documentAgent) throw new Error('Document agent is not initialized');
+      return documentAgent.applyTextCommand(command);
+    },
+    async revertTextCommand(command) {
+      await initPromise;
+      if (!documentAgent) throw new Error('Document agent is not initialized');
+      return documentAgent.revertTextCommand(command);
+    },
+    async focusTarget(target) {
+      await initPromise;
+      if (!documentAgent) throw new Error('Document agent is not initialized');
+      return documentAgent.focusTarget(target);
     },
 
     // ── 브리지 확장 (P4) — 자동화·플러그인·창 제어 ─────────

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -89,7 +89,10 @@ export class CanvasView {
       eventBus.on('document-page-invalidated', (payload) => {
         void this.refreshInvalidatedPageForMutation(payload);
       }),
-      eventBus.on('document-changed', () => {
+      eventBus.on('document-changed', (reason) => {
+        // document-agent는 host 응답 전 strict render를 이미 완료한다. 나머지 observer에는
+        // commit event를 전달하되 CanvasView만 같은 revision을 두 번 그리지 않는다.
+        if (reason === 'document-agent-rendered') return;
         void this.refreshPagesForMutation();
       }),
       eventBus.on('document-view-changed', () => {
@@ -181,6 +184,22 @@ export class CanvasView {
     const selected = await this.selectMutationRevision();
     if (!selected || !this.rendererSession.isCurrent(selected.selection)) return;
     this.refreshPages();
+  }
+
+  /** document-agent RPC 응답 전에 현재 visible page가 실제 canvas로 그려졌는지 확인한다. */
+  async refreshDocumentAgentMutation(): Promise<void> {
+    const selected = await this.selectMutationRevision();
+    if (!selected || !this.rendererSession.isCurrent(selected.selection)) {
+      throw new Error('document-agent renderer revision을 선택하지 못했습니다.');
+    }
+    this.refreshPages();
+    const scrollY = this.viewportManager.getScrollY();
+    const viewport = this.viewportManager.getViewportSize();
+    const visiblePages = this.virtualScroll.getVisiblePages(scrollY, viewport.height);
+    const failed = visiblePages.filter(pageIndex => !this.canvasPool.has(pageIndex));
+    if (visiblePages.length === 0 || failed.length > 0) {
+      throw new Error(`document-agent visible page render 실패: ${failed.join(',') || 'none'}`);
+    }
   }
 
   private async refreshInvalidatedPageForMutation(payload: unknown): Promise<void> {

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -150,3 +150,18 @@ test('SnapshotCommand 는 점유 스냅샷 id 수를 보고한다(예산 계산�
   const block = methodBlock(command, 'snapshotResourceCount(): number {');
   assert.match(block, /beforeId !== null[\s\S]*afterId !== null/, 'before/after 살아있는 id 수 반환');
 });
+
+test('document-agent 미commit rollback은 exact 최신 snapshot만 폐기하고 redo에 남기지 않는다', () => {
+  const block = methodBlock(
+    history,
+    'rollbackUncommittedSnapshot(',
+  );
+  assert.match(block, /command\.type !== expectedType/, '다른 최신 명령을 되돌리면 안 됨');
+  assert.match(block, /snapshotResourceCount\?\.\(\) !== 2/, '완성된 before\/after snapshot만 대상');
+  const undoAt = block.indexOf('command.undo(wasm)');
+  const popAt = block.indexOf('this.undoStack.pop()');
+  const discardAt = block.indexOf('command.discard?.(wasm)');
+  assert.ok(undoAt !== -1 && undoAt < popAt && popAt < discardAt,
+    'restore → undo stack 제거 → snapshot 폐기 순서여야 함');
+  assert.doesNotMatch(block, /redoStack\.push/, '실패한 미commit 명령은 redo에 남기면 안 됨');
+});

--- a/rhwp-studio/tests/document-agent-controller.test.ts
+++ b/rhwp-studio/tests/document-agent-controller.test.ts
@@ -1,0 +1,416 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { EventBus } from '../src/core/event-bus.ts';
+import {
+  DocumentAgentController,
+  collectTargetEvidence,
+  type DocumentAgentWasm,
+  type DocumentAgentInput,
+} from '../src/document-agent/controller.ts';
+import type {
+  RhwpApplyTextCommandV1,
+  RhwpBodyParagraphTargetV1,
+} from '../src/document-agent/types.ts';
+
+type Paragraph = {
+  text: string;
+  paraShapeId: number;
+  styleId: number;
+  charShapeIds: number[];
+  controls: number[];
+  fields: Array<[number, number]>;
+};
+
+const encoder = new TextEncoder();
+
+class FakeWasm implements DocumentAgentWasm {
+  documentGeneration = 1;
+  pageCount = 2;
+  sourceFormat = 'hwp';
+  paragraphs: Paragraph[][] = [[
+    paragraph('앞 문단'),
+    paragraph('기존 문단'),
+    paragraph('뒤 문단'),
+  ]];
+  replacementPageCount: number | null = null;
+
+  getSourceFormat() { return this.sourceFormat; }
+  getSectionCount() { return this.paragraphs.length; }
+  getParagraphCount(section: number) { return this.paragraphs[section]?.length ?? 0; }
+  getParagraphLength(section: number, paragraphIndex: number) {
+    return Array.from(this.paragraphs[section][paragraphIndex].text).length;
+  }
+  getTextRange(section: number, paragraphIndex: number, offset: number, count: number) {
+    return Array.from(this.paragraphs[section][paragraphIndex].text)
+      .slice(offset, offset + count)
+      .join('');
+  }
+  getControlTextPositions(section: number, paragraphIndex: number) {
+    return [...this.paragraphs[section][paragraphIndex].controls];
+  }
+  getCharPropertiesAt(section: number, paragraphIndex: number, offset: number) {
+    const para = this.paragraphs[section][paragraphIndex];
+    return { charShapeId: para.charShapeIds[Math.min(offset, para.charShapeIds.length - 1)] ?? 1 };
+  }
+  getParaPropertiesAt(section: number, paragraphIndex: number) {
+    return { paraShapeId: this.paragraphs[section][paragraphIndex].paraShapeId };
+  }
+  getStyleAt(section: number, paragraphIndex: number) {
+    return { id: this.paragraphs[section][paragraphIndex].styleId, name: '본문' };
+  }
+  getFieldInfoAt(pos: { sectionIndex: number; paragraphIndex: number; charOffset: number }) {
+    const fields = this.paragraphs[pos.sectionIndex][pos.paragraphIndex].fields;
+    const field = fields.find(([start, end]) => pos.charOffset >= start && pos.charOffset <= end);
+    return field
+      ? { inField: true, startCharIdx: field[0], endCharIdx: field[1] }
+      : { inField: false };
+  }
+  replaceText(section: number, paragraphIndex: number, offset: number, length: number, text: string) {
+    const para = this.paragraphs[section][paragraphIndex];
+    if (offset !== 0 || length !== Array.from(para.text).length) return { ok: false };
+    para.text = text;
+    const newLength = Array.from(text).length;
+    para.charShapeIds = Array(Math.max(newLength, 1)).fill(para.charShapeIds[0] ?? 1);
+    if (this.replacementPageCount !== null) this.pageCount = this.replacementPageCount;
+    return { ok: true, charOffset: 0, newLength };
+  }
+  setCharShapeId(section: number, paragraphIndex: number, start: number, end: number, id: number) {
+    const para = this.paragraphs[section][paragraphIndex];
+    for (let index = start; index < end; index += 1) para.charShapeIds[index] = id;
+    return '{}';
+  }
+  setParaShapeId(section: number, paragraphIndex: number, id: number) {
+    this.paragraphs[section][paragraphIndex].paraShapeId = id;
+    return '{}';
+  }
+  getPageOfPosition() { return { ok: true, page: 1 }; }
+  borrowDocumentHandle() {
+    return {
+      exportHwp: () => encoder.encode(JSON.stringify({
+        paragraphs: this.paragraphs,
+        pageCount: this.pageCount,
+      })),
+      exportHwpx: () => encoder.encode(JSON.stringify({
+        paragraphs: this.paragraphs,
+        pageCount: this.pageCount,
+      })),
+    };
+  }
+
+  cloneState() {
+    return {
+      pageCount: this.pageCount,
+      paragraphs: structuredClone(this.paragraphs),
+    };
+  }
+  restoreState(snapshot: ReturnType<FakeWasm['cloneState']>) {
+    this.pageCount = snapshot.pageCount;
+    this.paragraphs = structuredClone(snapshot.paragraphs);
+  }
+}
+
+class FakeInput implements DocumentAgentInput {
+  transactions = 0;
+  position = { sectionIndex: 0, paragraphIndex: 1, charOffset: 0 };
+  selection: { start: typeof this.position; end: typeof this.position } | null = null;
+  private wasm: FakeWasm;
+  private eventBus: EventBus;
+
+  constructor(wasm: FakeWasm, eventBus: EventBus) {
+    this.wasm = wasm;
+    this.eventBus = eventBus;
+  }
+
+  getCursorPosition() { return { ...this.position }; }
+  getSelection() { return this.selection ? structuredClone(this.selection) : null; }
+  async executeDocumentAgentOperation(
+    desc: Parameters<DocumentAgentInput['executeDocumentAgentOperation']>[0],
+    render: () => Promise<void>,
+  ) {
+    const snapshot = this.wasm.cloneState();
+    const positionBefore = { ...this.position };
+    try {
+      const result = desc.operation(this.wasm);
+      if (result === null) return;
+      this.position = { ...result };
+      try {
+        await render();
+      } catch (cause) {
+        this.wasm.restoreState(snapshot);
+        this.position = positionBefore;
+        throw Object.assign(new Error('render failed', { cause }), {
+          code: 'RENDER_FAILED',
+          recovered: true,
+        });
+      }
+      this.transactions += 1;
+      this.eventBus.emit('document-mutated', desc.operationType);
+    } catch (error) {
+      this.wasm.restoreState(snapshot);
+      this.position = positionBefore;
+      throw error;
+    }
+  }
+  focusBodyParagraph(section: number, paragraphIndex: number, length: number) {
+    this.position = { sectionIndex: section, paragraphIndex, charOffset: length };
+    this.selection = {
+      start: { sectionIndex: section, paragraphIndex, charOffset: 0 },
+      end: { sectionIndex: section, paragraphIndex, charOffset: length },
+    };
+    return true;
+  }
+}
+
+function paragraph(text: string): Paragraph {
+  return {
+    text,
+    paraShapeId: 2,
+    styleId: 3,
+    charShapeIds: Array(Math.max(Array.from(text).length, 1)).fill(4),
+    controls: [],
+    fields: [],
+  };
+}
+
+function target(wasm: FakeWasm): RhwpBodyParagraphTargetV1 {
+  return {
+    kind: 'body_paragraph',
+    section: 0,
+    paragraph: 1,
+    charOffset: 0,
+    length: wasm.getParagraphLength(0, 1),
+  };
+}
+
+function harness(options: { render?: () => Promise<void> } = {}) {
+  const wasm = new FakeWasm();
+  const eventBus = new EventBus();
+  const input = new FakeInput(wasm, eventBus);
+  const events: unknown[] = [];
+  eventBus.on('document-agent-changed', (event) => events.push(event));
+  const controller = new DocumentAgentController({
+    wasm,
+    input,
+    eventBus,
+    isDirty: () => true,
+    render: options.render ?? (async () => {}),
+  });
+  return { controller, wasm, input, events, eventBus };
+}
+
+function applyCommand(
+  controller: DocumentAgentController,
+  wasm: FakeWasm,
+  replacement = '새 문단',
+): RhwpApplyTextCommandV1 {
+  const state = controller.getDocumentState();
+  const exactTarget = target(wasm);
+  const evidence = collectTargetEvidence(wasm, exactTarget);
+  return {
+    schemaVersion: 1,
+    commandId: 'cmd-1',
+    expectedDocumentEpoch: state.documentEpoch,
+    expectedChangeSeq: state.changeSeq,
+    expectedDocumentSha256: state.documentSha256,
+    target: exactTarget,
+    expectedBeforeSha256: evidence.textSha256,
+    expectedFormatSha256: evidence.formatSha256,
+    expectedAdjacentContextSha256: evidence.adjacentContextSha256,
+    replacement,
+  };
+}
+
+test('apply/revert는 각각 한 트랜잭션·changeSeq 1회·strict receipt로 종결된다', async () => {
+  const { controller, wasm, input, events } = harness();
+  const command = applyCommand(controller, wasm);
+
+  const applied = await controller.applyTextCommand(command);
+  assert.equal(wasm.paragraphs[0][1].text, '새 문단');
+  assert.equal(input.transactions, 1);
+  assert.equal(applied.beforeChangeSeq, 0);
+  assert.equal(applied.afterChangeSeq, 1);
+  assert.equal(events.length, 1);
+
+  const reverted = await controller.revertTextCommand({
+    schemaVersion: 1,
+    commandId: command.commandId,
+    expectedDocumentEpoch: applied.documentEpoch,
+    expectedChangeSeq: applied.afterChangeSeq,
+    expectedAfterDocumentSha256: applied.afterDocumentSha256,
+    expectedAfterSha256: applied.afterTextSha256,
+  });
+  assert.equal(wasm.paragraphs[0][1].text, '기존 문단');
+  assert.equal(input.transactions, 2);
+  assert.equal(reverted.beforeChangeSeq, 1);
+  assert.equal(reverted.afterChangeSeq, 2);
+  assert.equal(events.length, 2);
+});
+
+test('target evidence는 세션 stable id 없이 고정된 UTF-8 SHA-256 벡터를 사용한다', () => {
+  const { wasm } = harness();
+  const evidence = collectTargetEvidence(wasm, target(wasm));
+
+  assert.equal(
+    evidence.textSha256,
+    '73b107c1b8b366ea082beba6cf29568890d48845fa212849f74b516209a6378e',
+  );
+  assert.equal(
+    evidence.formatSha256,
+    '5479c59c8c99dde1c9bb45c70a4689eab28233b28dcf31976db9ab8e4b74ec71',
+  );
+  assert.equal(
+    evidence.adjacentContextSha256,
+    '17026195f4004b9995060c1dd27a14fb8619c9afc502a371cbdebf94025b7568',
+  );
+});
+
+test('replacement 길이는 UTF-16 code unit가 아닌 Unicode code point로 계산한다', async () => {
+  const { controller, wasm } = harness();
+  const applied = await controller.applyTextCommand(applyCommand(controller, wasm, '🚀 새 문단'));
+
+  assert.equal(applied.afterTextSha256.length, 64);
+  assert.equal(wasm.getParagraphLength(0, 1), 6);
+});
+
+test('stale preimage는 mutation 0회로 거부된다', async () => {
+  const { controller, wasm, input, events } = harness();
+  const command = applyCommand(controller, wasm);
+  command.expectedBeforeSha256 = 'f'.repeat(64);
+
+  await assert.rejects(
+    controller.applyTextCommand(command),
+    (error: unknown) => (error as { code?: string }).code === 'TARGET_PREIMAGE_MISMATCH',
+  );
+  assert.equal(input.transactions, 0);
+  assert.equal(events.length, 0);
+  assert.equal(wasm.paragraphs[0][1].text, '기존 문단');
+});
+
+test('mixed format·control·field target은 mutation 전에 거부된다', () => {
+  for (const mutate of [
+    (wasm: FakeWasm) => { wasm.paragraphs[0][1].charShapeIds[1] = 99; },
+    (wasm: FakeWasm) => { wasm.paragraphs[0][1].controls = [1]; },
+    (wasm: FakeWasm) => { wasm.paragraphs[0][1].fields = [[0, 2]]; },
+  ]) {
+    const { controller, wasm, input } = harness();
+    mutate(wasm);
+    assert.throws(
+      () => collectTargetEvidence(wasm, target(wasm)),
+      (error: unknown) => (error as { code?: string }).code === 'TARGET_FORMAT_MISMATCH',
+    );
+    assert.equal(input.transactions, 0);
+  }
+});
+
+test('page count postcondition 실패는 같은 트랜잭션에서 rollback된다', async () => {
+  const { controller, wasm, input, events } = harness();
+  const command = applyCommand(controller, wasm, '페이지 증가');
+  wasm.replacementPageCount = 3;
+
+  await assert.rejects(
+    controller.applyTextCommand(command),
+    (error: unknown) => (error as { code?: string }).code === 'PAGE_COUNT_CHANGED',
+  );
+  assert.equal(wasm.paragraphs[0][1].text, '기존 문단');
+  assert.equal(wasm.pageCount, 2);
+  assert.equal(input.transactions, 0);
+  assert.equal(events.length, 0);
+});
+
+test('apply 뒤 일반 편집이 있으면 agent revert를 거부한다', async () => {
+  const { controller, wasm, eventBus } = harness();
+  const applied = await controller.applyTextCommand(applyCommand(controller, wasm));
+  wasm.paragraphs[0][0].text = '사용자 편집';
+  eventBus.emit('document-mutated', 'user-edit');
+
+  await assert.rejects(
+    controller.revertTextCommand({
+      schemaVersion: 1,
+      commandId: applied.commandId,
+      expectedDocumentEpoch: applied.documentEpoch,
+      expectedChangeSeq: applied.afterChangeSeq,
+      expectedAfterDocumentSha256: applied.afterDocumentSha256,
+      expectedAfterSha256: applied.afterTextSha256,
+    }),
+    (error: unknown) => (error as { code?: string }).code === 'COMMAND_NOT_LATEST',
+  );
+});
+
+test('같은 apply replay는 exact terminal 상태에서만 receipt를 재사용한다', async () => {
+  const { controller, wasm, input, eventBus } = harness();
+  const command = applyCommand(controller, wasm);
+  const first = await controller.applyTextCommand(command);
+  assert.deepEqual(await controller.applyTextCommand(structuredClone(command)), first);
+  assert.equal(input.transactions, 1);
+
+  await assert.rejects(
+    controller.applyTextCommand({ ...command, replacement: '다른 문단' }),
+    (error: unknown) => (error as { code?: string }).code === 'COMMAND_REPLAY_MISMATCH',
+  );
+
+  wasm.paragraphs[0][0].text = '후속 사용자 편집';
+  eventBus.emit('document-mutated', 'user-edit');
+  await assert.rejects(
+    controller.applyTextCommand(structuredClone(command)),
+    (error: unknown) => (error as { code?: string }).code === 'COMMAND_REPLAY_MISMATCH',
+  );
+});
+
+test('같은 revert replay도 exact terminal 상태가 바뀌면 거부한다', async () => {
+  const { controller, wasm, eventBus } = harness();
+  const applied = await controller.applyTextCommand(applyCommand(controller, wasm));
+  const command = {
+    schemaVersion: 1 as const,
+    commandId: applied.commandId,
+    expectedDocumentEpoch: applied.documentEpoch,
+    expectedChangeSeq: applied.afterChangeSeq,
+    expectedAfterDocumentSha256: applied.afterDocumentSha256,
+    expectedAfterSha256: applied.afterTextSha256,
+  };
+  const reverted = await controller.revertTextCommand(command);
+  assert.deepEqual(await controller.revertTextCommand(structuredClone(command)), reverted);
+
+  wasm.paragraphs[0][0].text = 'revert 뒤 사용자 편집';
+  eventBus.emit('document-mutated', 'user-edit');
+  await assert.rejects(
+    controller.revertTextCommand(structuredClone(command)),
+    (error: unknown) => (error as { code?: string }).code === 'COMMAND_REPLAY_MISMATCH',
+  );
+});
+
+test('strict render 실패는 snapshot을 복구하고 recovered=true를 전달한다', async () => {
+  const { controller, wasm, input, events } = harness({
+    render: async () => { throw new Error('renderer unavailable'); },
+  });
+  const command = applyCommand(controller, wasm);
+
+  await assert.rejects(
+    controller.applyTextCommand(command),
+    (error: unknown) => {
+      const typed = error as { code?: string; recovered?: boolean };
+      return typed.code === 'RENDER_FAILED' && typed.recovered === true;
+    },
+  );
+  assert.equal(wasm.paragraphs[0][1].text, '기존 문단');
+  assert.equal(input.transactions, 0);
+  assert.equal(events.length, 0);
+});
+
+test('selection context와 focus는 body paragraph만 exact하게 노출한다', () => {
+  const { controller, wasm, input } = harness();
+  const collapsed = controller.getSelectionContext();
+  assert.equal(collapsed.collapsed, true);
+  assert.deepEqual(collapsed.target, target(wasm));
+  assert.equal(collapsed.page, 2);
+
+  assert.deepEqual(controller.focusTarget(target(wasm)), { focused: true, page: 2 });
+  const selected = controller.getSelectionContext();
+  assert.equal(selected.collapsed, false);
+  assert.equal(selected.selectedTextSha256?.length, 64);
+  assert.deepEqual(input.selection?.start, {
+    sectionIndex: 0,
+    paragraphIndex: 1,
+    charOffset: 0,
+  });
+});

--- a/rhwp-studio/tests/embed-protocol.test.ts
+++ b/rhwp-studio/tests/embed-protocol.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../src/embed/protocol.ts';
 import { routeEmbedRequest, type EmbedRpcHandlers } from '../src/embed/rpc-router.ts';
 import { installEmbedRuntime } from '../src/embed/runtime.ts';
+import { DocumentAgentError } from '../src/document-agent/types.ts';
 
 test('renderer diagnostics v1 keeps auto intent in the additive selection field', () => {
   const source = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
@@ -55,6 +56,11 @@ test('embed protocol은 capability를 포함한 v1 connect와 session-bound requ
     'plugin-loader-v1',
     'hwpctrl-v1',
     'chrome-v1',
+    'document-state-v1',
+    'selection-context-v1',
+    'document-agent-command-v1',
+    'target-navigation-v1',
+    'document-change-events-v1',
   ]);
 
   assert.equal(isRequestEnvelope({
@@ -138,6 +144,73 @@ test('embed router는 binary load와 unknown method를 공개 동작으로 처�
     () => routeEmbedRequest('loadFile', { data: [3, 4], fileName: 'legacy.hwp' }, handlers),
     /binary data/,
   );
+});
+
+test('embed router는 document-agent v1 command와 target을 strict DTO로만 전달한다', async () => {
+  const calls: Array<{ method: string; value?: unknown }> = [];
+  const target = {
+    kind: 'body_paragraph' as const,
+    section: 0,
+    paragraph: 2,
+    charOffset: 0 as const,
+    length: 7,
+  };
+  const apply = {
+    schemaVersion: 1 as const,
+    commandId: 'cmd-1',
+    expectedDocumentEpoch: 2,
+    expectedChangeSeq: 3,
+    expectedDocumentSha256: 'a'.repeat(64),
+    target,
+    expectedBeforeSha256: 'b'.repeat(64),
+    expectedFormatSha256: 'c'.repeat(64),
+    expectedAdjacentContextSha256: 'd'.repeat(64),
+    replacement: '새 문단',
+  };
+  const revert = {
+    schemaVersion: 1 as const,
+    commandId: 'cmd-1',
+    expectedDocumentEpoch: 2,
+    expectedChangeSeq: 4,
+    expectedAfterDocumentSha256: 'e'.repeat(64),
+    expectedAfterSha256: 'f'.repeat(64),
+  };
+  const handlers = {
+    getDocumentState: async () => { calls.push({ method: 'state' }); return { ok: true }; },
+    getSelectionContext: async () => { calls.push({ method: 'selection' }); return { ok: true }; },
+    applyTextCommand: async (value: unknown) => { calls.push({ method: 'apply', value }); return { ok: true }; },
+    revertTextCommand: async (value: unknown) => { calls.push({ method: 'revert', value }); return { ok: true }; },
+    focusTarget: async (value: unknown) => { calls.push({ method: 'focus', value }); return { ok: true }; },
+  } as EmbedRpcHandlers;
+
+  await routeEmbedRequest('getDocumentState', {}, handlers);
+  await routeEmbedRequest('getSelectionContext', {}, handlers);
+  await routeEmbedRequest('applyTextCommand', { command: apply }, handlers);
+  await routeEmbedRequest('revertTextCommand', { command: revert }, handlers);
+  await routeEmbedRequest('focusTarget', { target }, handlers);
+  assert.deepEqual(calls, [
+    { method: 'state' },
+    { method: 'selection' },
+    { method: 'apply', value: apply },
+    { method: 'revert', value: revert },
+    { method: 'focus', value: target },
+  ]);
+
+  for (const [method, params] of [
+    ['getDocumentState', { extra: true }],
+    ['getSelectionContext', { extra: true }],
+    ['applyTextCommand', { command: { ...apply, extra: true } }],
+    ['applyTextCommand', { command: { ...apply, expectedChangeSeq: Number.NaN } }],
+    ['applyTextCommand', { command: { ...apply, replacement: 'line1\nline2' } }],
+    ['revertTextCommand', { command: { ...revert, expectedAfterSha256: 'bad' } }],
+    ['focusTarget', { target: { ...target, charOffset: 1 } }],
+    ['focusTarget', { target: { ...target, length: 4001 } }],
+  ] as const) {
+    await assert.rejects(
+      () => routeEmbedRequest(method, params, handlers),
+      (error: unknown) => (error as { code?: string }).code === 'INVALID_COMMAND',
+    );
+  }
 });
 
 test('embed runtime은 parent의 exact origin에서 v1 port session을 설치한다', async () => {
@@ -453,6 +526,220 @@ test('exportHml 실패는 bytes 없이 error-only envelope를 반환한다', asy
     cleanup();
     channel.port1.close();
   }
+});
+
+test('embed runtime은 document-agent allowlist 오류와 recovered 상태를 그대로 전달한다', async () => {
+  let messageListener: (event: MessageEvent) => void = () => {};
+  const hostWindow = {
+    addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+      messageListener = listener;
+    },
+    removeEventListener() {},
+  };
+  const parentWindow = { postMessage() {} };
+  const cleanup = installEmbedRuntime({
+    hostWindow: hostWindow as unknown as Window,
+    parentWindow: parentWindow as unknown as Window,
+    handlers: {
+      getDocumentState: async () => {
+        throw new DocumentAgentError('RENDER_FAILED', 'render failed', true);
+      },
+    } as EmbedRpcHandlers,
+  });
+  const channel = new MessageChannel();
+  const response = new Promise<unknown>((resolve) => {
+    channel.port1.onmessage = ({ data }) => {
+      if (data.type === 'rhwp-connected') {
+        channel.port1.postMessage({
+          type: 'rhwp-request', version: 1, sessionId: 'agent-error',
+          id: 5, method: 'getDocumentState', params: {},
+        });
+      } else {
+        resolve(data);
+      }
+    };
+    channel.port1.start();
+  });
+
+  try {
+    messageListener({
+      data: {
+        type: 'rhwp-connect', version: 1, sessionId: 'agent-error',
+        capabilities: ['transferable-array-buffer', 'document-state-v1'],
+      },
+      source: parentWindow,
+      origin: 'https://host.example',
+      ports: [channel.port2],
+    } as unknown as MessageEvent);
+    assert.deepEqual(await response, {
+      type: 'rhwp-response', version: 1, sessionId: 'agent-error', id: 5,
+      error: { code: 'RENDER_FAILED', message: 'render failed', recovered: true },
+    });
+  } finally {
+    cleanup();
+    channel.port1.close();
+  }
+});
+
+test('embed runtime은 client가 협상하지 않은 document-agent method를 dispatch하지 않는다', async () => {
+  let messageListener: (event: MessageEvent) => void = () => {};
+  let mutationCalls = 0;
+  const hostWindow = {
+    addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+      messageListener = listener;
+    },
+    removeEventListener() {},
+  };
+  const parentWindow = { postMessage() {} };
+  const cleanup = installEmbedRuntime({
+    hostWindow: hostWindow as unknown as Window,
+    parentWindow: parentWindow as unknown as Window,
+    handlers: {
+      applyTextCommand: async () => {
+        mutationCalls += 1;
+        return {} as never;
+      },
+    } as EmbedRpcHandlers,
+  });
+  const channel = new MessageChannel();
+  const response = new Promise<unknown>((resolve) => {
+    channel.port1.onmessage = ({ data }) => {
+      if (data.type === 'rhwp-connected') {
+        channel.port1.postMessage({
+          type: 'rhwp-request', version: 1, sessionId: 'no-agent-cap',
+          id: 55, method: 'applyTextCommand', params: {},
+        });
+      } else {
+        resolve(data);
+      }
+    };
+    channel.port1.start();
+  });
+
+  try {
+    messageListener({
+      data: {
+        type: 'rhwp-connect', version: 1, sessionId: 'no-agent-cap',
+        capabilities: ['transferable-array-buffer'],
+      },
+      source: parentWindow,
+      origin: 'https://host.example',
+      ports: [channel.port2],
+    } as unknown as MessageEvent);
+    assert.deepEqual(await response, {
+      type: 'rhwp-response', version: 1, sessionId: 'no-agent-cap', id: 55,
+      error: {
+        code: 'UNSUPPORTED_CAPABILITY',
+        message: 'document-agent-command-v1 was not negotiated by the client.',
+      },
+    });
+    assert.equal(mutationCalls, 0);
+  } finally {
+    cleanup();
+    channel.port1.close();
+  }
+});
+
+test('embed legacy transport는 document mutation method를 dispatch하지 않는다', async () => {
+  let messageListener: (event: MessageEvent) => void = () => {};
+  let mutationCalls = 0;
+  let resolveResponse: (value: unknown) => void = () => {};
+  const response = new Promise<unknown>((resolve) => { resolveResponse = resolve; });
+  const hostWindow = {
+    addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+      messageListener = listener;
+    },
+    removeEventListener() {},
+  };
+  const parentWindow = {
+    postMessage(message: unknown) { resolveResponse(message); },
+  };
+  const cleanup = installEmbedRuntime({
+    hostWindow: hostWindow as unknown as Window,
+    parentWindow: parentWindow as unknown as Window,
+    handlers: {
+      applyTextCommand: async () => {
+        mutationCalls += 1;
+        return {} as never;
+      },
+    } as EmbedRpcHandlers,
+  });
+
+  try {
+    messageListener({
+      data: { type: 'rhwp-request', id: 77, method: 'applyTextCommand', params: {} },
+      source: parentWindow,
+      origin: 'https://host.example',
+      ports: [],
+    } as unknown as MessageEvent);
+
+    assert.deepEqual(await Promise.race([
+      response,
+      new Promise((_, reject) => setTimeout(() => reject(new Error('legacy response timeout')), 50)),
+    ]), {
+      type: 'rhwp-response',
+      id: 77,
+      error: 'Legacy embed transport cannot execute document mutations.',
+    });
+    assert.equal(mutationCalls, 0);
+  } finally {
+    cleanup();
+  }
+});
+
+test('embed runtime은 bound port에 documentChanged v1 event를 전달하고 cleanup한다', async () => {
+  let messageListener: (event: MessageEvent) => void = () => {};
+  let emitDocumentChanged: (payload: unknown) => void = () => {};
+  let unsubscribed = 0;
+  const hostWindow = {
+    addEventListener(_type: string, listener: (event: MessageEvent) => void) {
+      messageListener = listener;
+    },
+    removeEventListener() {},
+  };
+  const parentWindow = { postMessage() {} };
+  const cleanup = installEmbedRuntime({
+    hostWindow: hostWindow as unknown as Window,
+    parentWindow: parentWindow as unknown as Window,
+    handlers: {} as EmbedRpcHandlers,
+    subscribeDocumentChanged(listener) {
+      emitDocumentChanged = listener;
+      return () => { unsubscribed += 1; };
+    },
+  });
+  const channel = new MessageChannel();
+  const eventPayload = {
+    schemaVersion: 1,
+    reason: 'agent_apply',
+    documentEpoch: 2,
+    changeSeq: 1,
+    commandId: 'cmd-1',
+  };
+  const eventMessage = new Promise<unknown>((resolve) => {
+    channel.port1.onmessage = ({ data }) => {
+      if (data.type === 'rhwp-connected') emitDocumentChanged(eventPayload);
+      if (data.type === 'rhwp-event') resolve(data);
+    };
+    channel.port1.start();
+  });
+
+  messageListener({
+    data: {
+      type: 'rhwp-connect', version: 1, sessionId: 'agent-event',
+      capabilities: ['transferable-array-buffer', 'document-change-events-v1'],
+    },
+    source: parentWindow,
+    origin: 'https://host.example',
+    ports: [channel.port2],
+  } as unknown as MessageEvent);
+
+  assert.deepEqual(await eventMessage, {
+    type: 'rhwp-event', version: 1, sessionId: 'agent-event',
+    event: 'documentChanged', payload: eventPayload,
+  });
+  cleanup();
+  assert.equal(unsubscribed, 1);
+  channel.port1.close();
 });
 
 function rendererDiagnostics(page: number) {

--- a/scripts/frontend-editor-embed.test.mjs
+++ b/scripts/frontend-editor-embed.test.mjs
@@ -24,6 +24,11 @@ test('@rhwp/editor public API uses exact-origin MessageChannel v1 binary transpo
       'renderer-diagnostics-v1',
       'font-decision-trace-v1',
       'notify-saved-v1',
+      'document-state-v1',
+      'selection-context-v1',
+      'document-agent-command-v1',
+      'target-navigation-v1',
+      'document-change-events-v1',
     ]);
     assert.equal(transfer.length, 1);
     sessionId = message.sessionId;
@@ -46,6 +51,11 @@ test('@rhwp/editor public API uses exact-origin MessageChannel v1 binary transpo
         'renderer-diagnostics-v1',
         'font-decision-trace-v1',
         'notify-saved-v1',
+        'document-state-v1',
+        'selection-context-v1',
+        'document-agent-command-v1',
+        'target-navigation-v1',
+        'document-change-events-v1',
       ],
     });
   });


### PR DESCRIPTION
## 변경 내용

- `@rhwp/editor`에 strict `document-agent-command-v1` 공개 API와 변경 이벤트를 추가합니다.
- Studio에 snapshot 기반 apply/revert, 충돌 감지, exact target focus/selection 동기화를 추가합니다.
- HWP/HWPX 브라우저 E2E와 SDK/프로토콜/히스토리 회귀 테스트를 추가합니다.
- editor와 Studio patch 버전을 `0.8.5`로 올립니다. Rust core 버전은 변경하지 않습니다.

## 검증

- `npm --prefix npm/editor test`: 32/32 통과
- `node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs`: 3/3 통과
- editor 선언 `tsc --noEmit`: 통과
- `npm pack --dry-run --json`: `@rhwp/editor@0.8.5`, 6개 파일 확인
- `npm --prefix rhwp-studio test`: 983개 중 982 통과, 1개 기존 skip
- `npm --prefix rhwp-studio run build`: 통과
- `npm --prefix rhwp-studio run e2e:document-agent`: HWP/HWPX 각각 15개 단언 통과

## 기준선 메모

- 로컬에 `cargo`/`rustfmt`가 없어 Rust 포맷 검사는 실행하지 못했습니다. 이 PR에는 Rust 소스 변경이 없습니다.
- 최신 `devel` 기준 `node scripts/rust-test-suite-manifest.mjs --check`는 기존 generated harness 32개 drift로 실패합니다. 이 PR 변경 범위와 무관하여 재생성 변경은 포함하지 않았습니다.
- `node scripts/rust-unit-test-tiers.mjs --check`는 4,225 tests / 298 modules로 통과했습니다.
