### PR TITLE
feat(studio): 문서 열기 흐름을 빈 문서·빈 쪽 기준으로 정리한다

### DIFF
--- a/rhwp-studio/e2e/MANIFEST.md
+++ b/rhwp-studio/e2e/MANIFEST.md
@@ -31,7 +31,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `debug-textbox.mjs` | 진단 | active | E2E 디버그: 글상자 삽입 후 텍스트 위치 확인 | — | 수동 | 수동 디버그 |
 | `dialog-theme.test.mjs` | 상시 | active | 다이얼로그 다크 테마 색상 정책 | — | 수동 |  |
 | `drag-selection-autoscroll.test.mjs` | 상시 | active | 텍스트 드래그 선택 edge 자동 스크롤 | — | npm e2e:drag-autoscroll |  |
-| `drop-confirm.test.mjs` | 상시 | active | #1439 드래그&드롭 로컬 파일 로딩 보안 게이트 | — | 수동 |  |
+| `drop-confirm.test.mjs` | 상시 | active | 드롭 확인 대화상자 경계 (문서=없음, 이미지=#1439 게이트) | — | 수동 |  |
 | `edit-pipeline.test.mjs` | 상시 | active | 편집 파이프라인 검증 (Issue #2) | — | 수동 |  |
 | `embed-save-ack.test.mjs` | 상시 | active | Task #2660 호스트 저장 완료 통지와 dirty/autosave 정리 계약 | footnote-01.hwp | 수동 |  |
 | `embed-transport.test.mjs` | 상시 | active | Issue #2186 @rhwp/editor MessageChannel v1 iframe transport | — | npm e2e:embed |  |
@@ -42,7 +42,7 @@ e2e 스크립트의 **단일 권위 목록**이다. 파일 추가/변경/폐기 
 | `form-control.test.mjs` | 상시 | active | 양식 컨트롤 — 셀 커서 진입(#111) + 체크박스 클릭 토글(#112) | form-002.hwpx | 수동 |  |
 | `form-edit-escape-cancel.test.mjs` | 상시 | active | #2375 Edit 양식 필드 Escape는 blur 뒤에도 취소·무기록 | form-01.hwp | npm e2e:form-edit-escape |  |
 | `gen-screenshot.mjs` | 유틸 | active | README 용 렌더 스크린샷 생성기 | basic/KTX.hwp | 수동 |  |
-| `global-shortcut.test.mjs` | 상시 | active | 전역 단축키 (문서 미로드 상태) | — | 수동 |  |
+| `global-shortcut.test.mjs` | 상시 | active | 시작 시 빈 문서 + 전역 단축키 | — | 수동 |  |
 | `grid-mode-click-coord.test.mjs` | 진단 | hold | 보류 ① 그리드 좌표 결함 — 정량 e2e 측정 | exam_kor.hwp | 수동 | legacy-name · 보류① 이슈 종속 |
 | `helpers.mjs` | 유틸 | active | E2E 테스트 헬퍼 — Puppeteer + Chrome CDP | — | 수동 |  |
 | `hml-equation-embed.test.mjs` | 상시 | active | PR #2219 HML equation canvas edit/undo/export/reload | — | 수동 |  |

--- a/rhwp-studio/e2e/drop-confirm.test.mjs
+++ b/rhwp-studio/e2e/drop-confirm.test.mjs
@@ -1,25 +1,30 @@
 /**
- * E2E 테스트: #1439 드래그&드롭 로컬 파일 로딩 보안 게이트
+ * E2E 테스트: 드래그&드롭 확인 대화상자 경계
  *
- * 드롭 시 즉시 로딩하지 않고 모달 확인 대화상자를 표시하며, [열기]에서만 로딩되고
- * [취소]/미동의 시 로딩되지 않아야 한다. (확장/웹 공통 — 순수 DOM 모달.)
+ * 문서 드롭은 열기 동작이라 확인 대화상자 없이 바로 로딩 분기로 들어간다.
+ * 이미지 드롭은 편집 중인 문서에 로컬 파일을 끼워 넣는 편집 동작이라 #1439 보안 게이트를
+ * 유지한다 — 모달에서 [열기]를 눌러야 삽입되고, [취소]면 삽입되지 않는다.
  */
 import { runTest, waitForCanvas, screenshot, assert, setTestCase } from './helpers.mjs';
 
 process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
 
-/** scroll-container 에 HWP 파일 drop 이벤트를 합성한다. */
-async function dispatchDrop(page, fileName, content) {
-  await page.evaluate((name, text) => {
+/** scroll-container 에 파일 drop 이벤트를 합성한다. */
+async function dispatchDrop(page, fileName, content, type) {
+  await page.evaluate((name, text, mime) => {
     const container = document.getElementById('scroll-container');
     if (!container) throw new Error('scroll-container not found');
-    const file = new File([text], name, { type: 'application/x-hwp' });
+    const isBase64 = mime.startsWith('image/');
+    const body = isBase64
+      ? Uint8Array.from(atob(text), (c) => c.charCodeAt(0))
+      : text;
+    const file = new File([body], name, { type: mime });
     const dt = new DataTransfer();
     dt.items.add(file);
     const ev = new DragEvent('drop', { bubbles: true, cancelable: true });
     Object.defineProperty(ev, 'dataTransfer', { value: dt });
     container.dispatchEvent(ev);
-  }, fileName, content);
+  }, fileName, content, type);
 }
 
 async function dropDialogVisible(page) {
@@ -38,44 +43,38 @@ async function clickDropDialogButton(page, label) {
   }, label);
 }
 
-async function hasLoadedDocument(page) {
-  return await page.evaluate(() => window.__wasm?.hasLoadedDocument?.() ?? null);
-}
-
-// 유효한 최소 HWP 가 아니어도 로딩 "시도" 여부만 보면 되므로, 로딩 분기 진입을
-// 판정하기 위해 실제 샘플 바이트를 쓰지 않고 더미를 쓴다. [취소] 케이스는 로딩
-// 분기 자체가 호출되지 않음을 검증한다.
+// 유효한 최소 HWP 가 아니어도 로딩 "시도" 여부만 보면 되므로 더미 바이트를 쓴다.
 const DUMMY = 'dummy-hwp-content';
+/** 1x1 투명 PNG (base64). */
+const PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
 
-runTest('드래그&드롭 보안 확인 대화상자', async ({ page }) => {
-  setTestCase('TC-1: 드롭 시 즉시 로딩되지 않고 확인 대화상자 표시');
-  await dispatchDrop(page, 'dropped.hwp', DUMMY);
+runTest('드래그&드롭 확인 대화상자 경계', async ({ page }) => {
+  setTestCase('TC-1: 문서 드롭은 확인 대화상자 없이 로딩 분기로 들어간다');
+  await dispatchDrop(page, 'dropped.hwp', DUMMY, 'application/x-hwp');
+  await page.evaluate(() => new Promise(r => setTimeout(r, 500)));
+  assert(!(await dropDialogVisible(page)), '문서 드롭에는 확인 대화상자가 없어야 함');
+  await screenshot(page, 'drop-doc-no-dialog');
+  // 더미 바이트라 로드는 실패한다 — 실패 알림(토스트)이 로딩 분기 진입의 흔적이다.
+  const attempted = await page.evaluate(
+    () => document.body.textContent?.includes('파일 로드 실패') ?? false,
+  );
+  assert(attempted, '문서 드롭이 곧바로 로딩을 시도해야 함');
+
+  setTestCase('TC-2: 이미지 드롭은 확인 대화상자를 유지한다 (#1439)');
+  await page.evaluate(() => {
+    document.querySelectorAll('.toast-confirm, .toast').forEach(el => el.remove());
+  });
+  await dispatchDrop(page, 'dropped.png', PNG_1X1, 'image/png');
   await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
-  assert(await dropDialogVisible(page), '드롭 후 확인 대화상자가 표시되어야 함');
-  await screenshot(page, 'drop-confirm-dialog');
+  assert(await dropDialogVisible(page), '이미지 드롭 후 확인 대화상자가 표시되어야 함');
+  await screenshot(page, 'drop-image-confirm-dialog');
 
-  setTestCase('TC-2: [취소] 시 대화상자 닫히고 로딩 안 됨');
-  const loadedBefore = await hasLoadedDocument(page);
+  setTestCase('TC-3: [취소] 시 대화상자가 닫히고 삽입되지 않는다');
   await clickDropDialogButton(page, '취소');
   await page.waitForFunction(() => !document.querySelector('.modal-overlay'), { timeout: 3000 });
-  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
-  assert(
-    (await hasLoadedDocument(page)) === loadedBefore,
-    '[취소] 후 문서 로드 상태가 변하지 않아야 함 (미로딩)',
-  );
-
-  setTestCase('TC-3: [열기] 시 로딩 분기 진입 (더미라 로드 실패하지만 시도됨)');
-  await dispatchDrop(page, 'dropped2.hwp', DUMMY);
-  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
-  assert(await dropDialogVisible(page), 'TC-3 재드롭 시 대화상자 표시');
-  await clickDropDialogButton(page, '열기');
-  await page.waitForFunction(() => !document.querySelector('.modal-overlay'), { timeout: 3000 });
-  // 더미 바이트라 로드는 실패(오류 알림)하나, [열기] 분기가 호출되어 상태바/토스트에
-  // 로딩 시도 흔적이 남는다 — 대화상자가 닫혔는지만으로 [열기] 동작을 확인한다.
-  await page.evaluate(() => new Promise(r => setTimeout(r, 500)));
   assert(
     !(await page.evaluate(() => Boolean(document.querySelector('.modal-overlay')))),
-    '[열기] 후 대화상자가 닫혀야 함 (로딩 분기 진입)',
+    '[취소] 후 대화상자가 닫혀야 함',
   );
 
   await waitForCanvas(page).catch(() => {}); // 더미 로드 실패해도 무시

--- a/rhwp-studio/e2e/global-shortcut.test.mjs
+++ b/rhwp-studio/e2e/global-shortcut.test.mjs
@@ -1,20 +1,20 @@
 /**
- * E2E 테스트 — 전역 단축키 (문서 미로드 상태)
+ * E2E 테스트 — 시작 시 빈 문서 + 전역 단축키
  *
- * 검증: 문서가 없는 빈 상태에서 Alt+N → 새 문서 생성
+ * 검증: 앱 시작 직후 빈 문서가 열려 편집 가능 상태이고, Alt+N → 새 문서 생성이 동작한다.
  */
 import { runTest, loadApp, screenshot, assert, getPageCount } from './helpers.mjs';
 
 process.env.VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
 
-runTest('전역 단축키 — 빈 상태 Alt+N', async ({ page }) => {
-  // 앱 로드만, 문서 생성 없음
+runTest('시작 시 빈 문서 + Alt+N', async ({ page }) => {
+  // 앱 로드만, 명시적 문서 생성 없음
   await loadApp(page);
-  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+  await page.evaluate(() => new Promise(r => setTimeout(r, 800)));
 
-  // 문서 미로드 상태 확인
+  // 시작 직후 빈 문서가 열려 있어야 한다
   const pageCountBefore = await page.evaluate(() => window.__wasm?.pageCount ?? 0);
-  assert(pageCountBefore === 0, `TC1: 초기 상태 문서 없음 (pageCount=${pageCountBefore})`);
+  assert(pageCountBefore >= 1, `TC1: 시작 시 빈 문서 자동 생성 (pageCount=${pageCountBefore})`);
   await screenshot(page, 'global-01-empty');
 
   // Alt+N 입력 (편집 영역 클릭 없이)

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -36,7 +36,6 @@ import { ContextMenu } from '@/ui/context-menu';
 import { CommandPalette } from '@/ui/command-palette';
 import { MODAL_DIALOG_CLOSED_EVENT } from '@/ui/dialog';
 import { showHmlImportWarning } from '@/ui/hml-import-warning';
-import { showLocalFontsModalIfNeeded } from '@/ui/local-fonts-modal';
 import { showToast } from '@/ui/toast';
 import { addRecentDoc, listRecentDocs } from '@/recent/recent-store';
 import { showDropConfirmDialog } from '@/ui/drop-confirm-dialog';
@@ -685,10 +684,15 @@ async function initialize(): Promise<void> {
     setupEventListeners();
     setupModalFocusRestore();
     setupGlobalShortcuts();
-    void loadFromUrlParam();
-    // embed 프로파일: 자동저장 복구 다이얼로그의 드래프트 복원도 호스트가 감지할 수
-    // 없는 문서 교체 경로이므로 띄우지 않는다 (드래프트 기록 자체는 유지).
-    if (chromeMode !== 'embed') void offerAutosaveRecoveryIfIdle();
+    // 시작 진입점은 순서를 지켜야 한다 — ?url= 로드와 자동저장 복구가 문서를 열 기회를
+    // 먼저 갖고, 아무도 열지 않았을 때만 빈 문서를 연다.
+    void (async () => {
+      await loadFromUrlParam();
+      // embed 프로파일: 자동저장 복구 다이얼로그의 드래프트 복원도 호스트가 감지할 수
+      // 없는 문서 교체 경로이므로 띄우지 않는다 (드래프트 기록 자체는 유지).
+      if (chromeMode !== 'embed') await offerAutosaveRecoveryIfIdle();
+      await openBlankDocumentIfIdle();
+    })();
     // embed 프로파일: PWA launch queue로 문서를 넘겨받는 진입도 문서 교체 경로이므로
     // 설치하지 않는다.
     if (chromeMode !== 'embed') {
@@ -825,12 +829,10 @@ function setupFileInput(): void {
       return;
     }
 
-    // [#1439] 보안: 드롭으로 로컬 파일을 읽는 동작은 기본에서 제외하고, 사용자가
-    // 명시적으로 [열기]를 눌러 동의한 경우에만 진행한다 (확장/웹 공통).
-    const confirmed = await showDropConfirmDialog(file.name);
-    if (!confirmed) return;
-
     if (isImage) {
+      // [#1439] 이미지 드롭은 로컬 파일을 읽어 편집 중인 문서에 끼워 넣는 편집 동작이므로
+      // 명시 동의를 유지한다. 문서 드롭은 열기 동작이라 확인 없이 바로 연다.
+      if (!await showDropConfirmDialog(file.name)) return;
       if (!inputHandler || wasm.pageCount === 0) return;
       const data = new Uint8Array(await file.arrayBuffer());
       const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
@@ -866,7 +868,9 @@ function setupFileInput(): void {
       return;
     }
 
-    // HWP/HWPX/HML — Finder/Explorer drop에서는 File System Access handle을 capture하지
+    // HWP/HWPX/HML — 드롭 열기는 확인 대화상자 없이 바로 연다. 드롭 자체가 명시적인
+    // 사용자 제스처이고, 파일을 열 때마다 확인을 받으면 열기 흐름이 끊긴다.
+    // Finder/Explorer drop에서는 File System Access handle을 capture하지
     // 않는다. macOS Chromium에서 encrypted HWPX drag/drop 시 해당 IPC가 renderer를 종료시키는
     // 사례가 있어, 열기에 충분한 File bytes만 사용한다. 저장은 이후 save-as 경로로 진행한다.
     await loadFile(file);
@@ -1175,41 +1179,18 @@ async function initializeDocument(
 async function promptLocalFontsIfNeeded(docInfo: DocumentInfo, displayName: string): Promise<void> {
   if (!docInfo.fontsUsed?.length) return;
 
-  const msg = sbMessage();
+  // 문서를 열 때마다 로컬 글꼴 감지 안내 모달을 띄우면 열람 흐름이 끊긴다. 저장된 감지 결과가
+  // 있으면 그대로 재사용하고, 없으면 대체 글꼴로 조용히 표시한다. 수동 감지는 옵션 대화상자의
+  // '로컬 글꼴 감지하기'로 계속 실행할 수 있다.
   try {
     if (!getLocalFontState().loaded) await loadStoredLocalFonts();
     const report = analyzeDocumentFonts(docInfo.fontsUsed);
     if (!report.shouldPromptLocalAccess) return;
-
-    const choice = await showLocalFontsModalIfNeeded(report, {
-      disableExternalWebFonts: extensionViewerSettings.disableExternalWebFonts,
-    });
-    if (choice !== 'detect') return;
-
-    msg.textContent = '로컬 글꼴 감지 중...';
-    const fonts = await detectLocalFonts({
-      force: true,
-      includeRegistered: true,
-      candidateFamilies: docInfo.fontsUsed,
-    });
-    const nextReport = analyzeDocumentFonts(docInfo.fontsUsed);
-    eventBus.emit('local-fonts-changed', { fonts, report: nextReport });
-    const state = getLocalFontState();
-    const resultLabel = state.source === 'font-presence-probe'
-      ? '확인됨'
-      : (state.probedFamilies.length > 0 ? '열거·확인됨' : '열거됨');
-    msg.textContent = `${displayName} (로컬 글꼴 ${fonts.length}개 ${resultLabel})`;
-    showToast({
-      message: `로컬 글꼴 ${fonts.length}개를 ${resultLabel.replace('됨', '')}하고 저장했습니다.\n다음 문서 로드부터 감지 결과를 재사용합니다.`,
-      durationMs: 5000,
-    });
+    console.log(
+      `[local-fonts] 감지 안내 모달 생략 — 대체 글꼴로 표시 (확인 필요 ${report.summary.needsLocalCheck}개, 문서 ${displayName})`,
+    );
   } catch (error) {
-    console.warn('[local-fonts] 감지 안내/실행 실패 (치명적이지 않음):', error);
-    msg.textContent = displayName;
-    showToast({
-      message: '로컬 글꼴 감지에 실패했습니다.\n웹 대체 글꼴로 계속 표시합니다.',
-      durationMs: 8000,
-    });
+    console.warn('[local-fonts] 저장된 감지 결과 로드 실패 (치명적이지 않음):', error);
   }
 }
 
@@ -1292,9 +1273,21 @@ async function loadDocumentForOpen(data: Uint8Array, fileName: string): Promise<
   }
 }
 
+/**
+ * 문서 열기가 실패하면 빈 쪽 상태로 남는다. WASM이 아직 이전 문서를 쥐고 있으면 그 뷰를
+ * 되살려, 열기 실패가 이미 열어 둔 문서를 잃는 일로 번지지 않게 한다.
+ */
+function restoreViewAfterFailedOpen(): void {
+  if (!canvasView || wasm.pageCount === 0) return;
+  void canvasView.loadDocument().catch((error) => {
+    console.warn('[main] 열기 실패 후 이전 문서 뷰 복구 실패:', error);
+  });
+}
+
 function showLoadErrorUnlessCancelled(error: unknown): void {
   if (isDocumentOpenCancelled(error)) {
     sbMessage().textContent = '문서 열기를 취소했습니다.';
+    restoreViewAfterFailedOpen();
     return;
   }
   showLoadError(error);
@@ -1329,6 +1322,9 @@ async function loadBytes(
   startTime = performance.now(),
   options: { dataReadProgressShown?: boolean; skipRecent?: boolean; suppressDialogs?: boolean } = {},
 ): Promise<void> {
+  // 파싱 전에 먼저 빈 쪽 상태로 만든다 — 이전 문서를 붙잡고 있다가 한 번에 갈아치우면
+  // 화면이 튀어 보인다. 파싱이 실패하면 아래 catch가 이전 문서 뷰를 되살린다.
+  canvasView?.showBlankPage();
   if (!options.dataReadProgressShown) {
     await updateLoadProgress(0, '문서 데이터 준비 중...');
   }
@@ -1494,6 +1490,18 @@ async function createNewDocument(): Promise<void> {
     msg.textContent = `새 문서 생성 실패: ${error}`;
     console.error('[main] 새 문서 생성 실패:', error);
   }
+}
+
+/**
+ * WASM 초기화 뒤 아무 문서도 열리지 않았으면 빈 문서를 열어 바로 편집할 수 있게 한다.
+ * 회색 작업 영역만 남은 시작 화면은 편집기가 준비되지 않은 것처럼 보인다.
+ * 문서를 넘겨받는 진입점(?url=, 자동저장 복구, PWA launch queue)이 이미 문서를 열었으면
+ * 건드리지 않는다. embed 프로파일은 호스트가 문서 교체를 통제하므로 제외한다.
+ */
+async function openBlankDocumentIfIdle(): Promise<void> {
+  if (chromeMode === 'embed') return;
+  if (wasm.pageCount > 0 || documentState.isDirty()) return;
+  await createNewDocument();
 }
 
 async function canReplaceCurrentDocument(skipUnsavedGuard?: boolean): Promise<boolean> {
@@ -1671,6 +1679,7 @@ function showLoadError(error: unknown): void {
   const sb = sbMessage();
   if (sb) sb.textContent = errMsg;
   console.error('[main] 파일 로드 실패:', error);
+  restoreViewAfterFailedOpen();
   showToast({
     message: errMsg,
     durationMs: 0, // 에러는 자동 페이드 없음 — 사용자가 읽고 닫기

--- a/rhwp-studio/src/styles/editor.css
+++ b/rhwp-studio/src/styles/editor.css
@@ -58,6 +58,15 @@
   background: var(--doc-paper);
 }
 
+/* 문서 교체 중 회색 작업 영역이 드러나 깜빡여 보이지 않도록 놓는 빈 쪽 자리표시자 */
+#scroll-content .page-placeholder {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 0;
+  background: var(--doc-paper);
+}
+
 #scroll-content .page-grid-overlay {
   position: absolute;
   mix-blend-mode: multiply;

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -24,6 +24,9 @@ import {
   type ZoomPageBox,
 } from './zoom-anchor.ts';
 
+/** 문서 교체 중 보여줄 빈 쪽 기본 크기(A4, zoom 1 기준 CSS px). 이전 문서 쪽 크기를 모를 때만 쓴다. */
+const BLANK_PAGE_FALLBACK_SIZE = { width: 794, height: 1123 };
+
 const TEXT_EDIT_STATIC_LAYER_VERIFY_DELAY_MS = 800;
 const AUTO_RENDERER_RESELECTION_DELAY_MS = 300;
 
@@ -58,6 +61,8 @@ export class CanvasView {
   private autoRendererReselectionTimer: ReturnType<typeof setTimeout> | null = null;
   private documentLoadPrepared = false;
   private layoutViewportSize = { width: 0, height: 0 };
+  private blankPagePlaceholder: HTMLElement | null = null;
+  private lastPageSize: { width: number; height: number } | null = null;
   private disposed = false;
 
   constructor(
@@ -145,7 +150,9 @@ export class CanvasView {
     );
 
     this.container.scrollTop = 0;
+    this.lastPageSize = { width: this.pages[0].width, height: this.pages[0].height };
     this.updateVisiblePages();
+    this.clearBlankPagePlaceholder();
     // 초기 replay가 예약한 document fallback을 load 완료 전에 확정한다.
     await Promise.resolve();
 
@@ -165,6 +172,48 @@ export class CanvasView {
     this.pageRenderer.beginDocument();
     this.activeRendererDecisionKey = null;
     this.reset();
+    this.showBlankPagePlaceholder();
+  }
+
+  /**
+   * 문서 열기를 시작할 때 현재 뷰를 비우고 빈 쪽 상태로 만든다. 파싱이 끝날 때까지
+   * 이전 문서를 붙잡고 있다가 한 번에 갈아치우면 화면이 튀어 보인다.
+   */
+  showBlankPage(): void {
+    if (this.disposed) return;
+    this.reset();
+    this.showBlankPagePlaceholder();
+  }
+
+  /**
+   * 새 문서의 첫 쪽이 그려질 때까지 빈 흰 쪽을 대신 놓는다. 자리표시자가 없으면 회색 작업
+   * 영역이 그대로 드러나 문서를 열 때마다 화면이 깜빡이는 것처럼 보인다.
+   */
+  private showBlankPagePlaceholder(): void {
+    if (this.disposed) return;
+    const zoom = this.viewportManager.getZoom();
+    const size = this.lastPageSize ?? BLANK_PAGE_FALLBACK_SIZE;
+    const gap = this.virtualScroll.getPageGap();
+    const width = size.width * zoom;
+    const height = size.height * zoom;
+
+    const placeholder = document.createElement('div');
+    placeholder.className = 'page-placeholder';
+    placeholder.setAttribute('aria-hidden', 'true');
+    placeholder.style.top = `${gap}px`;
+    placeholder.style.width = `${width}px`;
+    placeholder.style.height = `${height}px`;
+
+    // 자리표시자만 있는 동안에도 스크롤 영역이 쪽 하나 크기를 유지해야 가운데 정렬이 흔들리지 않는다.
+    this.scrollContent.style.width = `${width + 40}px`;
+    this.scrollContent.style.height = `${height + gap * 2}px`;
+    this.scrollContent.appendChild(placeholder);
+    this.blankPagePlaceholder = placeholder;
+  }
+
+  private clearBlankPagePlaceholder(): void {
+    this.blankPagePlaceholder?.remove();
+    this.blankPagePlaceholder = null;
   }
 
   resetRendererDiagnostics(): void {
@@ -878,6 +927,7 @@ export class CanvasView {
     this.currentVisiblePages = [];
     this.pages = [];
     this.scrollContent.replaceChildren();
+    this.blankPagePlaceholder = null;
   }
 
   private releaseAllRenderedPages(): void {

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -280,6 +280,11 @@ export class VirtualScroll {
     return this.maxPageWidth;
   }
 
+  /** 페이지 사이/위아래 여백(px). 빈 쪽 자리표시자도 같은 여백을 쓴다. */
+  getPageGap(): number {
+    return this.pageGap;
+  }
+
   getTotalHeight(): number {
     return this.totalHeight;
   }

--- a/rhwp-studio/tests/canvas-view-blank-page-placeholder.test.ts
+++ b/rhwp-studio/tests/canvas-view-blank-page-placeholder.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { VirtualScroll } from '../src/view/virtual-scroll.ts';
+
+// 문서를 교체하면 prepareDocumentLoad 가 scrollContent 를 비우고, 새 문서 첫 쪽이 그려질
+// 때까지 회색 작업 영역(--doc-workspace)이 그대로 드러난다. 그 구간이 로드 진행 표시와
+// 겹쳐 화면이 깜빡이는 것처럼 보였다. 빈 흰 쪽 자리표시자가 그 구간을 덮는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function section(text: string, startMarker: string, endMarker: string): string {
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start);
+  assert.ok(start >= 0 && end > start, `${startMarker} 범위를 찾을 수 있어야 한다`);
+  return text.slice(start, end);
+}
+
+test('문서 교체는 비운 직후 빈 쪽 자리표시자를 놓는다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const prepare = section(view, '  prepareDocumentLoad(): void {', '\n  /**');
+
+  const resetIndex = prepare.indexOf('this.reset();');
+  const showIndex = prepare.indexOf('this.showBlankPagePlaceholder();');
+  assert.ok(resetIndex >= 0, '문서 교체는 이전 문서 뷰를 비워야 한다');
+  assert.ok(showIndex > resetIndex, '비운 뒤에 빈 쪽 자리표시자를 놓아야 한다');
+});
+
+test('빈 쪽 자리표시자는 첫 쪽을 그린 뒤에만 걷는다', () => {
+  const view = source('src/view/canvas-view.ts');
+  const load = section(view, '  async loadDocument(): Promise<void> {', '\n  /** WASM 문서 교체');
+
+  const visibleIndex = load.indexOf('this.updateVisiblePages();');
+  const clearIndex = load.indexOf('this.clearBlankPagePlaceholder();');
+  assert.ok(visibleIndex >= 0, '문서 로드는 보이는 쪽을 그려야 한다');
+  assert.ok(clearIndex > visibleIndex, '쪽을 그린 뒤에 자리표시자를 걷어야 한다');
+});
+
+test('자리표시자는 문서 용지 색을 쓴다', () => {
+  const css = source('src/styles/editor.css');
+  const rule = section(css, '#scroll-content .page-placeholder {', '}');
+
+  assert.match(rule, /background:\s*var\(--doc-paper\)/);
+});
+
+test('자리표시자 배치는 실제 쪽 여백과 같은 값을 쓴다', () => {
+  const virtualScroll = new VirtualScroll();
+  const pages = [{ width: 800, height: 1000 }] as never;
+  virtualScroll.setPageDimensions(pages, 1, 1200);
+
+  assert.equal(virtualScroll.getPageGap(), 10);
+  assert.equal(virtualScroll.getPageOffset(0), virtualScroll.getPageGap());
+});

--- a/rhwp-studio/tests/chrome-mode.test.ts
+++ b/rhwp-studio/tests/chrome-mode.test.ts
@@ -79,8 +79,10 @@ test('main은 embed에서 수명주기 커맨드 등록만 거르고 메뉴는 �
   // 경로이므로 embed에서는 띄우지 않는다.
   assert.match(
     mainSource,
-    /if \(chromeMode !== 'embed'\) void offerAutosaveRecoveryIfIdle\(\);/,
+    /if \(chromeMode !== 'embed'\) await offerAutosaveRecoveryIfIdle\(\);/,
   );
+  // 시작 시 빈 문서도 호스트가 감지할 수 없는 문서 교체이므로 embed에서는 열지 않는다.
+  assert.match(mainSource, /async function openBlankDocumentIfIdle[\s\S]*?if \(chromeMode === 'embed'\) return;/);
   // index.html은 수정하지 않는다 — 기본 full 프로파일의 정적 마크업 검사가 그대로 유효하다.
   const indexHtml = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   assert.match(indexHtml, /data-cmd="file:save"/);

--- a/rhwp-studio/tests/hwp-password-open.test.ts
+++ b/rhwp-studio/tests/hwp-password-open.test.ts
@@ -23,7 +23,10 @@ test('암호 문서는 명시적인 암호 필요 오류에서만 입력 UI로 �
 
 test('드롭 문서도 파일 메뉴와 같은 암호 열기 경로를 쓰며 File System Access handle을 capture하지 않는다', () => {
   const dropPath = between(mainSource, "container.addEventListener('drop', async (e) => {", 'function setupZoomControls');
-  assert.match(dropPath, /const confirmed = await showDropConfirmDialog\(file\.name\)/, '드롭 열기 확인을 유지해야 합니다');
+  const imageBranch = dropPath.slice(dropPath.indexOf('if (isImage) {'), dropPath.indexOf('// HWP/HWPX/HML'));
+  assert.match(imageBranch, /showDropConfirmDialog\(file\.name\)/, '이미지 드롭 삽입 확인은 유지해야 합니다');
+  const docBranch = dropPath.slice(dropPath.indexOf('// HWP/HWPX/HML'));
+  assert.doesNotMatch(docBranch, /showDropConfirmDialog/, '문서 드롭 열기는 확인 대화상자를 띄우지 않습니다');
   assert.match(dropPath, /await loadFile\(file\);/, '드롭 문서는 파일 메뉴와 같은 loadFile 경로를 사용해야 합니다');
   assert.doesNotMatch(dropPath, /captureDroppedFileHandle|getAsFileSystemHandle|fileHandle:/,
     '암호 문서 드롭에서 Chromium File System Access IPC를 시작하면 안 됩니다');

--- a/rhwp-studio/tests/local-fonts-modal-copy.test.ts
+++ b/rhwp-studio/tests/local-fonts-modal-copy.test.ts
@@ -21,9 +21,13 @@ test('로컬 글꼴 감지 모달은 사용자에게 대체 글꼴 표현을 사
 
 test('외부 웹폰트 비활성 상태는 로컬 글꼴 감지 모달에 표시된다', () => {
   const modal = source('src/ui/local-fonts-modal.ts');
-  const main = source('src/main.ts');
 
   assert.match(modal, /외부 웹폰트 사용 안 함: 켜짐/);
   assert.match(modal, /외부 CDN 폰트를 요청하지 않고/);
-  assert.match(main, /disableExternalWebFonts:\s*extensionViewerSettings\.disableExternalWebFonts/);
+});
+
+test('문서 열기는 로컬 글꼴 감지 모달을 자동으로 띄우지 않는다', () => {
+  const main = source('src/main.ts');
+
+  assert.doesNotMatch(main, /showLocalFontsModalIfNeeded/);
 });

--- a/rhwp-studio/tests/startup-blank-document.test.ts
+++ b/rhwp-studio/tests/startup-blank-document.test.ts
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 시작 화면이 회색 작업 영역만 보이면 편집기가 준비되지 않은 것처럼 보인다. WASM 초기화가
+// 끝나면 빈 문서를 열어 바로 편집할 수 있게 하되, 문서를 넘겨받는 진입점(?url=, 자동저장
+// 복구)이 문서를 열 기회를 먼저 갖는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+function section(text: string, startMarker: string, endMarker: string): string {
+  const start = text.indexOf(startMarker);
+  const end = text.indexOf(endMarker, start);
+  assert.ok(start >= 0 && end > start, `${startMarker} 범위를 찾을 수 있어야 한다`);
+  return text.slice(start, end);
+}
+
+test('시작 진입점은 ?url= 로드와 자동저장 복구 뒤에 빈 문서를 연다', () => {
+  const main = source('src/main.ts');
+  const startup = section(main, '    setupGlobalShortcuts();', '\n    // E2E 테스트용 전역 노출');
+
+  const urlIndex = startup.indexOf('await loadFromUrlParam();');
+  const recoveryIndex = startup.indexOf('await offerAutosaveRecoveryIfIdle();');
+  const blankIndex = startup.indexOf('await openBlankDocumentIfIdle();');
+
+  assert.ok(urlIndex >= 0, '?url= 진입점이 먼저 문서를 열 기회를 가져야 한다');
+  assert.ok(recoveryIndex > urlIndex, '자동저장 복구가 그다음 기회를 가져야 한다');
+  assert.ok(blankIndex > recoveryIndex, '빈 문서는 마지막에만 연다');
+});
+
+test('빈 문서 자동 생성은 이미 열린 문서와 embed 프로파일을 건드리지 않는다', () => {
+  const main = source('src/main.ts');
+  const fn = section(main, 'async function openBlankDocumentIfIdle', '\nasync function canReplaceCurrentDocument');
+
+  assert.match(fn, /if \(chromeMode === 'embed'\) return;/);
+  assert.match(fn, /if \(wasm\.pageCount > 0 \|\| documentState\.isDirty\(\)\) return;/);
+  assert.match(fn, /await createNewDocument\(\);/);
+});
+
+test('문서 열기는 파싱 전에 빈 쪽 상태로 만든다', () => {
+  const main = source('src/main.ts');
+  const loadBytes = section(main, 'async function loadBytes(', '\n/** 파일 메뉴 "최근 문서"');
+
+  const blankIndex = loadBytes.indexOf('canvasView?.showBlankPage();');
+  const parseIndex = loadBytes.indexOf('await loadDocumentForOpen(data, fileName);');
+
+  assert.ok(blankIndex >= 0, '열기는 빈 쪽 상태부터 만들어야 한다');
+  assert.ok(parseIndex > blankIndex, '빈 쪽 상태를 만든 뒤에 파싱해야 한다');
+});
+
+test('열기 실패는 이전 문서 뷰를 되살린다', () => {
+  const main = source('src/main.ts');
+  const restore = section(main, 'function restoreViewAfterFailedOpen', '\nfunction showLoadErrorUnlessCancelled');
+
+  assert.match(restore, /if \(!canvasView \|\| wasm\.pageCount === 0\) return;/);
+  assert.match(restore, /canvasView\.loadDocument\(\)/);
+
+  const cancelled = section(main, 'function showLoadErrorUnlessCancelled', '\nasync function loadFile');
+  assert.match(cancelled, /restoreViewAfterFailedOpen\(\);/);
+
+  const failed = section(main, 'function showLoadError(', '\nconst initPromise');
+  assert.match(failed, /restoreViewAfterFailedOpen\(\);/);
+});


### PR DESCRIPTION
## 배경

rhwp-studio 의 문서 열기 흐름이 "편집기가 아직 준비되지 않은 화면"으로 보인다는 사용자 보고에서 출발했다. 네 지점이 겹쳐 있었다.

1. 시작 직후 회색 작업 영역만 보인다 — 파일을 열거나 Alt+N 을 눌러야 편집을 시작할 수 있다.
2. 문서를 열면 `CanvasView.prepareDocumentLoad()` 가 `scrollContent` 를 비운 뒤 첫 쪽이 그려질 때까지 회색 작업 영역(`--doc-workspace`)이 그대로 드러난다. 로드 진행 표시(단계마다 paint 대기)와 겹쳐 흰 쪽 → 회색 → 흰 쪽으로 깜빡여 보인다.
3. rhwp 기본 지원 밖 글꼴이 있는 문서는 열 때마다 "로컬 글꼴 감지" 모달이 열람을 막는다.
4. 드롭 자체가 명시적 사용자 제스처인데도 드래그&드롭 열기마다 확인 대화상자를 한 번 더 눌러야 한다.

## 변경

**시작 시 빈 문서** (`src/main.ts`)
- `openBlankDocumentIfIdle()` 추가 — WASM 초기화 뒤 아무도 문서를 열지 않았으면 빈 문서를 연다.
- 시작 진입점을 순차 실행으로 묶어 `?url=` 로드 → 자동저장 복구 → 빈 문서 순서를 고정했다. 자동저장 복구는 `wasm.pageCount > 0` 이면 스스로 물러나므로, 빈 문서를 먼저 열면 복구 제안이 사라진다 — 그래서 순서가 계약이다(테스트로 고정).
- embed 프로파일은 호스트가 문서 교체를 통제하므로 제외한다.

**빈 쪽 전환** (`src/view/canvas-view.ts`, `src/view/virtual-scroll.ts`, `src/styles/editor.css`)
- 빈 쪽 자리표시자(`.page-placeholder`, `var(--doc-paper)`)를 도입했다. 크기는 직전 문서 첫 쪽 × 현재 배율, 없으면 A4 기본값. 여백은 `VirtualScroll.getPageGap()` 으로 실제 쪽 배치와 같은 값을 쓴다.
- `showBlankPage()` — 문서 열기는 **파싱 전에** 빈 쪽 상태부터 만든다.
- `prepareDocumentLoad()` 는 뷰를 비운 직후 자리표시자를 놓고, `loadDocument()` 는 첫 쪽을 그린 뒤에만 걷는다.
- `restoreViewAfterFailedOpen()` — 열기가 실패하면(WASM 이 이전 문서를 쥐고 있으면) 이전 문서 뷰를 되살린다. 파싱 전에 화면을 비우는 대가를 여기서 닫는다.

**로컬 글꼴 감지 모달 제거** (`src/main.ts`)
- 문서 열기 경로에서 모달을 띄우지 않는다. 저장된 감지 스냅샷은 그대로 로드·재사용하고, 없으면 대체 글꼴로 조용히 표시한다.
- 수동 감지는 옵션 대화상자의 `로컬 글꼴 감지하기 / 재감지` 에 그대로 남아 있다. 모달 컴포넌트(`src/ui/local-fonts-modal.ts`)는 문구 검사와 함께 남겨 두었고 현재 호출부는 없다.

**드롭 확인 대화상자 경계 이동** (`src/main.ts`)
- 문서 드롭은 확인 없이 바로 연다.
- 이미지 드롭은 편집 중인 문서에 로컬 파일을 끼워 넣는 편집 동작이라 #1439 게이트를 유지한다.
- 보안 성격 변화이므로 별도로 남긴다: 문서 드롭에서 "로컬 파일 읽기 전 명시 동의" 단계가 사라진다. 드롭 제스처 자체를 동의로 본다는 판단이며, 되돌리려면 문서 분기에 `showDropConfirmDialog` 를 다시 넣으면 된다.

## 검증

모두 이 브랜치에서 실행했다.

```
cd rhwp-studio
npx tsc --noEmit                                   # 통과
npm test                                           # 967건 중 966 pass, 0 fail, 1 skip(기존)
node e2e/global-shortcut.test.mjs --mode=headless   # 통과
node e2e/drop-confirm.test.mjs --mode=headless      # 통과
```

브라우저 확인(headless Chrome 149, vite dev):
- 시작 직후 `pageCount=1`, 캐럿·도구 모음 활성, 상태바 `새 문서.hwp — 1페이지`.
- 문서 드롭 → 모달 없이 즉시 로딩 분기 진입(더미 바이트라 로드 실패 알림으로 확인).
- 이미지 드롭 → 확인 모달 유지, [취소] 시 삽입 없음.

## 테스트

- `tests/startup-blank-document.test.ts` (신규) — 시작 진입점 순서, embed·기존 문서 가드, 파싱 전 빈 쪽 전환, 실패 시 뷰 복구.
- `tests/canvas-view-blank-page-placeholder.test.ts` (신규) — 비운 직후 자리표시자 배치 / 첫 쪽 그린 뒤 제거 / 용지 색 / 여백 값 일치.
- `tests/local-fonts-modal-copy.test.ts` — main 이 모달을 자동으로 띄우지 않음을 고정(모달 문구 검사는 유지).
- `tests/hwp-password-open.test.ts` — 드롭 확인의 새 경계(이미지=유지, 문서=없음)로 갱신.
- `tests/chrome-mode.test.ts` — embed 에서 자동저장 복구와 빈 문서 자동 열기를 모두 제외함을 고정.
- `e2e/global-shortcut.test.mjs`, `e2e/drop-confirm.test.mjs`, `e2e/MANIFEST.md` — 바뀐 동작에 맞춰 갱신.

## 범위 밖

`rhwp-studio` 전용 UX 변경이다. 파서·렌더러·문서 코어와 Rust 코드는 건드리지 않았다.
