### PR TITLE
docs: #5581 통합 검토 기록을 보존한다

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -6,6 +6,14 @@ date: 2026-08-19
 
 # 2026-08-19 오늘할 일
 
+## #5581 kevin9327 verifier와 rhwp-agent CLI 누적 통합
+
+- 통합 PR [#5581](https://github.com/edwardkim/rhwp/pull/5581)은 `d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece`로 `devel`에 병합됐다.
+- 원 PR [#5545](https://github.com/edwardkim/rhwp/pull/5545), [#5546](https://github.com/edwardkim/rhwp/pull/5546), [#5550](https://github.com/edwardkim/rhwp/pull/5550)을 `-x` 계보와 메인터너 보정으로 통합했다.
+- `rhwp-agent` 명령 계약의 고정 목록 누락은 `0c7dc94b2`에서 80개 공개 명령으로 보정했다. 전체 `release-test`는 7,773개 통과했고, Lint, Native Skia, archive·slow·regular shard, CodeQL 세 언어, Proptest, Adapter inter-diff, Build & Test CI도 성공했다.
+- 원 PR 세 건과 연결 이슈 [#5518](https://github.com/edwardkim/rhwp/issues/5518), [#5508](https://github.com/edwardkim/rhwp/issues/5508)에 통합 근거 댓글을 남기고 종료했다.
+- 이 완료 기록과 [PR #5545](../pr/archives/pr_5545_review.md), [PR #5546](../pr/archives/pr_5546_review.md), [PR #5550](../pr/archives/pr_5550_review.md), [PR #5581](../pr/archives/pr_5581_review.md) 검토 기록은 소스 PR에 trailing commit으로 추가하지 않고 별도 docs-only PR로 검증한다.
+
 ## #5525 한글 2024 조판 호환 플래그
 
 - 원 PR source head `0a51e845741b8f9108dc43bb31cac589566386f7`를 기준으로 검토 archive와 오늘할일을 trailing docs-only commit으로 준비한다.

--- a/mydocs/pr/archives/pr_5545_review.md
+++ b/mydocs/pr/archives/pr_5545_review.md
@@ -1,11 +1,13 @@
 ---
 kind: pr-review
-status: approved-local-validation
+status: merged
 pr: 5545
 issue: 5518
 base: devel
 source_head: 37bd853590dddedfd9ca16d3aada41bce6bf755b
 integration_commit: 03f16cb371086a3a2084d21336beb2f414be3bfd
+integration_pr: 5581
+merge_commit: d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece
 ---
 
 # PR #5545 V-fresh toolVersion 검증기 검토
@@ -40,9 +42,11 @@ collaborator_self_merge.md, intake_and_review.md, post_merge.md
 - `cargo fmt --all -- --check`: 통과
 - `node scripts/rust-test-suite-manifest.mjs --check`: 통과
 - `node scripts/rust-unit-test-tiers.mjs --check`: 통과
+- 누적 통합 검증 `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 7,773 passed
+- 통합 PR #5581 CI: Lint, Native Skia, archive와 slow·regular shard, CodeQL 세 언어, Proptest, Adapter inter-diff, Build & Test 통과
 
 ## 결론
 
-**로컬 승인.** 원 저자 commit을 `-x` 계보로 적용했다. 누적 integration PR의 required CI가 성공하면
-[#5518](https://github.com/edwardkim/rhwp/issues/5518)을 aggregate PR로 종료하고, 원 PR #5545에는
-적용 commit과 병합 PR을 남긴 뒤 close한다.
+**병합 완료.** 원 저자 commit을 `-x` 계보로 적용한 뒤 통합 PR [#5581](https://github.com/edwardkim/rhwp/pull/5581)에
+포함했고, `d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece`로 `devel`에 병합됐다. 원 PR #5545와
+관련 이슈 [#5518](https://github.com/edwardkim/rhwp/issues/5518)는 통합 근거 댓글을 남긴 뒤 종료했다.

--- a/mydocs/pr/archives/pr_5546_review.md
+++ b/mydocs/pr/archives/pr_5546_review.md
@@ -1,11 +1,13 @@
 ---
 kind: pr-review
-status: approved-local-validation
+status: merged
 pr: 5546
 issue: 5508
 base: devel
 source_head: b3a4987765995bc0de9436d6ca72c04caa5649e9
 integration_commit: 0aadd6a26d64d9085a6bb2a2198159ad8c120970
+integration_pr: 5581
+merge_commit: d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece
 ---
 
 # PR #5546 V-abstain 봉투 모순 기권 검토
@@ -40,9 +42,11 @@ collaborator_self_merge.md, intake_and_review.md, post_merge.md
 - `cargo fmt --all -- --check`: 통과
 - `node scripts/rust-test-suite-manifest.mjs --check`: 통과
 - `node scripts/rust-unit-test-tiers.mjs --check`: 통과
+- 누적 통합 검증 `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 7,773 passed
+- 통합 PR #5581 CI: Lint, Native Skia, archive와 slow·regular shard, CodeQL 세 언어, Proptest, Adapter inter-diff, Build & Test 통과
 
 ## 결론
 
-**로컬 승인.** 원 저자 commit을 `-x` 계보로 적용했다. 누적 integration PR의 required CI가 성공하면
-[#5508](https://github.com/edwardkim/rhwp/issues/5508)을 aggregate PR로 종료하고, 원 PR #5546에는
-적용 commit과 병합 PR을 남긴 뒤 close한다.
+**병합 완료.** 원 저자 commit을 `-x` 계보로 적용한 뒤 통합 PR [#5581](https://github.com/edwardkim/rhwp/pull/5581)에
+포함했고, `d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece`로 `devel`에 병합됐다. 원 PR #5546과
+관련 이슈 [#5508](https://github.com/edwardkim/rhwp/issues/5508)는 통합 근거 댓글을 남긴 뒤 종료했다.

--- a/mydocs/pr/archives/pr_5550_review.md
+++ b/mydocs/pr/archives/pr_5550_review.md
@@ -1,6 +1,6 @@
 ---
 kind: pr-review
-status: approved-local-validation
+status: merged
 pr: 5550
 base: devel
 source_head: d53b4e355b1c1c59238f637ea8e1dd650e1bacce
@@ -13,6 +13,9 @@ integration_commits:
   - 5c6aff9e0aa72202a3e16476b3f0925b2b7d1a51
   - 523d76f317117b3d0e35770d39600d7b4abb91e0
 maintainer_correction: 27e733d143c3d2939540bd53c43386ac237f41dc
+integration_pr: 5581
+merge_commit: d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece
+post_validation_correction: 0c7dc94b2a0397c7bd0784b79b5e35c64bf5986f
 ---
 
 # PR #5550 rhwp-agent 조회 CLI 묶음 검토
@@ -57,6 +60,10 @@ collaborator_self_merge.md, intake_and_review.md, post_merge.md
 - `cargo fmt --all -- --check`: 통과
 - `node scripts/rust-test-suite-manifest.mjs --check`: 통과
 - `node scripts/rust-unit-test-tiers.mjs --check`: 통과
+- `0c7dc94b2`가 `capabilities --json`의 외부 명령 목록을 새 80개 공개 명령으로 갱신해 등재·실행 왕복 계약을 복구했다.
+- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 7,773 passed
+- `CARGO_TARGET_DIR=target/pr-review cargo clippy --all-targets -- -D warnings`: 통과
+- 통합 PR #5581 CI: Lint, Native Skia, archive와 slow·regular shard, CodeQL 세 언어, Proptest, Adapter inter-diff, Build & Test 통과
 
 ## 적용 계보
 
@@ -66,5 +73,6 @@ collaborator_self_merge.md, intake_and_review.md, post_merge.md
 
 ## 결론
 
-**로컬 승인.** 누적 integration PR의 required CI 성공 후 source PR #5550에 적용 계보와
-메인터너 보정을 기록하고 close한다.
+**병합 완료.** 누적 통합 PR [#5581](https://github.com/edwardkim/rhwp/pull/5581)이
+`d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece`로 `devel`에 병합됐다. 원 PR #5550에는 적용 계보와
+메인터너 보정 근거를 남긴 뒤 종료했다.

--- a/mydocs/pr/archives/pr_5581_review.md
+++ b/mydocs/pr/archives/pr_5581_review.md
@@ -1,0 +1,50 @@
+---
+kind: pr-review
+status: merged
+pr: 5581
+base: devel
+head: review/kevin9327-open-20260819
+merge_commit: d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece
+source_prs: [5545, 5546, 5550]
+issues: [5518, 5508]
+---
+
+# PR #5581 kevin9327 verifier와 rhwp-agent CLI 통합 검토
+
+## 라우팅
+
+```text
+base route: collaborator maintainer integration
+modifiers: external PR cherry-pick, cumulative validation, maintainer correction,
+post-merge source PR and issue closure, option B docs-only record
+loaded documents: pr_review_workflow.md, pr_review/README.md,
+collaborator_self_merge.md, intake_and_review.md, post_merge.md,
+local_validation.md
+```
+
+## 적용 범위
+
+| 원 PR | 적용 내용 | 원본 head |
+| --- | --- | --- |
+| [#5545](https://github.com/edwardkim/rhwp/pull/5545) | V-fresh toolVersion 검증기와 고정 코퍼스 | `37bd853590dddedfd9ca16d3aada41bce6bf755b` |
+| [#5546](https://github.com/edwardkim/rhwp/pull/5546) | V-abstain 봉투 모순 기권 검증기와 코퍼스 | `b3a4987765995bc0de9436d6ca72c04caa5649e9` |
+| [#5550](https://github.com/edwardkim/rhwp/pull/5550) | 읽기 전용 `rhwp-agent` 조회·비교·검색 명령 | `d53b4e355b1c1c59238f637ea8e1dd650e1bacce` |
+
+- 원 PR commit은 `-x` 계보로 누적 적용했다.
+- `tests/agent_cli_pack_contract.rs`는 `tests/cases/agent_cli_pack_contract.rs`로 옮겨 파생 harness에서 실제 실행되도록 보정했다.
+- CI가 발견한 `capabilities --json`의 고정 명령 계약 누락은 `0c7dc94b2`에서 80개 공개 명령으로 보정했다. 구현 단일 출처 `caps::COMMANDS`와 별도로 외부 공개 표면의 추가·삭제·개명을 감지한다.
+
+## 검증 기록
+
+- `node scripts/rust-test-suite-manifest.mjs --prepare`와 `--check`: 통과
+- `node scripts/rust-unit-test-tiers.mjs --check`: 통과
+- `cargo fmt --all -- --check`: 통과
+- `CARGO_TARGET_DIR=target/pr-review cargo clippy --all-targets -- -D warnings`: 통과
+- `cargo nextest run --cargo-profile release-test --target-dir target/pr-review --tests --test-threads 12 --no-fail-fast`: 7,773 passed
+- GitHub CI: Lint, Native Skia, archive builder, slow shard, regular shard 1~3, CodeQL 세 언어, Proptest, Adapter inter-diff, Frontend package gate, Build & Test aggregate 통과
+
+## 결론 및 후속 처리
+
+**병합 완료.** 통합 PR은 `d9ffc47f4f214f0cdadb1561ef5f00c6548a4ece`로 `devel`에 병합됐다.
+원 PR #5545, #5546, #5550에는 통합 근거 댓글을 남기고 종료했고, 관련 이슈 #5518과 #5508도 종료했다.
+이 문서는 소스 변경을 다시 실행시키지 않기 위해 옵션 B의 별도 docs-only PR로 보존한다.


### PR DESCRIPTION
## 변경 내용
- #5581 통합 병합, 전체 회귀, CI 결과를 검토 기록으로 보존합니다.
- 원 PR #5545, #5546, #5550과 이슈 #5518, #5508의 종료 근거를 오늘할일과 개별 검토 기록에 반영합니다.
- 소스 PR에는 trailing commit을 추가하지 않고, 별도 docs-only PR로 분리합니다.

## 검증
- `git diff --check` 통과
- 문서 전용 영향도이므로 CI fast-pass와 aggregate 성공을 확인합니다.

Closes none.