### PR TITLE
docs(test): integration test 제출 절차를 일관되게 정리한다

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@ closes #
 ## 테스트
 
 - [ ] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
-- [ ] `node scripts/rust-test-suite-manifest.mjs --check` 통과
-- [ ] `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
+- [ ] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
+- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
 - [ ] `cargo test` 통과
 - [ ] `cargo clippy -- -D warnings` 통과
 - [ ] 관련 샘플 파일로 SVG 내보내기 확인
@@ -21,6 +21,11 @@ closes #
 - [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
 - [ ] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
 - [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영
+
+> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
+> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
+> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
+> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.
 
 ## 성능 영향 및 측정 결과 (해당하는 경우)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,23 +39,23 @@
 
 ## 문서와 검증
 
-- **PR·push 직전 필수 (건너뛰면 CI Lint 실패)**:
+- **모든 PR·push 직전 필수 (건너뛰면 CI Lint Format check 실패)**:
   ```
   cargo fmt --all
   cargo fmt --all -- --check
-  node scripts/rust-test-suite-manifest.mjs --check
-  node scripts/rust-unit-test-tiers.mjs --check
   ```
   CI Format check 는 `cargo fmt --all -- --check` 이다. `cargo fmt --check` 만으로는
   부족하다. 테스트만 고친 커밋도 다시 돌려야 한다. `--check` 가 실패하면
   `cargo fmt --all` 후 다시 `--check` 가 통과하기 전에는 push 하지 않는다.
-  `src/` 의 `#[cfg(test)]` 줄이 바뀌었거나 devel 과 merge 되면
-  `node scripts/rust-unit-test-tiers.mjs --generate` 후 `--check` 한다.
-- **PR 전 필수**: `cargo fmt --all -- --check`. CI Lint Format check 와 같은 명령이다.
-  `cargo fmt --check` 만으로는 부족하다. 실패하면 `cargo fmt --all` 후 다시 `--check` 가
-  통과하기 전에는 PR 을 만들지 않는다. 이어서
-  `node scripts/rust-test-suite-manifest.mjs --check` 와
-  `node scripts/rust-unit-test-tiers.mjs --check` 도 통과해야 한다.
+- **source-side test 변경 시 추가**: `src/**`의 `#[cfg(test)]`를 변경하면
+  `node scripts/rust-unit-test-tiers.mjs --check`를 실행한다. 이 검사는 source와 정책만 읽고
+  파생 inventory를 만들지 않는다. 진단용 `--generate` 결과는 `tests/generated/unit-test-tiers.json`에
+  남으며 커밋하지 않는다.
+- **review·maintainer worktree와 CI 전용**: 새 integration source는 `tests/cases/` 원본만 PR에
+  포함한다. `node scripts/rust-test-suite-manifest.mjs --prepare`와 manifest `--check`는
+  파생 suite를 준비한 review worktree와 CI에서만 수행한다. generated suite·manifest·Cargo target은
+  검증 증적일 뿐 source PR에 stage하지 않는다. 세부 절차는 `CONTRIBUTING.md`와
+  `mydocs/manual/pr_review/local_validation.md`의 integration test 절을 따른다.
 - 문서 역할·생명주기·canonical 관계는 `mydocs/README.md`의 manifest를 따른다.
 - 문서 이동·정보구조 리팩토링의 링크와 메타데이터 검사는
   `mydocs/manual/markdown_link_check_guide.md`를 따른다. 일반 Markdown 추가·수정에는 자동 CI를 실행하지 않는다.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,21 @@
 # Contributing to rhwp
 
 > **PR·push 차단 게이트 — 하나라도 실패하면 `gh pr create` / `git push` 하지 마세요.**
-> 테스트만 고친 뒤에도 `cargo fmt --all -- --check` 를 다시 돌리세요.
+> 테스트만 고친 뒤에도 `cargo fmt --all -- --check` 를 다시 돌리세요. 일반 기여자의 source PR
+> checkout에서는 generated suite를 준비하지 않습니다.
 >
 > ```bash
 > cargo fmt --all
 > cargo fmt --all -- --check
-> node scripts/rust-test-suite-manifest.mjs --check
-> node scripts/rust-unit-test-tiers.mjs --check
 > ```
 >
 > CI Lint job 의 Format check 는 `cargo fmt --all -- --check` 입니다.
 > `cargo fmt --check` 만으로는 부족합니다. 실패하면 `cargo fmt --all` 로 고친 뒤
 > `--check` 가 통과할 때까지 PR 을 만들지 마세요.
-> `rust-unit-test-tiers --check`는 source와 추적 정책만 읽으며 파생 inventory를 만들거나 stage하지 않습니다.
+> `src/**`의 `#[cfg(test)]`를 바꾼 경우에는 추가로
+> `node scripts/rust-unit-test-tiers.mjs --check`를 실행하세요. 이 검사는 source와 추적 정책만
+> 읽으며 파생 inventory를 만들거나 stage하지 않습니다. 반면
+> `rust-test-suite-manifest.mjs --prepare`와 manifest `--check`는 review worktree와 CI만 수행합니다.
 
 rhwp에 관심을 가져주셔서 감사합니다!
 
@@ -155,6 +157,7 @@ cargo install cargo-nextest --locked             # 최초 1회
 cargo fmt --all                                  # 로컬 포맷 적용
 cargo fmt --all -- --check                       # CI와 같은 포맷 검증 — PR 전 필수
 node --test scripts/tests/rust-test-suite-manifest.test.mjs
+# `src/**`의 `#[cfg(test)]`를 변경한 경우에만 실행한다. 파생 파일은 생성하지 않는다.
 node scripts/rust-unit-test-tiers.mjs --check
 cargo nextest run \
   --cargo-profile release-test \
@@ -170,8 +173,10 @@ cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트
 새 통합 테스트는 `tests/cases/` 에만 둡니다. `tests/suites/suite-policy.json`,
 `tests/suites/unit-test-tier-policy.json`은 추적하는 정책이고, `tests/generated/`, `tests/suites/manifest.json`,
 `tests/generated/**`, Cargo의 generated test target 블록은 **PR에 넣지 않는 파생 산출물**입니다. 일반 기여자는 자신의 PR checkout에서 `--prepare`, `--generate`,
-`--sync`, `--rebalance`, `--check`를 실행해 이를 등록하지 않습니다. 새 원본의 배정과
-harness 검증은 PR review 전용 worktree 및 CI가 `--prepare` 뒤 `--check`로 수행합니다.
+`--sync`, `--rebalance`, 또는 `rust-test-suite-manifest.mjs --check`를 실행해 이를 등록하지 않습니다.
+`rust-unit-test-tiers.mjs --check`는 source-side `#[cfg(test)]` 변경의 정책 검사로만 실행할 수 있으며
+파일을 생성하지 않습니다. 새 원본의 배정과 harness 검증은 PR review 전용 worktree 및 CI가
+`--prepare` 뒤 manifest `--check`로 수행합니다.
 로컬에서는 위 계약 단위 테스트와 필요한 Rust 회귀 테스트만 실행하세요.
 
 - `release-test` 프로필은 PR CI와 같은 기준이며 debug 대비 수 배 빠릅니다.

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -112,8 +112,9 @@ node scripts/run-rust-test.mjs <확장자를_뺀_test_source_이름>
 
 제품 소스의 기존 `#[cfg(test)]`는 의존성에 따라 `integration_ready`, `test_support`, `white_box`로
 차등 관리한다. root `src/`와 내부 `crates/*/src/`를 모두 검사한다. 신규 소스 테스트 모듈과 test
-support 항목은 추가하지 않고 공개 API 회귀는 `tests/cases/`로 보낸다. 다음 계약 검사는 기존 기준선의
-증가를 차단하지만 테스트를 외부로 이동하거나 production crate와 함께 분리하는 변경은 허용한다.
+support 항목은 추가하지 않고 공개 API 회귀는 `tests/cases/`로 보낸다. source-side `#[cfg(test)]`를
+변경한 기여자는 다음 계약 검사를 실행할 수 있다. 이 검사는 manifest 준비와 별개로 source·정책만 읽는다.
+기존 기준선의 증가는 차단하지만 테스트를 외부로 이동하거나 production crate와 함께 분리하는 변경은 허용한다.
 
 ```bash
 node --test scripts/tests/rust-unit-test-tiers.test.mjs

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -61,8 +61,9 @@ node scripts/run-rust-test.mjs issue_1234_short_description \
 검증이 끝나면 이 파생 변경은 review worktree에서 복원한다. `--prepare`가 이름 변경·삭제와 신규 source를
 함께 처리하므로 일반 PR에 `--generate`·`--sync`·`--rebalance` 결과를 포함하지 않는다. 기여자가
 PR 전 검증으로 실행할 명령은 `node --test scripts/tests/rust-test-suite-manifest.test.mjs`와 변경 범위의
-Rust test이며, 파생 파일 일치 검사는 review worktree와 CI의 책임이다. 경로·crate-root 의존성이 탐지된
-source는 생성기가 singleton exception으로 보존한다.
+Rust test이며, source-side `#[cfg(test)]`를 바꾼 경우에는 `node scripts/rust-unit-test-tiers.mjs --check`도
+실행한다. 이 unit-tier 검사는 파생 파일을 만들지 않는다. 반면 manifest 파생 파일 일치 검사는 review
+worktree와 CI의 책임이다. 경로·crate-root 의존성이 탐지된 source는 생성기가 singleton exception으로 보존한다.
 
 제품 소스의 `#[cfg(test)]`는 root `src/`와 내부 `crates/*/src/`의 기존 모듈별 테스트 수와 test
 support 항목을 기준선으로 관리한다.

--- a/mydocs/working/task_m100_5571_stage1_integration_test_submission_guidance.md
+++ b/mydocs/working/task_m100_5571_stage1_integration_test_submission_guidance.md
@@ -1,0 +1,28 @@
+# #5571 기여자·검토자 integration test 제출 절차 정리
+
+## 목표
+
+새 integration test의 기여자 제출 경로와 review worktree·CI의 파생 suite 준비 경로를
+문서에서 일관되게 분리한다.
+
+## 관측 근거
+
+- PR #5550은 `tests/agent_cli_pack_contract.rs`를 최상위 `tests/`에 제출해 CI 정책에 의해 거부됐다.
+- `CONTRIBUTING.md`의 회귀 테스트 절은 원본을 `tests/cases/`에만 두고 일반 기여자가
+  manifest 준비를 하지 않는다고 설명한다.
+- 같은 문서의 앞부분과 PR 템플릿은 모든 PR에 manifest `--check`를 요구해, 준비되지 않은 source
+  checkout에서도 파생 결과를 다루도록 유도했다.
+
+## 결정
+
+1. 기여자는 새 원본을 `tests/cases/*.rs`에만 추가하고 generated suite·manifest·Cargo generated target을
+   커밋하지 않는다.
+2. `rust-test-suite-manifest.mjs --prepare`와 manifest `--check`는 review worktree·CI만 수행한다.
+3. `rust-unit-test-tiers.mjs --check`는 source-side `#[cfg(test)]` 변경에서만 실행할 수 있는 무생성
+   정책 검사로 별도 표기한다.
+4. PR 템플릿, 기여 안내, 에이전트 지침, 개발·검토 안내를 같은 역할 구분으로 갱신한다.
+
+## 범위 제외
+
+- test 정책, 자동 배정 스크립트, CI workflow의 동작은 변경하지 않는다.
+- PR #5550의 test 파일 이동은 해당 source PR의 메인터너 보정 범위다.


### PR DESCRIPTION
## 변경 요약

- 일반 기여자는 새 integration source를 `tests/cases/*.rs` 원본으로만 제출하도록 PR 템플릿을 보정했습니다.
- `rust-test-suite-manifest.mjs --prepare` 및 manifest `--check`를 review worktree·CI 전용 절차로 분리했습니다.
- source-side `#[cfg(test)]` 변경에만 무생성 `rust-unit-test-tiers.mjs --check`를 실행하도록 기여 안내, 에이전트 지침, 개발·검토 문서를 일치시켰습니다.

closes #5571

## 검증

- `cargo fmt --all -- --check`
- `git diff --check`

문서 전용 변경으로 Rust·frontend 테스트는 실행하지 않았습니다.