### PR TITLE
fix(release): Studio 표시 버전을 정합한다

### DIFF
--- a/mydocs/working/task_m100_5600_stage1_release_version_alignment.md
+++ b/mydocs/working/task_m100_5600_stage1_release_version_alignment.md
@@ -1,0 +1,23 @@
+---
+kind: working
+status: active
+issue: 5600
+---
+
+# #5600 사용자 표시 버전 기준선 정합
+
+## 원인
+
+release channel 정책은 `Cargo.toml`의 release version `0.8.4`와 Studio About, Chrome/Edge,
+Firefox 확장 표시 버전이 모두 같아야 한다. Chrome과 Firefox 매니페스트는 이미 `0.8.4`지만,
+`rhwp-studio/package.json`과 lockfile 루트 항목이 `0.8.5`여서 CI Lint가 실패했다.
+
+## 보정
+
+- Studio package와 lockfile 루트 package version을 `0.8.4`로 되돌린다.
+- 확장 매니페스트는 release version과 이미 일치하므로 변경하지 않는다.
+
+## 검증 계획
+
+1. `python3 -m unittest scripts/tests/test_release_channel_policy_workflow.py`를 실행한다.
+2. `cargo fmt --all -- --check`와 `git diff --check`를 실행한다.

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.5",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.8.5",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.3.0",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhwp-studio",
-  "version": "0.8.5",
+  "version": "0.8.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 요약

- Studio 패키지와 lockfile 루트 버전을 공식 release version `0.8.4`로 되돌립니다.
- Chrome/Edge와 Firefox 확장 매니페스트는 이미 `0.8.4`이므로 변경하지 않습니다.

## 원인

`rhwp-studio`만 `0.8.5`로 앞서 있어 release-channel 정책이 사용자 표시 버전 불일치를 차단했습니다.

## 검증

- `python3 -m unittest scripts/tests/test_release_channel_policy_workflow.py`
  - 5 passed
- `npm --prefix rhwp-studio ci --ignore-scripts`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #5600
