### PR TITLE
fix(ci): review tail 보조 검증을 재사용한다

### DIFF
--- a/.github/workflows/adapter-diff.yml
+++ b/.github/workflows/adapter-diff.yml
@@ -13,7 +13,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 concurrency:
   group: adapter-diff-${{ github.workflow }}-${{ github.ref }}
@@ -28,47 +30,100 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     outputs:
-      adapter_required: ${{ steps.classify.outputs.adapter_required }}
-      reason: ${{ steps.classify.outputs.reason }}
+      adapter_required: ${{ steps.classify.outputs.adapter_required || 'true' }}
+      reason: ${{ steps.classify.outputs.reason || 'preflight-unavailable' }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Classify adapter inter-diff impact
+      # 문서 전용 PR 또는 검증된 코드 후보 뒤의 mydocs review tail에서는 stable check
+      # 이름을 유지하고 worker만 skip한다. API·계보·후보 run 판정은 fail-closed다.
+      - name: Classify documentation-only or trusted trailing review tail
         id: classify
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if [[ "${EVENT_NAME}" != "pull_request" || -z "${BASE_SHA}" || -z "${HEAD_SHA}" ]]; then
-            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
-            echo "reason=full-non-pr-event" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            function setResult(required, reason) {
+              core.setOutput('adapter_required', required ? 'true' : 'false');
+              core.setOutput('reason', reason);
+              core.info(`adapter_required=${required} reason=${reason}`);
+            }
 
-          if ! changed_files="$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"; then
-            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
-            echo "reason=fail-closed-pr-diff-unavailable" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            const pr = context.payload.pull_request;
+            if (context.eventName !== 'pull_request' || !pr || pr.base.ref !== 'devel') {
+              setResult(true, `full-non-devel-pr:${pr?.base?.ref || context.eventName}`);
+              return;
+            }
 
-          if [[ -z "${changed_files}" ]]; then
-            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
-            echo "reason=fail-closed-empty-pr-diff" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            function isMydocsOnly(files) {
+              return files.length > 0 && files.every((file) => (
+                file.filename.startsWith('mydocs/')
+                && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
+              ));
+            }
 
-          if printf '%s\n' "${changed_files}" | grep -qv '^mydocs/'; then
-            echo "adapter_required=true" >> "$GITHUB_OUTPUT"
-            echo "reason=full-non-documentation-change" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            if (isMydocsOnly(files)) {
+              setResult(false, 'skip-mydocs-only-pr');
+              return;
+            }
 
-          echo "adapter_required=false" >> "$GITHUB_OUTPUT"
-          echo "reason=skip-mydocs-only-pr" >> "$GITHUB_OUTPUT"
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            let tailStart = commits.length;
+            for (let index = commits.length - 1; index >= 0; index -= 1) {
+              const commit = commits[index];
+              const detail = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: commit.sha,
+              });
+              const commitFiles = detail.data.files || [];
+              if (commitFiles.length === 0 || commitFiles.length >= 300 || !isMydocsOnly(commitFiles)) {
+                break;
+              }
+              tailStart = index;
+            }
+
+            const tail = commits.slice(tailStart);
+            const candidate = commits[tailStart - 1];
+            const linearTail = tail.length > 0 && tail.length <= 20 && candidate && tail.every((commit, index) => {
+              const expectedParent = index === 0 ? candidate.sha : tail[index - 1].sha;
+              return (commit.parents || []).length === 1 && commit.parents[0].sha === expectedParent;
+            });
+            if (!linearTail) {
+              setResult(true, 'full-code-or-non-mydocs-change');
+              return;
+            }
+
+            const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'adapter-diff.yml',
+              event: 'pull_request',
+              head_sha: candidate.sha,
+              per_page: 100,
+            });
+            const latestCandidateRun = candidateRuns
+              .filter((run) => (
+                run.event === 'pull_request'
+                && run.head_sha === candidate.sha
+                && (run.pull_requests || []).some((runPr) => Number(runPr.number) === Number(pr.number))
+              ))
+              .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+            if (!latestCandidateRun || latestCandidateRun.status !== 'completed' || latestCandidateRun.conclusion !== 'success') {
+              setResult(true, 'review-tail-candidate-run-unavailable');
+              return;
+            }
+
+            setResult(false, `skip-trusted-mydocs-tail:${candidate.sha}`);
 
   adapter-diff:
     name: adapter inter-diff

--- a/.github/workflows/proptest-roundtrip.yml
+++ b/.github/workflows/proptest-roundtrip.yml
@@ -16,6 +16,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pull-requests: read
 
@@ -34,9 +35,10 @@ jobs:
       fast_pass: ${{ steps.finalize.outputs.fast_pass || 'false' }}
       reason: ${{ steps.finalize.outputs.reason || 'preflight-unavailable' }}
     steps:
-      # 문서 전용 devel PR도 `prop roundtrip` check 이름은 남겨야 한다. workflow-level
-      # paths-ignore를 쓰면 required check가 사라질 수 있으므로 job 조건으로 skip한다.
-      - name: Detect mydocs-only devel PR
+      # 문서 전용 devel PR과 검증된 코드 후보 뒤의 mydocs review tail도 `prop roundtrip`
+      # check 이름은 남겨야 한다. workflow-level paths-ignore를 쓰면 required check가
+      # 사라질 수 있으므로 job 조건으로 skip한다.
+      - name: Detect mydocs-only or trusted trailing review tail
         id: detect
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -57,17 +59,78 @@ jobs:
               setResult(false, `non-devel-base:${pr?.base?.ref || 'unknown'}`);
               return;
             }
+
+            function isMydocsOnly(files) {
+              return files.length > 0 && files.every((file) => (
+                file.filename.startsWith('mydocs/')
+                && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
+              ));
+            }
+
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pr.number,
               per_page: 100,
             });
-            const mydocsOnly = files.length > 0 && files.every((file) => (
-              file.filename.startsWith('mydocs/')
-              && (!file.previous_filename || file.previous_filename.startsWith('mydocs/'))
-            ));
-            setResult(mydocsOnly, mydocsOnly ? 'mydocs-only-devel-pr' : 'code-or-non-mydocs-change');
+            if (isMydocsOnly(files)) {
+              setResult(true, 'mydocs-only-devel-pr');
+              return;
+            }
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            let tailStart = commits.length;
+            for (let index = commits.length - 1; index >= 0; index -= 1) {
+              const commit = commits[index];
+              const detail = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: commit.sha,
+              });
+              const commitFiles = detail.data.files || [];
+              if (commitFiles.length === 0 || commitFiles.length >= 300 || !isMydocsOnly(commitFiles)) {
+                break;
+              }
+              tailStart = index;
+            }
+
+            const tail = commits.slice(tailStart);
+            const candidate = commits[tailStart - 1];
+            const linearTail = tail.length > 0 && tail.length <= 20 && candidate && tail.every((commit, index) => {
+              const expectedParent = index === 0 ? candidate.sha : tail[index - 1].sha;
+              return (commit.parents || []).length === 1 && commit.parents[0].sha === expectedParent;
+            });
+            if (!linearTail) {
+              setResult(false, 'code-or-non-mydocs-change');
+              return;
+            }
+
+            const candidateRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'proptest-roundtrip.yml',
+              event: 'pull_request',
+              head_sha: candidate.sha,
+              per_page: 100,
+            });
+            const latestCandidateRun = candidateRuns
+              .filter((run) => (
+                run.event === 'pull_request'
+                && run.head_sha === candidate.sha
+                && (run.pull_requests || []).some((runPr) => Number(runPr.number) === Number(pr.number))
+              ))
+              .sort((left, right) => Date.parse(right.created_at) - Date.parse(left.created_at))[0];
+            if (!latestCandidateRun || latestCandidateRun.status !== 'completed' || latestCandidateRun.conclusion !== 'success') {
+              setResult(false, 'review-tail-candidate-run-unavailable');
+              return;
+            }
+
+            setResult(true, `trusted-mydocs-tail:${candidate.sha}`);
 
       - name: Finalize fast pass
         id: finalize

--- a/mydocs/working/task_m100_5596_stage1_review_tail_aux_workflows.md
+++ b/mydocs/working/task_m100_5596_stage1_review_tail_aux_workflows.md
@@ -1,0 +1,34 @@
+---
+kind: working
+status: active
+issue: 5596
+---
+
+# #5596 review-only trailing tail 보조 workflow fast-pass
+
+## 관찰
+
+- [#5569](https://github.com/edwardkim/rhwp/pull/5569)의 review 기록 trailing head는 `mydocs/**`만
+  바꿨지만, PR 전체 diff에 코드 후보가 남아 `Proptest roundtrip`과 `Adapter inter-diff` worker가
+  재실행됐다.
+- 기본 CI는 검증 완료 코드 후보 뒤의 review-only tail을 식별하지만, 두 보조 workflow는 단순
+  PR 전체 diff만 확인한다.
+
+## 설계
+
+- 기존 전체 `mydocs/**` PR skip과 stable check 이름을 유지한다.
+- PR head의 마지막 연속 `mydocs/**` commit들을 찾고, 선형 parent 연결과 최대 20개 tail을 확인한다.
+- tail 직전 후보 SHA에서 같은 PR 번호의 동일 workflow 최신 run이 `success`일 때만 worker를 skip한다.
+- GitHub API, 파일 목록, 계보, 후보 run 중 하나라도 확인하지 못하면 worker를 실행한다.
+- 이 workflow 변경은 `devel` 대상 PR에서 즉시 적용되며 `main` 반영을 기다리지 않는다.
+
+## 검증 계획
+
+1. Proptest와 Adapter workflow contract test를 실행한다.
+2. CI impact workflow contract test를 실행해 workflow 배선의 fail-closed 기대값을 확인한다.
+3. 최신 head PR의 Actions에서 preflight는 성공하고 두 worker가 `skipped`로 남는지 관찰한다.
+
+## 검증 결과
+
+- `python3 -m unittest scripts/tests/test_proptest_roundtrip_workflow.py scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_ci_impact_workflow.py`: 48 passed.
+- `git diff --check`: passed.

--- a/mydocs/working/task_m100_5600_stage1_release_version_alignment.md
+++ b/mydocs/working/task_m100_5600_stage1_release_version_alignment.md
@@ -1,0 +1,23 @@
+---
+kind: working
+status: active
+issue: 5600
+---
+
+# #5600 사용자 표시 버전 기준선 정합
+
+## 원인
+
+release channel 정책은 `Cargo.toml`의 release version `0.8.4`와 Studio About, Chrome/Edge,
+Firefox 확장 표시 버전이 모두 같아야 한다. Chrome과 Firefox 매니페스트는 이미 `0.8.4`지만,
+`rhwp-studio/package.json`과 lockfile 루트 항목이 `0.8.5`여서 CI Lint가 실패했다.
+
+## 보정
+
+- Studio package와 lockfile 루트 package version을 `0.8.4`로 되돌린다.
+- 확장 매니페스트는 release version과 이미 일치하므로 변경하지 않는다.
+
+## 검증 계획
+
+1. `python3 -m unittest scripts/tests/test_release_channel_policy_workflow.py`를 실행한다.
+2. `cargo fmt --all -- --check`와 `git diff --check`를 실행한다.

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.5",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.8.5",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.3.0",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.5",
+  "version": "0.8.4",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/tests/test_adapter_diff_workflow.py
+++ b/scripts/tests/test_adapter_diff_workflow.py
@@ -36,14 +36,17 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
 
-    def test_mydocs_only_pr_skips_adapter_job_but_keeps_a_stable_check(self) -> None:
+    def test_mydocs_only_or_trusted_trailing_tail_skips_adapter_job_but_keeps_a_stable_check(self) -> None:
         self.assertIn("adapter-impact:", self.wf)
         self.assertIn("name: adapter inter-diff preflight", self.wf)
-        self.assertIn("fetch-depth: 0", self.wf)
-        self.assertIn('git diff --name-only "${BASE_SHA}" "${HEAD_SHA}"', self.wf)
-        self.assertIn("grep -qv '^mydocs/'", self.wf)
-        self.assertIn("adapter_required=false", self.wf)
-        self.assertIn("reason=fail-closed-pr-diff-unavailable", self.wf)
+        self.assertIn("uses: actions/github-script", self.wf)
+        self.assertIn("github.rest.pulls.listCommits", self.wf)
+        self.assertIn("github.rest.repos.getCommit", self.wf)
+        self.assertIn("workflow_id: 'adapter-diff.yml'", self.wf)
+        self.assertIn("github.rest.actions.listWorkflowRuns", self.wf)
+        self.assertIn("core.setOutput('adapter_required', required ? 'true' : 'false')", self.wf)
+        self.assertIn("skip-trusted-mydocs-tail:", self.wf)
+        self.assertIn("review-tail-candidate-run-unavailable", self.wf)
         self.assertIn("needs: adapter-impact", self.wf)
         self.assertIn(
             "needs.adapter-impact.outputs.adapter_required == 'true'", self.wf
@@ -76,7 +79,9 @@ class AdapterDiffWorkflowTests(unittest.TestCase):
         self.assertIn("expected 4 shard count files", self.ci)
 
     def test_read_only_permissions(self) -> None:
+        self.assertIn("actions: read", self.wf)
         self.assertIn("contents: read", self.wf)
+        self.assertIn("pull-requests: read", self.wf)
 
     def test_skips_missing_adapters_honestly(self) -> None:
         self.assertIn("png", RUNNER.read_text(encoding="utf-8"))

--- a/scripts/tests/test_proptest_roundtrip_workflow.py
+++ b/scripts/tests/test_proptest_roundtrip_workflow.py
@@ -32,11 +32,17 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertIn("pull_request:", self.wf)
         self.assertIn("branches: [main, devel]", self.wf)
 
-    def test_mydocs_only_devel_pr_skips_worker_without_hiding_check(self) -> None:
+    def test_mydocs_only_or_trusted_trailing_tail_skips_worker_without_hiding_check(self) -> None:
         self.assertIn("name: Proptest preflight", self.wf)
         self.assertIn("pr.base.ref !== 'devel'", self.wf)
         self.assertIn("file.filename.startsWith('mydocs/')", self.wf)
         self.assertIn("file.previous_filename.startsWith('mydocs/')", self.wf)
+        self.assertIn("github.rest.pulls.listCommits", self.wf)
+        self.assertIn("github.rest.repos.getCommit", self.wf)
+        self.assertIn("workflow_id: 'proptest-roundtrip.yml'", self.wf)
+        self.assertIn("github.rest.actions.listWorkflowRuns", self.wf)
+        self.assertIn("trusted-mydocs-tail:", self.wf)
+        self.assertIn("review-tail-candidate-run-unavailable", self.wf)
         self.assertIn("name: prop roundtrip", self.wf)
         self.assertIn("needs: preflight", self.wf)
         self.assertIn("needs.preflight.outputs.fast_pass != 'true'", self.wf)
@@ -68,6 +74,7 @@ class ProptestRoundtripWorkflowTests(unittest.TestCase):
         self.assertIn("expected 4 shard count files", self.ci)
 
     def test_read_only_permissions(self) -> None:
+        self.assertIn("actions: read", self.wf)
         self.assertIn("contents: read", self.wf)
         self.assertIn("pull-requests: read", self.wf)
 


### PR DESCRIPTION
## 요약

- 코드 후보 뒤에 `mydocs/**` review-only trailing tail이 붙은 PR에서 Proptest와 Adapter inter-diff worker를 재사용 가능한 이전 성공 run으로 판정합니다.
- API, 파일 목록, 선형 계보, 동일 PR의 후보 workflow 성공 run을 모두 확인하지 못하면 기존처럼 worker를 실행합니다.
- stable preflight/check 이름은 유지하고 worker만 skip합니다.
- release policy 기준선에 맞게 Studio package와 lockfile 루트 version을 `0.8.4`로 복구합니다.

## 근거

[#5569](https://github.com/edwardkim/rhwp/pull/5569)의 trailing docs head에서 두 workflow가 PR 전체 diff의 코드 파일 때문에 다시 실행됐습니다. 이어 CI Lint에서 Studio `0.8.5`와 Cargo·확장 manifest `0.8.4`의 기준선 불일치를 확인했습니다.

## 검증

- `python3 -m unittest scripts/tests/test_proptest_roundtrip_workflow.py scripts/tests/test_adapter_diff_workflow.py scripts/tests/test_ci_impact_workflow.py`
  - 48 passed
- `python3 -m unittest scripts/tests/test_release_channel_policy_workflow.py`
  - 5 passed
- `npm --prefix rhwp-studio ci --ignore-scripts`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #5596
Closes #5600
