### PR TITLE
fix(renderer): 묶음 자식 그림의 자르기(crop)를 render tree 에 싣는다 (#5568)

### DIFF
--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -1921,11 +1921,29 @@ impl LayoutEngine {
                 // 그룹 내 그림: common이 비어있으므로 w, h(shape_attr 기반)를 직접 사용
                 let bin_data_id = pic.image_attr.bin_data_id;
                 let image_data = find_bin_data_bytes(bin_data_content, bin_data_id);
+                // [#5568] 그림 자르기(crop)를 본문 경로와 동일하게 싣는다. 묶음은
+                // 원본 하나를 imgClip 띠로 나눠 쓰는 문서가 있어(같은 bin_data 를
+                // 자식마다 다른 영역으로), 빠뜨리면 원본 전체가 대상 상자에
+                // 압착된다(비율 파괴). 렌더러의 crop 분기는 이 두 필드만 소비한다.
+                let crop = {
+                    let c = &pic.crop;
+                    if c.right > c.left
+                        && c.bottom > c.top
+                        && (c.left != 0 || c.top != 0 || c.right != 0 || c.bottom != 0)
+                    {
+                        Some((c.left, c.top, c.right, c.bottom))
+                    } else {
+                        None
+                    }
+                };
+                let original_size_hu = pic.crop_reference_size();
                 let img_id = tree.next_id();
                 let img_node = RenderNode::new(
                     img_id,
                     RenderNodeType::Image(ImageNode {
                         transform,
+                        crop,
+                        original_size_hu,
                         effect: pic.image_attr.effect,
                         brightness: pic.image_attr.brightness,
                         contrast: pic.image_attr.contrast,

--- a/tests/cases/issue_5568_group_picture_crop.rs
+++ b/tests/cases/issue_5568_group_picture_crop.rs
@@ -1,0 +1,95 @@
+//! [#5568] 묶음(container) 자식 그림의 자르기(imgClip) 렌더 계약.
+//!
+//! 묶음은 원본 하나를 imgClip 띠로 나눠 쓰는 문서가 있다(같은 bin_data 를
+//! 자식마다 다른 영역으로 자름 — 20211008101929000 8쪽 인포그래픽). 그룹 자식
+//! 경로가 `ImageNode.crop`/`original_size_hu` 를 싣지 않으면 원본 전체가 대상
+//! 상자에 압착돼 비율이 깨진다. SVG 렌더러는 crop 이 있으면 중첩
+//! `<svg x=.. viewBox=..>` 로 잘린 영역만 표시한다 — 그 방출 여부가 판정이다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use rhwp::model::control::Control;
+use rhwp::model::image::CropInfo;
+use rhwp::model::shape::{GroupShape, ShapeObject};
+use rhwp::wasm_api::HwpDocument;
+
+/// 8x8 빨강 단색 PNG (crop 판정은 이미지 픽셀 크기 파싱이 필요해 실제 PNG 를 쓴다).
+const PNG_8X8: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x08, 0x08, 0x02, 0x00, 0x00, 0x00, 0x4B, 0x6D, 0x29,
+    0xDC, 0x00, 0x00, 0x00, 0x12, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0xF8, 0xCF, 0xC0, 0x80,
+    0x15, 0x61, 0x17, 0x1D, 0xB4, 0x12, 0x00, 0x28, 0xFF, 0x3F, 0xC1, 0x6E, 0xEC, 0xDF, 0x61, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+];
+
+/// 그림 하나를 삽입한 뒤 그 그림을 묶음(Group) 자식으로 감싼 문서를 만든다.
+/// `crop` 이 Some 이면 자식 그림에 자르기(아래 절반)와 imgDim 좌표 기준을 싣는다.
+fn doc_with_grouped_picture(crop: Option<CropInfo>) -> HwpDocument {
+    let mut doc = HwpDocument::create_empty();
+    doc.insert_picture(
+        0, 0, 0, "[]", PNG_8X8, 6000, 6000, 8, 8, "png", "", None, None,
+    )
+    .expect("그림 삽입");
+
+    let paragraph = &mut doc.document_mut().sections[0].paragraphs[0];
+    let ctrl_idx = paragraph
+        .controls
+        .iter()
+        .position(|c| matches!(c, Control::Picture(_)))
+        .expect("삽입된 그림 컨트롤");
+    let Control::Picture(mut pic) = paragraph.controls.remove(ctrl_idx) else {
+        unreachable!()
+    };
+
+    if let Some(c) = crop {
+        pic.crop = c;
+        // crop 좌표 기준 범위(imgDim) — HWPX imgClip 계약과 동일 축.
+        pic.img_dim = (600, 600);
+    }
+
+    let mut group = GroupShape::default();
+    group.common = pic.common.clone();
+    group.shape_attr = pic.shape_attr.clone();
+    group.children = vec![ShapeObject::Picture(pic)];
+    paragraph.controls.insert(
+        ctrl_idx,
+        Control::Shape(Box::new(ShapeObject::Group(group))),
+    );
+    doc
+}
+
+fn nested_crop_svg_count(svg: &str) -> usize {
+    // 루트 `<svg xmlns=..>` 와 달리 crop 방출은 `<svg x="..` 로 시작한다.
+    svg.matches("<svg x=").count()
+}
+
+#[test]
+fn group_child_picture_crop_emits_nested_viewbox_svg() {
+    // 아래 절반만 표시하는 자르기: imgDim(600x600) 기준 y 300..600.
+    let doc = doc_with_grouped_picture(Some(CropInfo {
+        left: 0,
+        top: 300,
+        right: 600,
+        bottom: 600,
+    }));
+    let svg = doc.render_page_svg(0).expect("SVG 렌더");
+    assert!(
+        svg.contains("<image") || nested_crop_svg_count(&svg) > 0,
+        "그림이 렌더되지 않았다:\n{svg}"
+    );
+    assert!(
+        nested_crop_svg_count(&svg) > 0,
+        "묶음 자식 그림의 crop 이 소실됐다 — 중첩 <svg x=.. viewBox=..> 미방출:\n{svg}"
+    );
+}
+
+#[test]
+fn group_child_picture_without_crop_keeps_plain_image() {
+    let doc = doc_with_grouped_picture(None);
+    let svg = doc.render_page_svg(0).expect("SVG 렌더");
+    assert!(svg.contains("<image"), "그림이 렌더되지 않았다:\n{svg}");
+    assert_eq!(
+        nested_crop_svg_count(&svg),
+        0,
+        "자르기 없는 그림에 crop 경로가 발동했다:\n{svg}"
+    );
+}


### PR DESCRIPTION
# fix(renderer): 묶음 자식 그림의 자르기(crop)를 render tree 에 싣는다 (#5568)

## 근인

묶음(container)은 원본 하나를 `hp:imgClip` 띠로 나눠 쓰는 문서가 있다 — 같은 bin_data 를 자식마다 다른 영역으로 자른다. 그런데 그룹 자식 `ShapeObject::Picture` 경로(`renderer/layout/shape_layout.rs`)가 `ImageNode` 를 만들 때 `crop`/`original_size_hu` 를 싣지 않아, SVG 렌더러가 **원본 전체를 대상 상자에 밀어 넣어**(preserveAspectRatio=none) 비율이 깨진다. 본문 경로(`layout.rs`)·각주 경로(`picture_footnote.rs`)는 같은 두 필드를 채우고 있고, crop 해석기(`svg.rs compute_image_crop_src`)도 이미 존재한다 — **전달 누락 단독 결함**이다.

## 수정

그룹 자식 Picture 분기에 각주 경로와 동일한 유도식(crop 사각형 유효성 + 전량 0 제외, `crop_reference_size()`=imgDim)을 배선. 2개 필드 추가 외 로직 변경 없음.

## 실측 (`20211008101929000_2022학년도 서울특별시교육감 선발 후기고 신입생 전형요강.hwp` 8쪽)

인포그래픽(원본 PNG 1118×605) — 묶음 안 자식 2개가 같은 원본을 다른 띠로 자름:

| | 종전 | 수정 후 | 의도(imgClip) |
|---|---|---|---|
| 자식1 (플로차트) | 원본 전체를 621×139 상자에 압착 (종횡비 1.85→4.48) | 중첩 `<svg viewBox="49.5 79.1 1019.0 206.9">` 로 띠만 표시 | y 5931~21440HU = 79~286px 띠 |
| 자식2 (리본) | 원본 전체를 304×28 상자에 압착 | `viewBox="203.5 295.4 687.8 58.4"` | y 22151~26531HU 리본 |

배율 검산: 자식 scaMatrix(0.4620×0.1733)×컨테이너 scaMatrix(1.2028×1.3231)을 원본에 적용하면 정확히 종전 압착 크기(621.5×138.7)가 나온다 — 배치·배율은 정상이었고 자르기만 빠졌다. 수정 후 export-png 시각 확인: 압착 해소, 의도된 띠(1단계/2단계 화살표·중복불가/가능 리본)가 원래 비율로 표시.

## 게이트

- 신규 계약 테스트 `issue_5568_group_picture_crop`(tests/cases): 묶음 자식 그림 crop → 중첩 viewBox 방출 + 무-crop 음성 대조. **음성 검증**: 수정 없이 crop 테스트 FAIL 확인
- rustfmt(변경 파일)·clippy `-D warnings`·`cargo check --target wasm32-unknown-unknown --lib` 통과
- `rust-test-suite-manifest --check`/`--test`·`rust-unit-test-tiers --check` 통과 (파생 산출물 미포함)
- nextest 전체 7,722건 중 7,721 통과 — 유일 실패는 알려진 로컬 타이밍 플레이크 `issue_2833`(병렬 release 빌드 CPU 경합 중 발동, 단독 재실행 통과 확인)
- Native Skia 3종(release-test, `target/pr-review`) 전부 통과: skia lib 58 · `issue_2225_missing_picture_placeholder` 2 · `render_p37_direct_pdf_export` 4
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(로컬 rustfmt 직접 검사로 대체) · Docker 부재로 표준 WASM 빌드 대신 CI WASM lane(`clippy/check --target wasm32`) 로컬 재현
- 영향 범위: 그룹 자식 그림 한정 — crop 없는 그림은 분기 자체가 기존 경로(음성 테스트로 고정). 인접 의심 지점(`table_cell_content.rs` 셀 그림의 명시적 `crop: None`)은 이슈 #5568 에 후속으로 기록

이슈 #5568 (발견 경위: 사용자 제보 8쪽 그림 찌그러짐; 동반 조사 #5566)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
