### PR TITLE
docs: PR #5572 검토 기록과 오늘할일을 보존한다

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -37,3 +37,10 @@ date: 2026-08-19
 - `cargo fmt --all -- --check`, suite manifest 정책, source-side unit tier 정책과 최신 code candidate의 Full CI·CodeQL·Native Skia·Render Diff는 통과했다.
 - [PR #5548 검토 기록](../pr/archives/pr_5548_review.md)과 이 항목은 CI 성공 뒤 같은 docs-only trailing commit으로 contributor source branch에 push한다.
 - trailing head의 aggregate와 mergeability를 다시 확인한 뒤 승인 절차에 따라 merge하며, `closes #5534`의 auto-close와 후속 comment·branch/worktree 정리를 확인한다.
+
+## #5572 integration test 제출 절차 문서 정합
+
+- PR [#5572](https://github.com/edwardkim/rhwp/pull/5572)는 기여자 source PR, PR review worktree, CI의 파생 suite 책임을 분리했다.
+- merge commit은 `c7106572af238804bb5fe4a34f326b46af3cbccf`이며, issue [#5571](https://github.com/edwardkim/rhwp/issues/5571)은 closing keyword로 자동 종료됐다.
+- 로컬에서 `cargo fmt --all -- --check`와 `git diff --check`를 통과했다. 최신 head의 CI preflight, Lint, package gate, Native Skia, test archive, slow·regular shard, CodeQL, Build & Test aggregate도 모두 통과했다.
+- 사용자 지시에 따라 merge 뒤 옵션 B의 별도 문서 전용 PR로 [PR #5572 검토 기록](../pr/archives/pr_5572_review.md)과 이 완료 기록을 보존한다.

--- a/mydocs/pr/archives/pr_5572_review.md
+++ b/mydocs/pr/archives/pr_5572_review.md
@@ -1,0 +1,67 @@
+---
+kind: pr-review
+status: completed
+pr: 5572
+issue: 5571
+base: devel
+source_head: 72b72683101181f2348ce9a9d07775139d2e6dd4
+merge_commit: c7106572af238804bb5fe4a34f326b46af3cbccf
+---
+
+# PR #5572 integration test 제출 절차 문서 정합 검토
+
+## 라우팅
+
+```text
+base route: collaborator self-merge
+modifiers: PR 접수와 리뷰 기록, review-only fast-pass, merge 후속 처리
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, review_only_fast_pass.md,
+post_merge.md
+```
+
+## PR metadata
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#5572](https://github.com/edwardkim/rhwp/pull/5572) |
+| 작성자 | `jangster77` |
+| base | `devel` |
+| source head | `72b72683101181f2348ce9a9d07775139d2e6dd4` |
+| merge commit | `c7106572af238804bb5fe4a34f326b46af3cbccf` |
+| 관련 이슈 | [#5571](https://github.com/edwardkim/rhwp/issues/5571) |
+| merge 시점 | 2026-08-19 06:12 UTC |
+
+## 변경 범위와 판정
+
+- PR 템플릿은 새 integration test가 `tests/cases/*.rs` 원본만 포함하도록 고쳤다.
+- `rust-test-suite-manifest.mjs --prepare`와 manifest `--check`는 review worktree와 CI 전용으로 명시했다.
+- source-side `#[cfg(test)]` 변경에서만 `rust-unit-test-tiers.mjs --check`를 실행하도록 기여자·에이전트·개발·검토 문서를 정렬했다.
+- renderer, fixture, Rust 제품 코드, test 정책, CI workflow 변경이 없으므로 시각 검증은 적용 대상이 아니다.
+
+## 검증 기록
+
+### 로컬
+
+- `cargo fmt --all -- --check`: 통과
+- `git diff --check`: 통과
+- 문서 전용 변경이므로 Rust·frontend test는 실행하지 않았다.
+
+### GitHub Actions
+
+최신 source head에서 다음 검증이 모두 통과했다.
+
+- [CI workflow](https://github.com/edwardkim/rhwp/actions/runs/32221552387): CI preflight, Lint, Frontend package gate, Native Skia, Build test archive, slow shard, regular shard 1/3·2/3·3/3, Build & Test aggregate
+- [CodeQL workflow](https://github.com/edwardkim/rhwp/actions/runs/32221552237): preflight와 JavaScript/TypeScript·Python·Rust 분석
+- [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/32221552163): preflight와 prop roundtrip
+- [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/32221552184): 통과
+
+영향 정책상 Frontend unit gate와 WASM Build는 skipped였고, aggregate는 성공했다.
+
+## 결론과 후속 처리
+
+**병합 완료.** 최신 head가 `MERGEABLE`·`CLEAN`이고 required check가 모두 성공한 뒤 squash merge했다.
+
+- issue [#5571](https://github.com/edwardkim/rhwp/issues/5571)은 `closes #5571`로 자동 종료된 것을 확인했다.
+- 사용자가 지정한 옵션 B에 따라 이 archive와 오늘할일은 별도 review-only 문서 PR로 보존한다.
+- 이 후속 기록 PR이 병합되면 원 PR·이슈 기록을 중복 게시하지 않고, 작업 branch 정리만 수행한다.


### PR DESCRIPTION
## 변경 요약

- 병합된 PR #5572의 archive review에 실제 merge SHA, 로컬 검증, GitHub Actions 결과를 기록합니다.
- 2026-08-19 오늘할일에 #5572와 #5571의 완료·자동 종료 사실을 남깁니다.

## 검증

- `cargo fmt --all -- --check`
- `git diff --check`

전체가 `mydocs/` 변경인 review-only fast-pass 후보입니다. 이 후속 기록 PR이 병합되면 원 PR·이슈 기록을 다시 갱신하지 않습니다.