### PR TITLE
fix(serializer/hwpx): 문단 축을 넘는 lineseg 를 저장하지 않는다 — 한글 개방 무한 정지 (#5563)

### DIFF
--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -1202,15 +1202,30 @@ fn line_segs_within_text(
     layout_only_fill_lines: usize,
 ) -> &[LineSeg] {
     let real = line_segs.len().saturating_sub(layout_only_fill_lines);
-    let in_range = line_segs[..real]
-        .iter()
-        .position(|seg| seg.text_start > char_count)
-        .unwrap_or(real);
-    if in_range == 0 {
+    let in_range = line_segs_within_text_axis(&line_segs[..real], char_count);
+    if in_range.is_empty() {
         line_segs
     } else {
-        &line_segs[..in_range]
+        in_range
     }
+}
+
+/// [#5563] 문단 축을 넘어서지 않는 줄만 남긴 접두부.
+///
+/// 판정(`>` 경계·접두부만 남기는 이유)은 위 `line_segs_within_text` 주석이 정본이다.
+/// HWP5 저장기와 HWPX 저장기가 **같은 규칙**을 써야 하므로 그 판정만 여기로 떼어
+/// 둘이 공유한다 — HWPX 쪽은 조판 전용 보강 줄 계약(#4677)을 갖지 않으므로 축
+/// 판정만 필요하다.
+///
+/// 첫 줄부터 범위 밖이면 빈 슬라이스를 돌려준다. 무엇을 할지는 호출부가 정한다 —
+/// HWP5 는 원본을 그대로 두고(문단 자체가 비정상), HWPX 는 `linesegarray` 를 통째로
+/// 생략해 한글이 스스로 조판하게 한다(#1380 과 같은 계약).
+pub(crate) fn line_segs_within_text_axis(line_segs: &[LineSeg], char_count: u32) -> &[LineSeg] {
+    let in_range = line_segs
+        .iter()
+        .position(|seg| seg.text_start > char_count)
+        .unwrap_or(line_segs.len());
+    &line_segs[..in_range]
 }
 
 /// PARA_LINE_SEG 직렬화

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1083,6 +1083,16 @@ pub fn diff_linesegs(a: &Document, b: &Document) -> Vec<LinesegDiff> {
     out
 }
 
+/// [#5563] 비교 대상이 되는 줄 — 저장기가 실제로 파일에 실을 수 있는 접두부.
+fn axis_comparable_line_segs(
+    para: &crate::model::paragraph::Paragraph,
+) -> &[crate::model::paragraph::LineSeg] {
+    if para.char_count == 0 {
+        return &para.line_segs;
+    }
+    crate::serializer::body_text::line_segs_within_text_axis(&para.line_segs, para.char_count)
+}
+
 /// 문단 1쌍의 lineseg 비교 + 컨트롤 내부 문단 재귀 (`diff_paragraph_char_shapes` 와
 /// 동일 경로 순회).
 fn diff_paragraph_linesegs(
@@ -1095,8 +1105,12 @@ fn diff_paragraph_linesegs(
 ) {
     use crate::model::control::Control;
 
-    let la = &pa.line_segs;
-    let lb = &pb.line_segs;
+    // [#5563] 문단 축을 넘어서는 줄은 저장기가 파일에 싣지 않는다(HWPX·HWP5 공통
+    // 계약 — `line_segs_within_text_axis`). 비교에서도 같은 규칙을 먼저 걸어야
+    // "저장할 수 없는 줄"이 IR 차이로 잡히지 않는다. 축 증거가 없는 합성 IR
+    // (`char_count == 0`)은 종전대로 전부 비교한다.
+    let la = axis_comparable_line_segs(pa);
+    let lb = axis_comparable_line_segs(pb);
     if la.len() != lb.len() {
         out.push(LinesegDiff {
             section,

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -38,6 +38,7 @@ use crate::model::shape::{
 };
 
 use crate::parser::tags;
+use crate::serializer::body_text::line_segs_within_text_axis;
 
 use super::context::SerializeContext;
 use super::field::{
@@ -734,16 +735,35 @@ pub(crate) fn render_paragraph_parts(
     // 한글 2022 가 만나면 **그 문단부터 문서 끝까지 본문을 통째로 폐기**한다
     // (성년후견 h2x: -112,075자 실측 — lineseg 억제만으로 전량 회복). 방출을
     // 생략하면 한글이 열 때 재계산한다(#1380 과 같은 계약).
-    if !para.line_segs.is_empty() && position_axis_intact {
+    // [#5563] 문단 축을 넘어서는 `textpos` 를 실은 줄은 내보내지 않는다. 원본이
+    // 들고 있던 낡은 줄나눔 캐시가 그대로 옮겨 실리면(07990: 5개 문단이 길이 15 에
+    // textpos 119 등) 한글 2022 가 "다음 줄은 119번째 글자에서 시작"을 14글자 문단에서
+    // 해소하려다 **파일 개방이 끝나지 않는다**(COM Open 3,663초 미반환 실측). rhwp 는
+    // 자기가 쓴 파일을 그대로 다시 읽으므로 `--verify` 로는 잡히지 않는다.
+    //
+    // 판정은 HWP5 저장기의 #4677 계약(`line_segs_within_text_axis`)을 그대로 쓴다 —
+    // 경계 `text_start == char_count` 는 정상(한컴 자신이 쓰는 값)이라 `>` 이고, 범위
+    // 밖이 나오면 그 앞까지만 남긴다. 첫 줄부터 범위 밖이면 요소를 통째로 생략해
+    // 한글이 스스로 조판하게 한다(#1380 과 같은 계약).
+    //
+    // `char_count` 가 0 인 합성 IR(파서를 거치지 않은 문단)은 축 증거가 없으므로
+    // 종전대로 원본 줄을 그대로 낸다.
+    let axis_line_segs = if para.char_count > 0 {
+        line_segs_within_text_axis(&para.line_segs, para.char_count)
+    } else {
+        &para.line_segs[..]
+    };
+
+    if !axis_line_segs.is_empty() && position_axis_intact {
         // IR 기반 출력 — 원본 lineseg 값 보존 (#177)
         //
         let linesegs = format!(
             "{}{}{}",
             LINESEG_SLOT_OPEN,
-            render_lineseg_array_from_ir(&para.line_segs),
+            render_lineseg_array_from_ir(axis_line_segs),
             LINESEG_SLOT_CLOSE
         );
-        let vert_end = next_vert_cursor_from_ir(&para.line_segs, vert_start);
+        let vert_end = next_vert_cursor_from_ir(axis_line_segs, vert_start);
         (runs_xml, linesegs, vert_end)
     } else {
         // IR 에 line_segs 없음 — linesegarray 방출 생략 (#1380)

--- a/tests/cases/issue_5563_hwpx_lineseg_axis.rs
+++ b/tests/cases/issue_5563_hwpx_lineseg_axis.rs
@@ -1,0 +1,107 @@
+//! [Issue #5563] 문단 축을 넘어서는 `textpos` 를 실은 `hp:lineseg` 는 저장하지 않는다.
+//!
+//! 원본이 들고 있던 낡은 줄나눔 캐시가 HWPX 산출에 그대로 옮겨 실리면(07990: 길이
+//! 15 문단에 `textpos=119` 등 5개 문단) 한글 2022 가 "다음 줄은 119번째 글자에서
+//! 시작"을 14글자 문단에서 해소하려다 **파일 개방이 끝나지 않는다**(COM `Open()`
+//! 3,663초 미반환). rhwp 는 자기가 쓴 파일을 그대로 다시 읽으므로 `--verify` 로는
+//! 보이지 않는다.
+//!
+//! 판정은 HWP5 저장기의 #4677 계약과 같다 — 경계 `text_start == char_count` 는
+//! 한컴 자신이 쓰는 정상값이라 `>` 이고, 범위 밖이 나오면 그 앞까지만 남긴다.
+
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::serializer::hwpx::context::SerializeContext;
+use rhwp::serializer::hwpx::section::write_section;
+
+fn seg(text_start: u32) -> LineSeg {
+    LineSeg {
+        text_start,
+        vertical_pos: 0,
+        line_height: 1000,
+        text_height: 1000,
+        baseline_distance: 850,
+        line_spacing: 600,
+        column_start: 0,
+        segment_width: 42520,
+        tag: 393_216,
+    }
+}
+
+/// 텍스트 3글자(끝 마커 포함 `char_count=4`) 문단에 주어진 줄들을 실어 section XML 을 얻는다.
+fn section_xml(line_segs: Vec<LineSeg>) -> String {
+    let mut para = Paragraph::default();
+    para.text = "가나다".to_string();
+    para.char_offsets = vec![0, 1, 2];
+    para.char_count = 4; // 글자 3 + 끝 마커 1
+    para.line_segs = line_segs;
+
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    let mut doc = Document::default();
+    doc.sections.push(section.clone());
+    let mut ctx = SerializeContext::collect_from_document(&doc);
+    let bytes = write_section(&section, &doc, 0, &mut ctx).expect("section 직렬화");
+    String::from_utf8(bytes).expect("UTF-8 section XML")
+}
+
+/// 계약 1 — 범위 밖 줄부터 잘라 내고 그 앞 접두부만 남는다.
+#[test]
+fn line_segs_beyond_paragraph_axis_are_dropped() {
+    let xml = section_xml(vec![seg(0), seg(2), seg(99)]);
+
+    assert!(xml.contains(r#"textpos="0""#), "첫 줄은 남아야 함: {xml}");
+    assert!(xml.contains(r#"textpos="2""#), "범위 안 줄은 남아야 함");
+    assert!(
+        !xml.contains(r#"textpos="99""#),
+        "문단 축(4)을 넘는 줄은 저장되면 안 됨"
+    );
+}
+
+/// 계약 2 — 경계값 `text_start == char_count` 는 한컴 자신이 쓰는 정상값이라 남는다.
+#[test]
+fn line_seg_at_exact_axis_end_is_kept() {
+    let xml = section_xml(vec![seg(0), seg(4)]);
+
+    assert!(xml.contains(r#"textpos="4""#), "끝을 가리키는 줄은 정상값");
+}
+
+/// 계약 3 — 첫 줄부터 범위 밖이면 `linesegarray` 를 통째로 생략한다(한글이 스스로 조판).
+#[test]
+fn all_out_of_axis_line_segs_drop_the_whole_array() {
+    let xml = section_xml(vec![seg(7), seg(12)]);
+
+    assert!(
+        !xml.contains("<hp:linesegarray"),
+        "전부 범위 밖이면 요소를 내지 않는다: {xml}"
+    );
+}
+
+/// 계약 4 — 저장할 수 없는 줄은 IR 왕복 비교에서도 차이로 잡히지 않는다.
+///
+/// 이 규칙이 없으면 `export-hwpx --verify` 가 자기 계약대로 버린 줄을 "재파싱 후 IR
+/// 차이" 로 신고해 exit 3 이 된다.
+#[test]
+fn out_of_axis_line_segs_are_not_reported_as_ir_difference() {
+    fn doc_with(line_segs: Vec<LineSeg>) -> Document {
+        let mut para = Paragraph::default();
+        para.text = "가나다".to_string();
+        para.char_offsets = vec![0, 1, 2];
+        para.char_count = 4;
+        para.line_segs = line_segs;
+        let mut section = Section::default();
+        section.paragraphs.push(para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+        doc
+    }
+
+    let source = doc_with(vec![seg(0), seg(2), seg(99)]);
+    let reparsed = doc_with(vec![seg(0), seg(2)]);
+
+    let diffs = rhwp::serializer::hwpx::roundtrip::diff_linesegs(&source, &reparsed);
+    assert!(
+        diffs.is_empty(),
+        "저장 못 하는 줄은 비교 대상이 아니어야 함: {diffs:?}"
+    );
+}


### PR DESCRIPTION
## 변경 요약

rhwp 가 HWP5 → HWPX 로 저장한 산출을 한글 2022 가 **열지 못하고 무한 정지**한다. 원본이 들고 있던 낡은 줄나눔 캐시(`hp:lineseg`)가 산출에 그대로 옮겨 실려, **문단 실제 길이를 넘는 `textpos`** 가 파일에 들어가기 때문이다. 07990 에서 5개 문단이 위반한다 — 예: 본문 14글자(`char_count=15`) 문단에 `textpos = [0, 97, 119]`. 한글은 "다음 줄은 119번째 글자에서 시작"을 14글자 문단에서 해소하려다 `Open()` 이 3,663초까지 반환하지 않는다(이슈 실측 7회). rhwp 는 자기가 쓴 파일을 그대로 다시 읽으므로 `--verify` 로는 보이지 않는다.

**수정** — 저장 시 문단 축을 넘어서는 줄은 내보내지 않는다.

- 판정은 HWP5 저장기가 이미 쓰고 있는 **#4677 계약** 그대로다. 경계 `text_start == char_count` 는 한컴 자신이 빈 문단·개체 셀에 쓰는 정상값이라 판정은 `>` 이고, 범위 밖이 나오면 **그 앞 접두부만** 남긴다. 그 판정만 `line_segs_within_text_axis` 로 떼어 HWP5·HWPX 저장기가 공유한다(새 규칙을 만들지 않았다).
- 첫 줄부터 범위 밖이면 `linesegarray` 를 통째로 생략해 한글이 스스로 조판하게 한다 — #1380 과 같은 계약.
- `char_count == 0` 인 합성 IR(파서를 거치지 않은 문단)은 축 증거가 없으므로 종전대로 원본 줄을 그대로 낸다.
- IR 왕복 비교(`diff_linesegs`)에도 같은 규칙을 먼저 건다. 이게 없으면 저장기가 계약대로 버린 줄이 "재파싱 후 IR 차이"로 신고돼 `export-hwpx --verify` 가 exit 3 이 된다.

## 관련 이슈

closes #5563

## 검증

**07990(`1262000-201900020_D0150012-1-000_4. 연구계획서.hwp`, 이슈 재현 문서)**

| 지표 | 수정 전 | 수정 후 |
|---|---|---|
| 산출의 축 위반 문단 | **5** | **0** |
| `export-hwpx --verify` | exit 0 (위반을 그대로 실어 통과) | exit 0 |
| rhwp 쪽수(산출) | 19 | 19 |
| 본문 해시(공백 줄 제외, 원본 대비) | 동일 | **동일** |

산출에서 실제로 사라진 것은 낡은 캐시가 만들던 **유령 빈 줄 8바이트**뿐이고, 글자는 원본과 1바이트도 다르지 않다(원본·수정 전·수정 후 세 산출의 비-공백 본문 해시가 모두 `a1f0d9fe…`).

**회귀 — 10k 코퍼스 표본 150문서 before/after 대조**

- `export-hwpx --verify` exit 변화 **0**
- 쪽수 변화 **0**
- 본문(비-공백) 해시 변화 **0**
- 산출 `hp:lineseg` 개수 변화 **0** (이 표본에는 위반 문서가 없었다 — 아래 한계 참조)

**테스트**

- `cargo test -p rhwp --lib` **3,893 통과 / 0 실패**
- `regression_suite_019`(hwpx 왕복 계약) 111 통과, `regression_suite_024` 117 통과
- 인접 계약 개별 통과 — `issue_2527_empty_lineseg_reflow`, `issue_4397_ruby_hwp5_roundtrip`, `issue_4398_orphan_fieldend`
- 신규 계약 `tests/cases/issue_5563_hwpx_lineseg_axis.rs` 4건 — ① 범위 밖 줄부터 잘림 ② 경계값 `text_start == char_count` 는 남음 ③ 전부 범위 밖이면 요소 생략 ④ 저장 못 하는 줄은 IR 비교에서 차이로 잡히지 않음

## 한계 (범위 밖으로 남는 것)

- **한글 오라클 재확인은 미실시**다 — 로컬·CI 에 한글 2022 가 없다. 이슈의 결정적 검정(위반 문단의 `linesegarray` 제거 → 한글이 즉시 개방)과 같은 방향이고, 이 수정은 그보다 보수적으로 범위 안 접두부를 남긴다.
- 이번 판정 기준은 **원본 축(`char_count`)** 이다. 저장기가 표현하지 못하는 컨트롤을 떨궈 **산출 축이 `char_count` 보다 짧아지는** 갈래는 #4778 가드가 일부만 덮는다. 이슈가 센 h2x 258 / 6,539 는 산출 기준 집계라 이 수정만으로 전부 사라진다고 주장하지 않는다 — 코퍼스 700문서 산출 전수 대조를 돌리는 중이며 결과는 이 PR 코멘트로 붙이겠다.
- 뿌리는 #4771(파생 조판 상태를 원본 IR 과 분리)이다. 이 PR 은 그 재설계 전까지 한글 개방을 막는 값만 파일에서 걷어낸다.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `node scripts/rust-unit-test-tiers.mjs --check` 통과
- [x] `cargo test` 통과 (lib 전수 + 관련 통합 스위트 — 위 목록)
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 렌더 경로 변경 아님(저장 경로 한정), 대신 산출 쪽수·본문 해시로 대체 측정
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음
- [ ] rhwp-studio 편집·UI 변경 — 해당 없음

## 성능 영향 및 측정 결과

- 예상 영향: 없음. 문단당 `line_segs` 를 한 번 훑는 선형 검사 하나가 추가된다.
- 재현·측정: 150문서 배치에서 `export-hwpx` 실패·타임아웃 증가 없음.
