### PR TITLE
ci(adapter): 문서 전용 PR에서 inter-diff를 건너뛴다

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -23,10 +23,59 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  adapter-impact:
+    name: adapter inter-diff preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      adapter_required: ${{ steps.classify.outputs.adapter_required }}
+      reason: ${{ steps.classify.outputs.reason }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify adapter inter-diff impact
+        id: classify
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" != "pull_request" || -z "${BASE_SHA}" || -z "${HEAD_SHA}" ]]; then
+            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
+            echo "reason=full-non-pr-event" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! changed_files="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"; then
+            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
+            echo "reason=fail-closed-pr-diff-unavailable" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -z "${changed_files}" ]]; then
+            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
+            echo "reason=fail-closed-empty-pr-diff" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if printf '%s\n' "${changed_files}" | grep -qv '^mydocs/'; then
+            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
+            echo "reason=full-non-documentation-change" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "adapter_required=false" >> "$GITHUB_OUTPUT"
+          echo "reason=skip-mydocs-only-pr" >> "$GITHUB_OUTPUT"
+
   adapter-diff:
     name: adapter inter-diff
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: adapter-impact
+    if: ${{ always() && needs.adapter-impact.result == 'success' && needs.adapter-impact.outputs.adapter_required == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/mydocs/working/task_m100_5575_stage1_adapter_docs_fast_pass.md
+++ b/mydocs/working/task_m100_5575_stage1_adapter_docs_fast_pass.md
@@ -1,0 +1,28 @@
+# #5575 Adapter inter-diff 문서 전용 fast-pass
+
+## 배경
+
+PR #5573은 `mydocs/**` 두 파일만 바꾼 검토 기록 PR이었다. 중앙 CI, CodeQL, Proptest는
+fast-pass로 무거운 lane을 건너뛰었지만, 독립 `Adapter inter-diff` workflow는 항상 전체
+adapter harness를 실행해 2분 9초가 추가됐다.
+
+## 원인
+
+`adapter-diff.yml`은 중앙 CI preflight 결과를 소비하지 않고 모든 `pull_request`에서
+`adapter-diff` job을 실행한다. workflow-level `paths-ignore`는 required check 자체를
+사라지게 해 pending 위험이 있으므로 해결책이 될 수 없다.
+
+## 변경 계획
+
+1. 항상 실행되는 `adapter inter-diff preflight` job에서 PR base/head diff를 확인한다.
+2. 변경 파일이 비어 있지 않고 전부 `mydocs/**`일 때만 adapter job을 skip한다.
+3. 비문서 변경, PR이 아닌 trigger, base/head 또는 diff 오류는 fail-closed로 전체 adapter
+   검증을 유지한다.
+4. workflow test로 skip gate, full-history diff, fail-closed 분기와 `paths-ignore` 부재를
+   고정한다.
+
+## 완료 기준
+
+- 문서 전용 PR에서 `adapter inter-diff` check가 `skipped` 상태로 남는다.
+- 코드와 fixture, CI, 테스트 또는 알 수 없는 변경은 기존 adapter 검증을 실행한다.
+- push와 수동 실행은 전체 검증을 유지한다.

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -32,9 +32,23 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertTrue(CI_SCENE.is_file(), "CI 픽스처가 없다")
 
     def test_runs_on_pull_request(self) -> None:
-        """PR 마다 도는 always-on job. nightly 전용 스윕이 아니다."""
+        """PR마다 stable check를 남기되 문서 전용은 본 검증을 건너뛴다."""
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
+
+    def test_mydocs_only_pr_skips_adapter_job_but_keeps_a_stable_check(self) -> None:
+        self.assertIn("adapter-impact:", self.wf)
+        self.assertIn("name: adapter inter-diff preflight", self.wf)
+        self.assertIn("fetch-depth: 0", self.wf)
+        self.assertIn('git diff --name-only "${BASE_SHA}" "${HEAD_SHA}"', self.wf)
+        self.assertIn("grep -qv '^mydocs/'", self.wf)
+        self.assertIn("adapter_required=false", self.wf)
+        self.assertIn("reason=fail-closed-pr-diff-unavailable", self.wf)
+        self.assertIn("needs: adapter-impact", self.wf)
+        self.assertIn(
+            "needs.adapter-impact.outputs.adapter_required == 'true'", self.wf
+        )
+        self.assertNotIn("paths-ignore:", self.wf)
 
     def test_is_cheap(self) -> None:
         self.assertNotIn("--features native-skia", self.wf)


### PR DESCRIPTION
## 요약

- `mydocs/**`만 변경한 PR에서 Adapter inter-diff의 전체 harness를 실행하지 않도록 독립 preflight를 추가합니다.
- workflow-level `paths-ignore` 대신 job-level `if`를 사용해 `adapter inter-diff` check 이름은 계속 남기고 `skipped`로 종료합니다.
- PR base/head diff를 읽지 못하거나 비문서 변경, push, 수동 실행인 경우에는 fail-closed로 기존 전체 adapter 검증을 유지합니다.

Closes #5575

## 원인

PR #5573은 중앙 CI·CodeQL·Proptest fast-pass에는 들어갔지만 Adapter inter-diff workflow가 별도 무조건 실행 경로여서 2분 9초를 추가로 사용했습니다.

## 검증

- `python3 -m unittest scripts/tests/test_adapter_diff_workflow.py`
- `cargo fmt --all -- --check`
- `node scripts/rust-test-suite-manifest.mjs --prepare`
- `node scripts/rust-test-suite-manifest.mjs --check`
- `node scripts/rust-unit-test-tiers.mjs --check`
- `git diff --check`
