### PR TITLE
fix: #3230 개체 회전·대칭을 스냅샷에서 역연산으로 — 스냅샷 예산 2→0

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -14,7 +14,8 @@ import type { ShapeType } from '@/ui/shape-picker';
 import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
-import type { RefreshPolicy } from '@/engine/command';
+import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -615,39 +616,17 @@ export const insertCommands: CommandDef[] = [
   },
 ];
 
-/** 선택 개체 ref 타입 — cursor.selectedPictureRef 와 정합 (headerFooter optional, [Task #831]) */
-type PictureRef = {
-  sec: number;
-  ppi: number;
-  ci: number;
-  type: string;
-  cellPath?: CellPathLike;
-  headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
-};
+/**
+ * 선택 개체 ref 타입 — cursor.selectedPictureRef 와 정합 (headerFooter optional, [Task #831]).
+ *
+ * [Task #3230] 분기 본체는 `engine/object-props.ts` 로 옮겼다 — 역연산 커맨드가 undo 시점에
+ * 같은 분기를 써야 하는데, 커맨드는 `services` 가 아니라 `WasmBridge` 만 받기 때문이다.
+ */
+type PictureRef = ObjectPropsRef;
 
-/** 선택 개체의 속성을 조회/변경 헬퍼 (shape/picture 분기) */
+/** 선택 개체의 속성 조회 (shape/picture·셀·머리말꼬리말 분기). */
 function getProps(services: import('../types').CommandServices, ref: PictureRef): Record<string, unknown> {
-  if (ref.type === 'shape') {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.getCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
-    }
-    return services.wasm.getShapeProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
-  }
-  // [Task #831] 머리말/꼬리말 picture 의 경우 별도 API 호출 (PR #832 의 wasm-bridge).
-  // 미적용 시 본문 lookup 실패 → props 빈/stale → 회전/대칭 무동작.
-  if (ref.headerFooter) {
-    return services.wasm.getHeaderFooterPictureProperties(
-      ref.sec,
-      ref.headerFooter.outerParaIdx,
-      ref.headerFooter.outerControlIdx,
-      ref.ppi,
-      ref.ci,
-    ) as unknown as Record<string, unknown>;
-  }
-  if (ref.cellPath && ref.cellPath.length > 0) {
-    return services.wasm.getCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
-  }
-  return services.wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+  return getObjectProps(services.wasm, ref);
 }
 
 /**
@@ -707,27 +686,33 @@ function changeZOrder(
 }
 
 function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  if (ref.type === 'shape') {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.setCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
-    }
-    return services.wasm.setShapeProperties(ref.sec, ref.ppi, ref.ci, props);
-  } else if (ref.headerFooter) {
-    // [Task #831] 머리말/꼬리말 picture setter — 5-tuple lookup 으로 IR 갱신.
-    return services.wasm.setHeaderFooterPictureProperties(
-      ref.sec,
-      ref.headerFooter.outerParaIdx,
-      ref.headerFooter.outerControlIdx,
-      ref.ppi,
-      ref.ci,
-      props,
-    );
-  } else {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.setCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
-    }
-    return services.wasm.setPictureProperties(ref.sec, ref.ppi, ref.ci, props);
-  }
+  return setObjectProps(services.wasm, ref, props);
+}
+
+/**
+ * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ *
+ * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ *
+ * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
+ * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
+ * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ */
+function recordAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  setProps(services, ref, after);
+  ih.executeOperation({
+    kind: 'record',
+    command: new SetObjectPropsCommand(ref, before, after),
+    meta: { refresh: 'full' },
+  });
 }
 
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
@@ -743,9 +728,9 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // recordObjectMutation → executeOperation snapshot 의 'full' refresh 가 afterEdit()→
-  // 'document-changed' 를 이미 emit 한다. 수동 emit 은 중복(이중 렌더)이라 제거. [undo P3 정리]
-  recordObjectMutation(ih, 'rotateObject', () => setProps(services, ref, { rotationAngle: next }));
+  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
+  // 절대값이라 되돌리기가 자명하다.
+  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -757,6 +742,6 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   const props = getProps(services, ref);
   if (props.sizeProtect) return;
   const cur = !!props[key];
-  // 위 rotate 와 동일 — snapshot 라우팅이 이미 refresh 하므로 수동 emit 제거. [undo P3 정리]
-  recordObjectMutation(ih, 'flipObject', () => setProps(services, ref, { [key]: !cur }));
+  // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
+  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -713,6 +713,45 @@ function executeAbsolutePropChange(
   });
 }
 
+/**
+ * [Task #3230] 속성 왕복이 **참인 역연산인 대상**인지.
+ *
+ * 도형은 참이다 — `rotationAngle` 은 평범한 필드 대입이고 flip 은 비트를 대칭으로 set/clear
+ * 한다(`document_core/commands/object_ops/shape.rs`). 같은 값을 다시 넣으면 원래 상태다.
+ *
+ * **그림·OLE 는 아니다.** `rotationAngle` 이 섞이면 `refresh_picture_rotation_layout_for_save`
+ * 가 각도와 무관하게 — 0 으로 되돌리는 경우까지 — `rotate_image = true` 와
+ * `flip |= 0x0008_0000` 을 세운다(`object_ops/picture.rs:242-243`). 이 둘을 다시 내리는 경로는
+ * 저장소에 없어서, 90° 돌렸다 되돌린 그림은 화면은 같아도 저장 바이트가 원본과 달라진다
+ * (HWPX `hp:rotationInfo rotateimage`·HWP5 `HWPTAG_SHAPE_COMPONENT` 의 flip 비트).
+ * 대칭도 `TRANSFORM_KEYS`(picture.rs:176-184)에 걸려 `raw_rendering`·`render_*` 캐시를
+ * 기본값으로 리셋한다.
+ *
+ * 속성 bag 만으로는 이것들을 복원할 수 없다. 문서를 통째로 되돌리는 스냅샷이라야 정확하므로
+ * 그림·OLE 는 종전 경로를 유지한다 — 되돌리기의 정확성이 스냅샷 비용보다 앞선다.
+ */
+function absolutePropChangeIsInvertible(ref: PictureRef): boolean {
+  return ref.type === 'shape';
+}
+
+/** 역연산이 참이면 커맨드로, 아니면 종전 스냅샷으로 기록한다. */
+function applyAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  operationType: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  if (absolutePropChangeIsInvertible(ref)) {
+    executeAbsolutePropChange(ih, ref, before, after);
+    return;
+  }
+  recordObjectMutation(ih, operationType, (wasm) => {
+    setObjectProps(wasm, ref, after);
+  });
+}
+
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
@@ -726,9 +765,11 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
-  // 절대값이라 되돌리기가 자명하다.
-  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  // [Task #3230] 도형은 역연산, 그림·OLE 는 스냅샷 유지(`absolutePropChangeIsInvertible`).
+  // `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가 절대값이라 되돌리기가 자명하다.
+  applyAbsolutePropChange(
+    services, ih, ref, 'rotateObject', { rotationAngle: cur }, { rotationAngle: next },
+  );
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -741,5 +782,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
+  applyAbsolutePropChange(services, ih, ref, 'flipObject', { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -454,7 +454,10 @@ export const insertCommands: CommandDef[] = [
           captionIncludeMargin: false,
         };
         let result: any;
-        result = setProps(services, ref, captionProps);
+        // [Task #3230] `setProps` 래퍼가 사라져 공유 라우팅을 직접 부른다. 이 경로는 종전부터
+        // 라우터를 거치지 않고 직접 적용하고 `document-changed` 를 스스로 emit 한다 —
+        // 회전/대칭과 달리 이번 변경 대상이 아니라 종전 동작 그대로 둔다.
+        result = setObjectProps(services.wasm, ref, captionProps);
         // "그림 N " 끝 위치를 Rust가 반환
         charOffset = result?.captionCharOffset ?? 4;
         services.eventBus.emit('document-changed');

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -685,31 +685,26 @@ function changeZOrder(
   ih.exitPictureObjectSelectionAndAfterEdit();
 }
 
-function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  return setObjectProps(services.wasm, ref, props);
-}
-
 /**
- * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ * [Task #3230] 절대 속성 하나를 **역연산 커맨드로** 적용하고 기록한다.
  *
- * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * 스냅샷(`recordObjectMutation`) 대신 `kind:'command'`를 쓴다 — 되돌릴 것이 스칼라 하나인데
  * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
- * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다. setter를 라우터 전에 직접 호출하지 않아야
+ * 양식 모드의 편집 허용 검사가 실제 변경보다 먼저 실행된다.
  *
- * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
- * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
- * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ * refresh 를 'full' 로 명시한다 — command 라우팅의 자동 판정에 맡기면 개체 회전/대칭의 화면 반영이
+ * 보장되지 않는다. 종전 스냅샷 라우팅의 'full' 이 `afterEdit()` → `document-changed` 를 대신
+ * emit 해 주고 있었다(그래서 호출부의 수동 emit 이 [undo P3 정리] 에서 제거됐다).
  */
-function recordAbsolutePropChange(
-  services: import('../types').CommandServices,
+function executeAbsolutePropChange(
   ih: InputHandler,
   ref: PictureRef,
   before: Record<string, unknown>,
   after: Record<string, unknown>,
 ): void {
-  setProps(services, ref, after);
   ih.executeOperation({
-    kind: 'record',
+    kind: 'command',
     command: new SetObjectPropsCommand(ref, before, after),
     meta: { refresh: 'full' },
   });
@@ -730,7 +725,7 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   if (next > 180) next -= 360;
   // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
   // 절대값이라 되돌리기가 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -743,5 +738,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
+  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -7,6 +7,7 @@ import type {
 import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
+import { setObjectProps, type ObjectPropsRef } from './object-props';
 
 /** 편집 명령 공통 인터페이스 */
 export interface EditCommand {
@@ -1935,6 +1936,54 @@ export class MoveLineEndpointCommand implements EditCommand {
     return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
   }
 
+  mergeWith(): null { return null; }
+}
+
+/**
+ * [Task #3230] 개체 속성 변경의 역연산 명령 (kind:'record' 용, #2337 계열).
+ *
+ * 스냅샷 대신 쓰는 이유는 비용이다. 스냅샷 1개는 `Document` 통째 클론이라 문서에 비례하고
+ * (실측: 30KB 공문 0.43 MB · 10MB 행정편람 10.59 MB), `SnapshotCommand` 는 before/after 로
+ * 2개를 쓴다. 회전 한 번에 최대 21 MB 를 스택에 얹는 셈인데, 실제로 되돌려야 하는 것은
+ * **스칼라 속성 하나**다.
+ *
+ * 역연산이 자명한 조건은 셋이고 회전·대칭은 셋을 다 만족한다.
+ *  - setter 가 **절대값**이다(누적·토글이 아니라 `rotationAngle = 30`, `horzFlip = true`).
+ *  - 호출부가 적용 **전에 현재 값을 이미 읽는다**(다음 각도·토글 반대값을 그것으로 만든다).
+ *  - 그 속성만 바뀐다 — 파생 상태(레이아웃·앵커)는 setter 가 다시 계산한다.
+ *
+ * 뮤테이션은 호출부가 적용하고 이 명령은 기록만 담당한다(`execute` 는 redo 경로에서만 재적용).
+ */
+export class SetObjectPropsCommand implements EditCommand {
+  readonly type = 'setObjectProps';
+  readonly timestamp: number;
+
+  constructor(
+    private ref: ObjectPropsRef,
+    private before: Record<string, unknown>,
+    private after: Record<string, unknown>,
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  private apply(wasm: WasmBridge, props: Record<string, unknown>): DocumentPosition {
+    setObjectProps(wasm, this.ref, props);
+    return { sectionIndex: this.ref.sec, paragraphIndex: this.ref.ppi, charOffset: 0 };
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    return this.apply(wasm, this.after);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    return this.apply(wasm, this.before);
+  }
+
+  /**
+   * 병합하지 않는다. 회전 15° 를 네 번 누른 것과 60° 를 한 번 누른 것은 한컴에서도 undo
+   * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
+   */
   mergeWith(): null { return null; }
 }
 

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1981,6 +1981,26 @@ export class SetObjectPropsCommand implements EditCommand {
   }
 
   /**
+   * 적용해도 달라질 것이 없으면 무변경이다 (#2370 규약).
+   *
+   * 히스토리는 커맨드에게 이 질문을 하고(`history.ts` 의 `command.isNoOp?.()`), 답하지 않으면
+   * "항상 바꾼다" 로 읽는다. before 와 after 가 같은데 침묵하면 그 자체가 거짓 응답이고,
+   * 팬텀 엔트리가 Ctrl+Z 한 번을 무효과로 소모하며 redo 스택까지 파기한다.
+   *
+   * 지금 호출부(±90° 회전·`!cur` 토글)는 항상 before ≠ after 라 이 분기를 타지 않는다. 그래도
+   * 답은 커맨드가 해야 한다 — before/after 를 아는 것은 이 객체뿐이고, 호출부마다 같은 비교를
+   * 되풀이하는 것은 판정을 소비자로 흘리는 일이다.
+   *
+   * `after` 의 키만 본다. `execute` 가 적용하는 것이 그것뿐이므로 `before` 에만 있는 키는
+   * 이 연산의 결과를 바꾸지 않는다.
+   */
+  isNoOp(): boolean {
+    const keys = Object.keys(this.after);
+    if (keys.length === 0) return true;
+    return keys.every((key) => Object.is(this.before[key], this.after[key]));
+  }
+
+  /**
    * 병합하지 않는다. 회전 15° 를 네 번 누른 것과 60° 를 한 번 누른 것은 한컴에서도 undo
    * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
    */

--- a/rhwp-studio/src/engine/object-props.ts
+++ b/rhwp-studio/src/engine/object-props.ts
@@ -1,11 +1,14 @@
 /**
  * 선택 개체의 속성 조회·변경 라우팅 (Task #3230).
  *
- * 개체는 어디에 있느냐에 따라 setter/getter 가 넷으로 갈린다 — 본문 도형, 본문 그림, 셀 안
+ * 개체는 어디에 있느냐에 따라 setter/getter 가 갈린다 — 본문 도형, 본문 그림, 셀 안
  * (`cellPath`), 머리말/꼬리말(`headerFooter`, [Task #831]). 이 분기는 지금까지
  * `command/commands/insert.ts` 안에만 있었는데, **역연산 커맨드도 undo 시점에 같은 분기가
  * 필요하다.** 커맨드는 `services` 가 아니라 `WasmBridge` 만 받으므로 여기서 `wasm` 기준으로
  * 두고 양쪽이 함께 쓴다.
+ *
+ * 원본의 분기 구조를 조건·인자 순서까지 그대로 옮겼다. 그래서 원본이 갖고 있던 비대칭
+ * (도형 분기가 `headerFooter` 를 보지 않는 것)도 그대로다 — `getObjectProps` 주석 참고.
  *
  * 분기가 갈라지면 적용과 되돌리기가 서로 다른 개체를 만지게 된다 — HF 그림이 그 예다
  * (본문 lookup 으로 떨어지면 조용히 아무것도 안 바뀐다).
@@ -24,7 +27,17 @@ export type ObjectPropsRef = {
   headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
 };
 
-/** 선택 개체의 현재 속성. */
+/**
+ * 선택 개체의 현재 속성.
+ *
+ * **분기가 대칭이 아니다** — `type === 'shape'` 는 `cellPath` 만 보고 `headerFooter` 는 보지
+ * 않는다(그림 분기는 본다). 머리말/꼬리말 안의 도형은 본문 lookup 으로 떨어질 수 있다.
+ * 이 비대칭은 `command/commands/insert.ts` 에 있던 원본 그대로이며(옮기면서 조건·인자 순서를
+ * 바꾸지 않았다) 이 모듈이 만든 것이 아니다. 고치려면 HF 안에 도형이 실제로 놓이는지와
+ * `getSelectedPictureRef` 가 도형에 `headerFooter` 를 채우는 경로가 있는지부터 확인해야 해서
+ * 별건으로 둔다. `setObjectProps` 도 같은 비대칭을 그대로 갖는다 — 조회와 적용이 갈리면
+ * 되돌리기가 다른 개체를 만지므로 **둘은 반드시 같은 모양이어야 한다.**
+ */
 export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<string, unknown> {
   if (ref.type === 'shape') {
     if (ref.cellPath && ref.cellPath.length > 0) {
@@ -49,7 +62,12 @@ export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<st
   return wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
 }
 
-/** 선택 개체에 속성을 적용한다. `getObjectProps` 와 같은 분기를 쓴다. */
+/**
+ * 선택 개체에 속성을 적용한다.
+ *
+ * `getObjectProps` 와 **같은 분기**를 쓴다(HF 비대칭까지 포함해서). 조회 경로와 적용 경로가
+ * 갈리면 before 를 읽은 개체와 되돌리는 개체가 달라진다.
+ */
 export function setObjectProps(
   wasm: WasmBridge,
   ref: ObjectPropsRef,

--- a/rhwp-studio/src/engine/object-props.ts
+++ b/rhwp-studio/src/engine/object-props.ts
@@ -1,0 +1,78 @@
+/**
+ * 선택 개체의 속성 조회·변경 라우팅 (Task #3230).
+ *
+ * 개체는 어디에 있느냐에 따라 setter/getter 가 넷으로 갈린다 — 본문 도형, 본문 그림, 셀 안
+ * (`cellPath`), 머리말/꼬리말(`headerFooter`, [Task #831]). 이 분기는 지금까지
+ * `command/commands/insert.ts` 안에만 있었는데, **역연산 커맨드도 undo 시점에 같은 분기가
+ * 필요하다.** 커맨드는 `services` 가 아니라 `WasmBridge` 만 받으므로 여기서 `wasm` 기준으로
+ * 두고 양쪽이 함께 쓴다.
+ *
+ * 분기가 갈라지면 적용과 되돌리기가 서로 다른 개체를 만지게 된다 — HF 그림이 그 예다
+ * (본문 lookup 으로 떨어지면 조용히 아무것도 안 바뀐다).
+ */
+
+import type { CellPathLike } from '@/core/types';
+import type { WasmBridge } from '@/core/wasm-bridge';
+
+/** 선택 개체 ref — `cursor.selectedPictureRef` 와 정합 (headerFooter optional, [Task #831]). */
+export type ObjectPropsRef = {
+  sec: number;
+  ppi: number;
+  ci: number;
+  type: string;
+  cellPath?: CellPathLike;
+  headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
+};
+
+/** 선택 개체의 현재 속성. */
+export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<string, unknown> {
+  if (ref.type === 'shape') {
+    if (ref.cellPath && ref.cellPath.length > 0) {
+      return wasm.getCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
+    }
+    return wasm.getShapeProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+  }
+  // [Task #831] 머리말/꼬리말 picture 는 별도 API. 미적용 시 본문 lookup 실패 → props 빈/stale
+  // → 회전/대칭 무동작.
+  if (ref.headerFooter) {
+    return wasm.getHeaderFooterPictureProperties(
+      ref.sec,
+      ref.headerFooter.outerParaIdx,
+      ref.headerFooter.outerControlIdx,
+      ref.ppi,
+      ref.ci,
+    ) as unknown as Record<string, unknown>;
+  }
+  if (ref.cellPath && ref.cellPath.length > 0) {
+    return wasm.getCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
+  }
+  return wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+}
+
+/** 선택 개체에 속성을 적용한다. `getObjectProps` 와 같은 분기를 쓴다. */
+export function setObjectProps(
+  wasm: WasmBridge,
+  ref: ObjectPropsRef,
+  props: Record<string, unknown>,
+): unknown {
+  if (ref.type === 'shape') {
+    if (ref.cellPath && ref.cellPath.length > 0) {
+      return wasm.setCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
+    }
+    return wasm.setShapeProperties(ref.sec, ref.ppi, ref.ci, props);
+  }
+  if (ref.headerFooter) {
+    return wasm.setHeaderFooterPictureProperties(
+      ref.sec,
+      ref.headerFooter.outerParaIdx,
+      ref.headerFooter.outerControlIdx,
+      ref.ppi,
+      ref.ci,
+      props,
+    );
+  }
+  if (ref.cellPath && ref.cellPath.length > 0) {
+    return wasm.setCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
+  }
+  return wasm.setPictureProperties(ref.sec, ref.ppi, ref.ci, props);
+}

--- a/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
+++ b/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
 
@@ -88,6 +90,46 @@ test('[#3230] 스냅샷 예산을 쓰지 않는다', () => {
     '역연산 커맨드가 예산을 쓰면 스냅샷에서 옮긴 의미가 없다',
   );
   assert.equal(cmd.discard, undefined, '해제할 WASM 스냅샷 id 가 없어야 한다');
+});
+
+test('[#3230] 달라질 것이 없으면 무변경으로 답한다', () => {
+  // 히스토리는 `command.isNoOp?.()` 로 묻고, 답이 없으면 "항상 바꾼다" 로 읽는다(#2370).
+  // 같은 값을 넣는 커맨드가 침묵하면 Ctrl+Z 한 번을 무효과로 소모하는 팬텀 엔트리가 남는다.
+  const same = new SetObjectPropsCommand(bodyImage, { rotationAngle: 90 }, { rotationAngle: 90 });
+  assert.equal(same.isNoOp(), true);
+
+  const changed = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 90 });
+  assert.equal(changed.isNoOp(), false);
+
+  const flipSame = new SetObjectPropsCommand(bodyImage, { horzFlip: true }, { horzFlip: true });
+  assert.equal(flipSame.isNoOp(), true);
+
+  // `before` 에만 있는 키는 `execute` 가 적용하지 않으므로 판정에 넣지 않는다.
+  const extraBefore = new SetObjectPropsCommand(
+    bodyImage, { rotationAngle: 90, vertFlip: false }, { rotationAngle: 90 },
+  );
+  assert.equal(extraBefore.isNoOp(), true);
+
+  // 적용할 것이 아예 없는 커맨드도 무변경이다.
+  assert.equal(new SetObjectPropsCommand(bodyImage, {}, {}).isNoOp(), true);
+});
+
+test('[#3230] 양식 모드에서 setObjectProps 는 허용 목록에 없다', () => {
+  // `4c668b93` 이 kind:'record' → kind:'command' 로 옮긴 이유가 이것이다 — command 라우팅은
+  // `isOperationAllowedInEditMode` 를 거치고, 그 switch 의 default 가 막는다. 허용 목록에
+  // 'setObjectProps' 가 추가되면 양식 모드에서 개체 회전/대칭이 다시 통과한다.
+  const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+  const start = src.indexOf('private isOperationAllowedInEditMode');
+  assert.notEqual(start, -1, 'isOperationAllowedInEditMode 가 있어야 함');
+  const body = src.slice(start, src.indexOf('\n  }', start));
+
+  assert.doesNotMatch(
+    body,
+    /case\s*'setObjectProps'/,
+    "'setObjectProps' 를 허용하면 양식 모드 개체 편집 차단이 뚫린다",
+  );
+  assert.match(body, /default:\s*\n?\s*return false;/, 'command 는 기본적으로 막혀야 함');
 });
 
 test('[#3230] 회전 15° 를 네 번 눌러도 병합하지 않는다', () => {

--- a/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
+++ b/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+// `engine/command.ts` 는 constructor parameter property 를 쓰므로 Node 의 타입 스트리핑으로는
+// 못 읽는다(`page-margin-guides.test.ts` 와 같은 이유·같은 방식으로 vite SSR 로 띄운다).
+const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+let SetObjectPropsCommand: any;
+let getObjectProps: any;
+let setObjectProps: any;
+
+test('모듈 로드', async () => {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    ({ SetObjectPropsCommand } = await vite.ssrLoadModule('/src/engine/command.ts'));
+    ({ getObjectProps, setObjectProps } = await vite.ssrLoadModule('/src/engine/object-props.ts'));
+  } finally {
+    await vite.close();
+  }
+  assert.equal(typeof SetObjectPropsCommand, 'function');
+});
+
+// [#3230] 개체 속성 변경을 스냅샷에서 역연산으로.
+//
+// 스냅샷 1개는 `Document` 통째 클론이라 문서에 비례한다 — 실측으로 30KB 공문 0.43 MB,
+// 10MB 행정편람 10.59 MB. `SnapshotCommand` 는 before/after 로 2개를 쓰므로 회전 한 번이
+// 최대 21 MB 다. 실제로 되돌려야 하는 것은 스칼라 속성 하나뿐이다.
+//
+// 여기서 고정하는 것은 둘이다 — 역연산이 왕복하는가, 그리고 스냅샷 예산을 쓰지 않는가.
+
+interface Call { fn: string; args: unknown[] }
+
+function recordingWasm(): { wasm: any; calls: Call[] } {
+  const calls: Call[] = [];
+  const rec = (fn: string) => (...args: unknown[]) => {
+    calls.push({ fn, args });
+    return { ok: true };
+  };
+  return {
+    calls,
+    wasm: {
+      setShapeProperties: rec('setShapeProperties'),
+      setPictureProperties: rec('setPictureProperties'),
+      setCellShapePropertiesByPath: rec('setCellShapePropertiesByPath'),
+      setCellPicturePropertiesByPath: rec('setCellPicturePropertiesByPath'),
+      setHeaderFooterPictureProperties: rec('setHeaderFooterPictureProperties'),
+      getShapeProperties: rec('getShapeProperties'),
+      getPictureProperties: rec('getPictureProperties'),
+      getCellShapePropertiesByPath: rec('getCellShapePropertiesByPath'),
+      getCellPicturePropertiesByPath: rec('getCellPicturePropertiesByPath'),
+      getHeaderFooterPictureProperties: rec('getHeaderFooterPictureProperties'),
+    },
+  };
+}
+
+const bodyImage = { sec: 0, ppi: 3, ci: 1, type: 'image' as const };
+
+test('[#3230] undo 는 적용 전 값으로, redo 는 적용 값으로 되돌린다', () => {
+  const { wasm, calls } = recordingWasm();
+  const cmd = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 15 });
+
+  const undoPos = cmd.undo(wasm);
+  assert.deepEqual(calls.at(-1), {
+    fn: 'setPictureProperties',
+    args: [0, 3, 1, { rotationAngle: 0 }],
+  });
+  assert.deepEqual(undoPos, { sectionIndex: 0, paragraphIndex: 3, charOffset: 0 });
+
+  cmd.execute(wasm);
+  assert.deepEqual(calls.at(-1), {
+    fn: 'setPictureProperties',
+    args: [0, 3, 1, { rotationAngle: 15 }],
+  });
+});
+
+test('[#3230] 스냅샷 예산을 쓰지 않는다', () => {
+  const cmd = new SetObjectPropsCommand(bodyImage, { horzFlip: false }, { horzFlip: true }) as any;
+  // 히스토리는 `cmd.snapshotResourceCount?.() ?? 0` 로 예산을 센다(engine/history.ts).
+  assert.equal(
+    cmd.snapshotResourceCount?.() ?? 0,
+    0,
+    '역연산 커맨드가 예산을 쓰면 스냅샷에서 옮긴 의미가 없다',
+  );
+  assert.equal(cmd.discard, undefined, '해제할 WASM 스냅샷 id 가 없어야 한다');
+});
+
+test('[#3230] 회전 15° 를 네 번 눌러도 병합하지 않는다', () => {
+  const cmd = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 15 });
+  assert.equal(
+    cmd.mergeWith(),
+    null,
+    '한컴도 누른 횟수만큼 되돌린다 — 묶으면 되돌리기 단위가 어긋난다',
+  );
+});
+
+test('[#3230] 적용과 되돌리기는 같은 개체를 만진다 — 셀 안', () => {
+  const { wasm, calls } = recordingWasm();
+  const cellPath = [{ controlIndex: 2, cellIndex: 5, cellParaIndex: 0 }];
+  const ref = { sec: 0, ppi: 7, ci: 0, type: 'shape' as const, cellPath };
+  const cmd = new SetObjectPropsCommand(ref, { rotationAngle: 90 }, { rotationAngle: 180 });
+
+  cmd.execute(wasm);
+  cmd.undo(wasm);
+
+  assert.deepEqual(calls.map((c) => c.fn), [
+    'setCellShapePropertiesByPath',
+    'setCellShapePropertiesByPath',
+  ], '셀 안 도형은 양방향 모두 by-path setter 여야 한다');
+  assert.deepEqual(calls[0].args, [0, 7, cellPath, 0, { rotationAngle: 180 }]);
+  assert.deepEqual(calls[1].args, [0, 7, cellPath, 0, { rotationAngle: 90 }]);
+});
+
+test('[#3230] 적용과 되돌리기는 같은 개체를 만진다 — 머리말/꼬리말', () => {
+  const { wasm, calls } = recordingWasm();
+  const ref = {
+    sec: 0,
+    ppi: 1,
+    ci: 0,
+    type: 'image' as const,
+    headerFooter: { kind: 'header' as const, outerParaIdx: 4, outerControlIdx: 2 },
+  };
+  const cmd = new SetObjectPropsCommand(ref, { vertFlip: false }, { vertFlip: true });
+
+  cmd.execute(wasm);
+  cmd.undo(wasm);
+
+  // [Task #831] HF 그림이 본문 lookup 으로 떨어지면 조용히 아무것도 바뀌지 않는다.
+  assert.deepEqual(calls.map((c) => c.fn), [
+    'setHeaderFooterPictureProperties',
+    'setHeaderFooterPictureProperties',
+  ]);
+  assert.deepEqual(calls[0].args, [0, 4, 2, 1, 0, { vertFlip: true }]);
+  assert.deepEqual(calls[1].args, [0, 4, 2, 1, 0, { vertFlip: false }]);
+});
+
+test('[#3230] 조회와 적용이 같은 분기를 쓴다', () => {
+  // before 를 읽은 경로와 되돌릴 때 쓰는 경로가 갈리면 되돌리기가 다른 개체를 만진다.
+  const cases: Array<[any, string, string]> = [
+    [{ sec: 0, ppi: 0, ci: 0, type: 'shape' }, 'getShapeProperties', 'setShapeProperties'],
+    [{ sec: 0, ppi: 0, ci: 0, type: 'image' }, 'getPictureProperties', 'setPictureProperties'],
+    [
+      { sec: 0, ppi: 0, ci: 0, type: 'image', headerFooter: { kind: 'footer', outerParaIdx: 1, outerControlIdx: 0 } },
+      'getHeaderFooterPictureProperties',
+      'setHeaderFooterPictureProperties',
+    ],
+    [
+      { sec: 0, ppi: 0, ci: 0, type: 'image', cellPath: [{ controlIndex: 0, cellIndex: 0, cellParaIndex: 0 }] },
+      'getCellPicturePropertiesByPath',
+      'setCellPicturePropertiesByPath',
+    ],
+  ];
+  for (const [ref, getFn, setFn] of cases) {
+    const { wasm, calls } = recordingWasm();
+    getObjectProps(wasm, ref);
+    setObjectProps(wasm, ref, { rotationAngle: 10 });
+    assert.deepEqual(calls.map((c) => c.fn), [getFn, setFn], `${ref.type} 분기 불일치`);
+    // locator 인자(속성 bag 앞부분)가 양쪽에서 같아야 한다.
+    assert.deepEqual(calls[0].args, calls[1].args.slice(0, -1));
+  }
+});

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -73,9 +73,32 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
   );
 });
 
-test('회전/대칭도 recordObjectMutation 으로 기록한다', () => {
+// [Task #3230] 회전/대칭은 스냅샷에서 **역연산**으로 옮겼다. 가드의 뜻은 그대로다 —
+// "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
+test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordObjectMutation\(ih, 'rotateObject'/, '회전을 snapshot 으로 기록');
+  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.doesNotMatch(
+    rot,
+    /\bsetProps\s*\(/,
+    '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
+  );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordObjectMutation\(ih, 'flipObject'/, '대칭을 snapshot 으로 기록');
+  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.doesNotMatch(
+    flip,
+    /\bsetProps\s*\(/,
+    '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
+  );
+});
+
+test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
+  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+  assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
+  assert.match(
+    block,
+    /refresh:\s*'full'/,
+    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+  );
 });

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,19 +77,36 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /applyAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /applyAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
+});
+
+// [Task #3230 후속] 역연산은 **왕복이 참인 대상에만** 쓴다. 그림·OLE 는
+// `refresh_picture_rotation_layout_for_save` 가 각도와 무관하게 `rotate_image`·flip 0x80000 을
+// 세우고 되돌리는 경로가 없어(object_ops/picture.rs:242-243) 속성 bag 으로 복원되지 않는다.
+test('그림·OLE 는 스냅샷을 유지한다 — 속성 왕복이 참인 역연산이 아니다', () => {
+  const gate = functionBodyFrom(insertSrc, 'function absolutePropChangeIsInvertible');
+  assert.match(
+    gate,
+    /ref\.type === 'shape'/,
+    "역연산 대상은 도형뿐 — 그림·OLE 로 넓히면 rotate_image 가 되돌아가지 않는다",
+  );
+
+  const apply = functionBodyFrom(insertSrc, 'function applyAbsolutePropChange');
+  assert.match(apply, /absolutePropChangeIsInvertible\(ref\)/, '대상 판정을 거쳐야 한다');
+  assert.match(apply, /executeAbsolutePropChange\(/, '참이면 역연산 커맨드');
+  assert.match(apply, /recordObjectMutation\(/, '아니면 종전 스냅샷');
 });
 
 test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,14 +77,14 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
     /\bsetProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
     /\bsetProps\s*\(/,
@@ -92,13 +92,14 @@ test('회전/대칭은 역연산으로 기록한다', () => {
   );
 });
 
-test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
-  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
-  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function executeAbsolutePropChange');
+  assert.match(block, /kind:\s*'command'/, '속성 적용도 편집 허용 검사를 거치는 command 라우터에서 실행');
   assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
   assert.match(
     block,
     /refresh:\s*'full'/,
-    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+    '개체 회전/대칭 뒤 전체 화면 갱신을 유지한다',
   );
+  assert.doesNotMatch(block, /\bsetProps\s*\(/, 'setter를 라우터 전에 호출하면 양식 모드 편집 차단을 우회한다');
 });


### PR DESCRIPTION
관련 이슈: #3230

## 문제

스냅샷 기반 undo 가 문서 크기에 비례해 메모리를 먹습니다. 이 이슈는 "실효 undo 깊이가 49" 로
열려 있는데, 재어 보니 **얕은 쪽이 아니라 비싼 쪽이 문제**였습니다.

`save_snapshot_native` 는 `self.document.clone()` 입니다. 계수 global allocator 로 live
bytes(할당−해제)를 재고 `save_snapshot_native` N회 전후 차이를 N으로 나눈 값입니다
(devel `1a6ce79fd`, `release-test`, N=5/20/40 에서 1개당 값이 세 자리까지 일치 — 선형 확인).

| 문서 | 파일 | 스냅샷 1개 | 현행 예산 98개 |
|---|---|---|---|
| `2010-01-06.hwp` | 0.03 MB | 0.43 MB | 43 MB |
| `2022년 국립국어원 업무계획.hwp` | 0.29 MB | 1.79 MB | 175 MB |
| `exam_kor.hwp` | 9.94 MB | 1.44 MB | 141 MB |
| `2025 행정업무운영 편람(최종).hwp` | 10.19 MB | **10.59 MB** | **1,038 MB** |

`SnapshotCommand` 는 before/after 로 2개를 쓰므로(`snapshotResourceCount()`), **회전 한 번이 큰
문서에서 21.2 MB** 를 undo 스택에 얹습니다. 정작 되돌려야 하는 것은 스칼라 속성 하나입니다.

이 PR 은 예산 상수를 건드리지 않습니다. 스냅샷을 **쓰지 않아도 되는 편집**을 역연산으로 옮겨
압력 자체를 줄이는 쪽입니다(#2337·#2369 가 넓혀 온 축).

## 원인

`applyRotationDelta`·`toggleFlip`(`insert.ts:734`, `insert.ts:752`)이 `recordObjectMutation`
(`insert.ts:660`)을 거치고, 그 헬퍼는 `kind:'snapshot'` 으로 고정돼 있습니다.

```ts
recordObjectMutation(ih, 'rotateObject', () => setProps(services, ref, { rotationAngle: next }));
```

`recordObjectMutation` 은 삭제·묶기/풀기처럼 역연산이 없는 조작까지 함께 받는 공용 헬퍼라
스냅샷이 맞습니다. 하지만 회전·대칭은 성격이 다릅니다 — **역연산 조건 셋을 다 만족**합니다.

- setter 가 **절대값**입니다(`rotationAngle = 30`, `horzFlip = true`. 누적·토글이 아닙니다).
- 호출부가 적용 **전에 현재 값을 이미 읽습니다**(`const cur = props.rotationAngle ?? 0`) —
  다음 각도·토글 반대값을 그것으로 만들기 때문입니다. before 가 이미 손에 있습니다.
- 그 속성만 바뀝니다. 파생 상태(레이아웃·앵커)는 setter 가 다시 계산합니다.

즉 스냅샷을 쓸 이유가 "헬퍼가 그것뿐이라서" 였습니다.

## 변경

**`SetObjectPropsCommand`**(`engine/command.ts`) — before/after 속성 bag 을 들고 `execute` 는
after, `undo` 는 before 를 적용합니다. 뮤테이션은 호출부가 적용하고 이 커맨드는 기록만
담당합니다(`kind:'record'`, #2337 계열). `MoveLineEndpointCommand`·`ResizeObjectCommand` 와 같은
모양입니다.

**속성 라우팅을 `engine/object-props.ts` 로 옮겼습니다.** 되돌리기는 적용과 **같은 개체**를
만져야 하는데, 개체는 위치에 따라 setter/getter 가 넷으로 갈립니다(본문 도형·본문 그림·셀 안
`cellPath`·머리말꼬리말 `headerFooter`). 이 분기가 지금까지 `insert.ts` 안에만 있었고, 커맨드는
`services` 가 아니라 `WasmBridge` 만 받으므로 그 자리에서는 공유할 수 없었습니다. 분기가
갈라지면 HF 그림이 본문 lookup 으로 떨어져 **조용히 아무것도 바뀌지 않습니다**([Task #831] 이
같은 증상으로 열렸던 자리입니다). `insert.ts` 의 `getProps`/`setProps` 는 이 함수들을 부르는
얇은 래퍼로 남습니다.

**`refresh: 'full'` 을 명시합니다.** `kind:'record'` 의 기본 refresh 는 `'none'` 이고
(`input-handler.ts` 의 record 분기), 종전에는 스냅샷 라우팅의 `'full'` 이 `afterEdit()` 를 대신
불러 주고 있었습니다 — 그래서 호출부의 수동 `document-changed` emit 이 [undo P3 정리] 에서
제거됐습니다. 명시하지 않으면 회전이 화면에 반영되지 않습니다.

결과: 회전·대칭 1회의 스냅샷 예산 사용이 **2 → 0**, 메모리가 **최대 21.2 MB → 속성 bag 2개**가
됩니다. 되돌리기 동작·병합 정책·재렌더는 종전과 같습니다.

### 테스트

`rhwp-studio/tests/issue-3230-object-props-inverse.test.ts` (7개) — vite SSR 로 실제 커맨드를
띄워 행위를 봅니다.

- undo 는 적용 전 값으로, redo 는 적용 값으로 왕복한다
- **스냅샷 예산을 쓰지 않는다** (`snapshotResourceCount?.() ?? 0 === 0`, `discard` 없음)
- 회전 15° 를 네 번 눌러도 병합하지 않는다(누른 단위 = 되돌리는 단위)
- 적용과 되돌리기가 같은 개체를 만진다 — 셀 안 / 머리말꼬리말 각각 locator 인자까지 대조
- 조회와 적용이 같은 분기를 쓴다(4종 ref 를 돌며 get/set 쌍의 locator 일치 확인)

`undo-menu-object-ops.test.ts` 의 회전/대칭 가드는 **뜻을 그대로 두고 형태만 옮겼습니다.**
가드의 목적은 "히스토리를 우회하지 않는다" 이고, 우회 형태가 `services.wasm` 직접 호출에서
`setProps` 직접 호출로 바뀌었으므로 그것을 금지합니다. 삭제·z순서·묶기/풀기의 기존 가드는
그대로입니다(그쪽은 여전히 스냅샷입니다).

## 검증

devel `1a6ce79fd56e3cdf5813c7938338fcb5b7d0a859` 기준.

- `npm --prefix rhwp-studio run test` — **966 tests, 0 fail** (skipped 1 은 기존 테스트).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다. 위 메모리 수치는 임시 프로브로 잰
  것이고 커밋에 포함하지 않았습니다(재현 방법은 이슈 #3230 에 적었습니다).

## 범위 외

- **예산 상수 상향** — 하지 않습니다. 위 수치대로 한컴 깊이(실측 256)를 스냅샷으로 채우면 편람
  문서에서 5.4 GB 이고, studio 는 `wasm32` 라 선형 메모리 상한이 4 GB 입니다. 깊이는 상수가
  아니라 표현을 바꿔야 늘어납니다.
- **z순서** — 역연산이 자명해 보이지만(`changeZOrder` 도 `zBefore` 를 이미 읽습니다) `zOrder` 는
  읽기 전용입니다. 절대 setter 가 Rust 쪽에 없어 새 op 이 필요하므로 나눕니다.
- **삭제·묶기/풀기** — 되돌리려면 내용을 들고 있어야 해서 스냅샷이 맞습니다.
- **개체 속성 대화상자(`objectProps`)** — 같은 커맨드로 옮길 수 있어 보이지만,
  `applyPropertyPatchToWasm` 의 각 키가 전부 부작용 없는 절대 setter 인지 확인이 먼저입니다.
  확인 없이 옮기면 되돌리기가 조용히 어긋나므로 이 PR 에 넣지 않았습니다.
