### PR TITLE
docs: PR #5576 검토 기록을 보존한다

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -44,3 +44,11 @@ date: 2026-08-19
 - merge commit은 `c7106572af238804bb5fe4a34f326b46af3cbccf`이며, issue [#5571](https://github.com/edwardkim/rhwp/issues/5571)은 closing keyword로 자동 종료됐다.
 - 로컬에서 `cargo fmt --all -- --check`와 `git diff --check`를 통과했다. 최신 head의 CI preflight, Lint, package gate, Native Skia, test archive, slow·regular shard, CodeQL, Build & Test aggregate도 모두 통과했다.
 - 사용자 지시에 따라 merge 뒤 옵션 B의 별도 문서 전용 PR로 [PR #5572 검토 기록](../pr/archives/pr_5572_review.md)과 이 완료 기록을 보존한다.
+
+## #5576 Adapter inter-diff 문서 전용 fast-pass
+
+- PR [#5576](https://github.com/edwardkim/rhwp/pull/5576)은 문서 전용 PR에서도 독립 Adapter inter-diff workflow가 전체 harness를 실행하던 문제를 해결했다.
+- merge commit은 `2e852d7f730865cb32000519303df11b18c3f2fe`이며, issue [#5575](https://github.com/edwardkim/rhwp/issues/5575)는 closing keyword로 자동 종료됐다.
+- 최신 source head의 CI preflight, Lint, Frontend package gate, Native Skia, test archive, slow·regular shard, Build & Test aggregate, CodeQL 세 언어, Proptest, Adapter inter-diff가 모두 통과했다. workflow 변경 PR이므로 Adapter 본 job은 fail-closed로 실행된 것이 정상이다.
+- 사용자 지시에 따라 merge 뒤 옵션 B의 별도 문서 전용 PR로 [PR #5576 검토 기록](../pr/archives/pr_5576_review.md)과 이 완료 기록을 보존한다.
+- 이 문서 PR에서는 `adapter inter-diff preflight` 성공과 본 `adapter inter-diff`의 `skipped` 상태를 확인해 문서 전용 fast-pass의 실제 동작을 검증한다.

--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -51,4 +51,4 @@ date: 2026-08-19
 - merge commit은 `2e852d7f730865cb32000519303df11b18c3f2fe`이며, issue [#5575](https://github.com/edwardkim/rhwp/issues/5575)는 closing keyword로 자동 종료됐다.
 - 최신 source head의 CI preflight, Lint, Frontend package gate, Native Skia, test archive, slow·regular shard, Build & Test aggregate, CodeQL 세 언어, Proptest, Adapter inter-diff가 모두 통과했다. workflow 변경 PR이므로 Adapter 본 job은 fail-closed로 실행된 것이 정상이다.
 - 사용자 지시에 따라 merge 뒤 옵션 B의 별도 문서 전용 PR로 [PR #5576 검토 기록](../pr/archives/pr_5576_review.md)과 이 완료 기록을 보존한다.
-- 이 문서 PR에서는 `adapter inter-diff preflight` 성공과 본 `adapter inter-diff`의 `skipped` 상태를 확인해 문서 전용 fast-pass의 실제 동작을 검증한다.
+- 옵션 B 문서 PR [#5579](https://github.com/edwardkim/rhwp/pull/5579)에서 중앙 무거운 lane은 모두 skipped, Build & Test aggregate는 5초 성공, [Adapter inter-diff workflow](https://github.com/edwardkim/rhwp/actions/runs/32224422692)는 preflight 48초 성공과 본 `adapter inter-diff`의 skipped 상태를 남겨 문서 전용 fast-pass 동작을 확인했다.

--- a/mydocs/pr/archives/pr_5576_review.md
+++ b/mydocs/pr/archives/pr_5576_review.md
@@ -62,11 +62,21 @@ post_merge.md
 
 영향 정책상 Frontend unit gate와 WASM Build는 skipped였고, aggregate는 성공했다.
 
+### 옵션 B 문서 전용 검증
+
+[PR #5579](https://github.com/edwardkim/rhwp/pull/5579)는 review archive와 오늘할일만 바꾼
+`mydocs/**` 전용 PR이다. 최신 문서 head에서 다음 결과를 확인했다.
+
+- [CI workflow](https://github.com/edwardkim/rhwp/actions/runs/32224422771): preflight와 Build & Test aggregate는 성공하고 Lint, Native Skia, archive, nextest worker, frontend lane은 skipped
+- [CodeQL workflow](https://github.com/edwardkim/rhwp/actions/runs/32224422690): preflight 성공, language matrix skipped
+- [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/32224422677): preflight 성공, prop roundtrip skipped
+- [Adapter inter-diff workflow](https://github.com/edwardkim/rhwp/actions/runs/32224422692): `adapter inter-diff preflight` 48초 성공, 본 `adapter inter-diff` skipped
+
 ## 결론과 후속 처리
 
 **병합 완료.** 최신 head가 `MERGEABLE`·`CLEAN`이고 required check가 모두 성공한 뒤 squash merge했다.
 
 - issue [#5575](https://github.com/edwardkim/rhwp/issues/5575)는 `closes #5575`로 자동 종료된 것을 확인했다.
 - 사용자가 지정한 옵션 B에 따라 이 archive와 오늘할일은 별도 review-only 문서 PR로 보존한다.
-- 이 후속 문서 PR에서 `adapter inter-diff`가 `skipped`로 남는 것을 검증한다.
+- 이 후속 문서 PR에서 `adapter inter-diff`가 `skipped`로 남는 것을 검증했다.
 - 이 후속 기록 PR이 병합되면 원 PR·이슈 기록을 중복 게시하지 않고, 작업 branch 정리만 수행한다.

--- a/mydocs/pr/archives/pr_5576_review.md
+++ b/mydocs/pr/archives/pr_5576_review.md
@@ -1,0 +1,72 @@
+---
+kind: pr-review
+status: completed
+pr: 5576
+issue: 5575
+base: devel
+source_head: 14ea4acd3df77fadc986add8db5a80ce9e66e4aa
+merge_commit: 2e852d7f730865cb32000519303df11b18c3f2fe
+---
+
+# PR #5576 Adapter inter-diff 문서 전용 fast-pass 검토
+
+## 라우팅
+
+```text
+base route: collaborator self-merge
+modifiers: PR 접수와 리뷰 기록, review-only fast-pass, merge 후속 처리
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, review_only_fast_pass.md,
+post_merge.md
+```
+
+## PR metadata
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#5576](https://github.com/edwardkim/rhwp/pull/5576) |
+| 작성자 | `jangster77` |
+| base | `devel` |
+| source head | `14ea4acd3df77fadc986add8db5a80ce9e66e4aa` |
+| merge commit | `2e852d7f730865cb32000519303df11b18c3f2fe` |
+| 관련 이슈 | [#5575](https://github.com/edwardkim/rhwp/issues/5575) |
+| merge 시점 | 2026-08-19 06:38 UTC |
+
+## 변경 범위와 판정
+
+- `adapter inter-diff preflight`가 PR base/head diff를 full history에서 확인한다.
+- 변경 파일이 비어 있지 않고 모두 `mydocs/**`일 때만 `adapter inter-diff` job을 skip한다.
+- 비문서 변경, PR 이외 trigger, base/head 또는 diff 오류는 fail-closed로 기존 전체 adapter harness를 실행한다.
+- workflow-level `paths-ignore`를 사용하지 않아 required check가 사라지거나 pending 상태가 되는 경로를 만들지 않는다.
+- workflow contract test가 full-history diff, 문서 전용 gate, fail-closed 이유와 `paths-ignore` 부재를 고정한다.
+
+## 검증 기록
+
+### 로컬
+
+- `python3 -m unittest scripts/tests/test_adapter_diff_workflow.py`: 통과
+- `cargo fmt --all -- --check`: 통과
+- `node scripts/rust-test-suite-manifest.mjs --prepare`: 통과
+- `node scripts/rust-test-suite-manifest.mjs --check`: 통과
+- `node scripts/rust-unit-test-tiers.mjs --check`: 통과
+- `git diff --check`: 통과
+
+### GitHub Actions
+
+최신 source head에서 다음 검증이 모두 통과했다.
+
+- [CI workflow](https://github.com/edwardkim/rhwp/actions/runs/32223208955): CI preflight, Lint, Frontend package gate, Native Skia, Build test archive, slow shard, regular shard 1/3·2/3·3/3, Build & Test aggregate
+- [CodeQL workflow](https://github.com/edwardkim/rhwp/actions/runs/32223208770): preflight와 JavaScript/TypeScript·Python·Rust 분석
+- [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/32223208765): preflight와 prop roundtrip
+- [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/32223208787): workflow 변경이므로 full adapter harness 통과
+
+영향 정책상 Frontend unit gate와 WASM Build는 skipped였고, aggregate는 성공했다.
+
+## 결론과 후속 처리
+
+**병합 완료.** 최신 head가 `MERGEABLE`·`CLEAN`이고 required check가 모두 성공한 뒤 squash merge했다.
+
+- issue [#5575](https://github.com/edwardkim/rhwp/issues/5575)는 `closes #5575`로 자동 종료된 것을 확인했다.
+- 사용자가 지정한 옵션 B에 따라 이 archive와 오늘할일은 별도 review-only 문서 PR로 보존한다.
+- 이 후속 문서 PR에서 `adapter inter-diff`가 `skipped`로 남는 것을 검증한다.
+- 이 후속 기록 PR이 병합되면 원 PR·이슈 기록을 중복 게시하지 않고, 작업 branch 정리만 수행한다.


### PR DESCRIPTION
## 목적

PR #5576의 완료 review archive와 오늘할일 기록을 코드 변경과 분리한 옵션 B 문서 전용 후속 PR입니다.

## 검증 목표

이 PR은 `mydocs/**`만 변경합니다. #5576에서 도입한 gate에 따라 다음을 확인합니다.

- `adapter inter-diff preflight`: 성공
- `adapter inter-diff`: `skipped`
- 중앙 CI·CodeQL·Proptest의 review-only fast-pass: 성공

## 로컬 확인

- `cargo fmt --all -- --check`
- `node scripts/rust-test-suite-manifest.mjs --check`
- `node scripts/rust-unit-test-tiers.mjs --check`
- `git diff --check`
