### PR TITLE
fix(renderer): 어울림(Square) 표의 문단 기준 세로 오프셋을 렌더 y 에 반영한다 (#5566)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -8404,6 +8404,22 @@ impl LayoutEngine {
                 } else if let Some(anchor_y) = square_anchor_y {
                     table_visual_shift = (anchor_y - y_offset).max(0.0);
                     anchor_y
+                } else if !is_tac
+                    && tbl_is_square
+                    && matches!(t.common.vert_rel_to, VertRelTo::Para)
+                    && para_has_visible_text(para)
+                    && signed_hwpunit(t.common.vertical_offset) > 0
+                {
+                    // [#5566] 가시 텍스트 host 에 앵커된 어울림(Square) 표의 문단 기준
+                    // 양수 세로 오프셋. 종전에는 이 형상이 어느 분기에도 안 걸려
+                    // 폴백(y_offset = 앵커 줄 상단)으로 떨어져 표가 host 첫 줄 텍스트
+                    // 위에 얹혔다(가로 오프셋은 tbl_inline_x 로 적용돼 세로만 소실 —
+                    // 20180108093532000 8쪽, 10k 영향 64문서). 빈 host 는 위의
+                    // para_float_lane 경로가, 저장 사다리 신호가 있는 우측 다줄 wrap 은
+                    // square_anchor_y 가 이미 정합 처리하므로 여기 오지 않는다.
+                    // 음수 오프셋은 실측이 없어 종전(무시) 동작을 유지한다.
+                    para_y_for_table
+                        + hwpunit_to_px(signed_hwpunit(t.common.vertical_offset), self.dpi)
                 } else if tac_detached_line_shift > 0.0 {
                     y_offset + tac_detached_line_shift
                 } else {

--- a/tests/cases/issue_5566_square_table_voffset.rs
+++ b/tests/cases/issue_5566_square_table_voffset.rs
@@ -1,0 +1,167 @@
+//! [#5566] 어울림(Square) 비-TAC 표의 문단 기준 세로 오프셋(vertOffset) 렌더 계약.
+//!
+//! horz_rel_to=Para 인 Square 표는 x 만 인라인 경로에서 계산되고 y 는 흐름
+//! 시작점에 직결돼, vertOffset(PARA) 이 소실되면 표가 앵커 줄 첫 텍스트 위에
+//! 얹힌다(20180108093532000 8쪽: 제목 줄과 1×7 절차 표 겹침 — 가로 오프셋만
+//! 적용되고 세로는 0 고정, 10k 코퍼스 영향 64문서).
+//!
+//! 픽스처: 기존 표 샘플의 첫 표를 Square·Para·오프셋으로 변조해 HWPX 로
+//! 내보낸다(HWP5 재저장은 새 배치 속성을 raw_ctrl_data 경로에서 유실하고,
+//! create_empty 합성 문서는 HWPX 직렬화 전제 스타일 등록이 없다 — 실샘플
+//! 변조 + HWPX 왕복이 이 계약을 태우는 최소 경로다). 판정은 CLI
+//! `dump-extents` 의 첫 최상위 표 y — 오프셋 0 대비 1904HU(≈25.4px)만큼
+//! 내려가야 한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::{HorzRelTo, TextWrap, VertRelTo};
+use rhwp::wasm_api::HwpDocument;
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-5566-{tag}-{}-{}.hwpx",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn fixture(vert_offset: u32) -> PathBuf {
+    let bytes = std::fs::read(repo_path("samples/hwp_table_test-m.hwp")).expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("샘플 파싱");
+
+    // 첫 표의 위치를 찾는다.
+    let mut loc = None;
+    'find: for (si, section) in doc.document().sections.iter().enumerate() {
+        for (pi, para) in section.paragraphs.iter().enumerate() {
+            if para.controls.iter().any(|c| matches!(c, Control::Table(_))) {
+                loc = Some((si, pi));
+                break 'find;
+            }
+        }
+    }
+    let (si, pi) = loc.expect("샘플에 표가 없다");
+
+    // 이 계약은 **가시 텍스트 host** 에 앵커된 표가 대상이다(빈 host 는 별도
+    // lane 경로가 정합 처리 — issue_4090 계약). host 문단에 앵커 텍스트를 넣는다.
+    doc.insert_text(si as u32, pi as u32, 0, "앵커 제목 줄")
+        .expect("host 텍스트 삽입");
+
+    let para = &mut doc.document_mut().sections[si].paragraphs[pi];
+    let table = para
+        .controls
+        .iter_mut()
+        .find_map(|c| match c {
+            Control::Table(t) => Some(t),
+            _ => None,
+        })
+        .expect("표");
+    table.common.treat_as_char = false;
+    table.common.text_wrap = TextWrap::Square;
+    table.common.vert_rel_to = VertRelTo::Para;
+    table.common.horz_rel_to = HorzRelTo::Para;
+    table.common.vertical_offset = vert_offset;
+
+    let out = temp(&format!("voff{vert_offset}"));
+    std::fs::write(&out, doc.export_hwpx_native().expect("HWPX 내보내기")).unwrap();
+    out
+}
+
+/// 전 페이지 dump-extents 에서 첫 최상위 표의 y 시작과, 그 표 뒤 첫 최상위
+/// 본문 TextLine 의 y 시작을 파싱한다(셀 내부 줄은 들여쓰기가 더 깊다).
+fn first_table_and_next_line_y(path: &PathBuf) -> (f64, f64) {
+    let out = Command::new(rhwp_bin())
+        .args(["dump-extents"])
+        .arg(path)
+        .output()
+        .expect("dump-extents 실행");
+    let text = String::from_utf8_lossy(&out.stdout).to_string();
+    let mut table_y = None;
+    let mut next_line_y = None;
+    for line in text.lines() {
+        let t = line.trim_start();
+        if table_y.is_none() {
+            if t.starts_with("Table ") {
+                table_y = parse_y(t);
+            }
+            continue;
+        }
+        if next_line_y.is_none()
+            && line.starts_with("      TextLine ")
+            && !line.starts_with("       ")
+        {
+            next_line_y = parse_y(t);
+            break;
+        }
+    }
+    (
+        table_y.unwrap_or_else(|| panic!("Table 노드 없음:\n{text}")),
+        next_line_y.unwrap_or(f64::NAN),
+    )
+}
+
+fn parse_y(line: &str) -> Option<f64> {
+    let yp = line.find("y=")?;
+    let rest = &line[yp + 2..];
+    let end = rest.find("..")?;
+    rest[..end].trim().parse::<f64>().ok()
+}
+
+#[test]
+fn square_para_table_respects_positive_vert_offset() {
+    let f0 = fixture(0);
+    let f1 = fixture(1904); // 1904 HU ≈ 25.39px @96dpi
+
+    // 배치 속성이 HWPX 왕복에서 살아남는지 선확인.
+    let rp = HwpDocument::from_bytes(&std::fs::read(&f1).unwrap()).expect("재파싱");
+    let rp_ok = rp.document().sections.iter().any(|s| {
+        s.paragraphs.iter().any(|p| {
+            p.controls.iter().any(|c| {
+                matches!(
+                    c,
+                    Control::Table(t)
+                        if !t.common.treat_as_char
+                            && matches!(t.common.text_wrap, TextWrap::Square)
+                            && matches!(t.common.vert_rel_to, VertRelTo::Para)
+                            && t.common.vertical_offset == 1904
+                )
+            })
+        })
+    });
+    assert!(rp_ok, "HWPX 왕복에서 배치 속성 유실");
+
+    let (t0, n0) = first_table_and_next_line_y(&f0);
+    let (t1, n1) = first_table_and_next_line_y(&f1);
+    let _ = std::fs::remove_file(&f0);
+    let _ = std::fs::remove_file(&f1);
+
+    let delta = t1 - t0;
+    let expected = 1904.0 * 96.0 / 7200.0;
+    assert!(
+        (delta - expected).abs() < 1.5,
+        "Square·Para 표의 vertOffset 이 렌더 y 에 반영되지 않았다: delta={delta:.2}px \
+         (기대 {expected:.2}px) — offset0 table_y={t0:.1}, offset1904 table_y={t1:.1}"
+    );
+    // 후속 흐름은 프로파일에 따라 저장 vpos(불변) 또는 흐름 전진(오프셋 동반,
+    // 20180108093532000 실측)으로 갈린다 — 여기서는 후속 줄이 표 위로 끌려
+    // 올라가지 않았다는 최소 불변식만 고정한다.
+    if n0.is_finite() && n1.is_finite() {
+        assert!(
+            n1 >= n0 - 0.5,
+            "표 뒤 본문 줄이 위로 끌려갔다: {n0:.2} -> {n1:.2}"
+        );
+    }
+}


### PR DESCRIPTION
# fix(renderer): 어울림(Square) 표의 문단 기준 세로 오프셋을 렌더 y 에 반영한다 (#5566)

## 근인

**가시 텍스트 host** 에 앵커된 어울림(Square) 비-TAC 표(vertRelTo=Para, vertOffset>0)는 `layout.rs` 의 `table_y_start` 캐스케이드(빈 host lane → 예약 gap → 절대 top → TAC inline → 저장 다줄 float top → visible TopAndBottom → 저장 사다리 square_anchor_y)의 **어느 분기에도 걸리지 않아 폴백(y_offset = 앵커 줄 상단)으로 떨어진다**. 가로 오프셋은 `tbl_inline_x` 경로로 적용되므로 세로만 소실 — 표가 host 첫 줄 텍스트 위에 얹혀 겹친다.

## 수정

캐스케이드의 `square_anchor_y`(저장 사다리 앵커 — 우측 다줄 wrap 실측 신호, 우선 유지) **다음 순위**에 `para_y + vertOffset` 분기를 추가. 가드 = 비-TAC ∧ Square ∧ vertRelTo=Para ∧ **host 가시 텍스트** ∧ 양수 오프셋.

- **빈 host 는 제외**: 기존 `para_float_lane` 경로가 이미 한글 PDF 정답지에 맞춰 정합 처리한다 — 초기 시도(무가드로 table_layout 쪽에 적용)는 `issue_4090_empty_host_right_square_table_keeps_left_wrap_prefix` 가 **이중 적용 회귀**로 잡아냈고, 판별자(host 가시 텍스트)를 세워 재설계했다. 4090 계약은 최종본에서 통과.
- 음수 오프셋은 실측이 없어 종전(무시) 동작 유지.

## 실측

- **20180108093532000(2018 후기고 전학 계획) 8쪽**: 제목 "다. 서류접수반 업무 흐름도"와 1×7 절차 표가 y=75.6 에서 겹침 → 표 y **75.6 → 101.0**(= 문단 상단 + 1904HU=25.4px 정확), 겹침 해소. 후속 줄(pi=154/155)도 25.4px 전진해 한글 저장 vpos(202.8/234.0)에 더 근접(종전 166.2/211.3 → 191.6/222.8). export-png 전후 시각 확인.
- **10k 코퍼스 영향 전수**: HWP5 원시 CTRL_HEADER 비트 스캔(tac=0·wrap=Square·vertRelTo=Para·vertOffset>0, 양성대조=위 문서)으로 6,474 HWP5 중 **영향 64문서**. `word-count --json` A/B(계수 상위 60): **쪽수 변화 0**, charCount 전량 불변.
- **최다 영향 문서**(문체부 연구보고서, 해당 표 46개): SVG 전후 변경 16쪽, 스팟체크(236쪽)에서 같은 부류의 표-표 겹침(구성요인 표 ↔ 설문 표) 해소 확인 — 제보된 "동일 패턴 재발"이 실제로 코퍼스에 퍼진 결함이었다.

## 게이트

- 계약 테스트 `issue_5566_square_table_voffset`(신규): 실샘플 표를 host 텍스트 삽입 + Square·Para·1904HU 변조 → HWPX 왕복 → dump-extents 로 표 y 델타 25.4px 판정. **음성 대조: 수정 없이 FAIL 확인**. 기존 `issue_4090` Square 계약과 동시 통과.
- 픽스처 조사 부산물: **HWP5 재저장이 새로 만든 표의 배치 속성(wrap/vertOffset)을 유실**(#2055 계열) — 별도 이슈 예정.
- rustfmt(변경 파일)·`cargo check --target wasm32 --lib`·manifest/tier 체크·manifest 단위 테스트 통과
- clippy `-D warnings`·nextest 전체·Native Skia 3종(release-test): 결과는 아래 코멘트로 갱신
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(변경 파일 rustfmt 직접 검사로 대체) · Docker 부재로 표준 WASM 빌드 대신 CI WASM lane 로컬 재현

이슈 #5566 (동반 조사 #5568=PR #5577)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
