### PR TITLE
fix(parser/hwp3): 구역 첫 문단에 SectionDef 를 합성하고 secd/cold 8유닛 슬롯을 좌표에 계상한다 (#5542, #5532)

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -4269,6 +4269,82 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, doc_info: &Hwp3D
             fixup_hwp3_answer_column_def(&mut section.paragraphs, &para_shapes, body_width_hu);
         }
     }
+
+    // [#5542/#5532] 구역 첫 문단에 SectionDef 컨트롤을 합성하고 secd/cold 의
+    // 8유닛 슬롯을 문단 좌표계에 계상한다 — 모든 앞머리 컨트롤 합성이 끝난
+    // 뒤(위 fixup 들 포함) 한 번만.
+    for section in &mut doc.sections {
+        let section_def = section.section_def.clone();
+        account_hwp3_section_leading_control_units(&mut section.paragraphs, section_def);
+    }
+}
+
+/// [#5542] 구역 첫 문단의 IR 계약 정합 — `Control::SectionDef` 합성 + 슬롯 계상.
+///
+/// HWP5 파서(`body_text.rs`)는 구역 첫 문단 controls 에 `SectionDef`/`ColumnDef` 를
+/// 싣고, PARA_TEXT 의 확장 컨트롤 코드가 8유닛씩 위치 좌표(char_offsets·char_shapes·
+/// lineseg textpos·char_count)를 전진시킨다. HWPX 파서도 `secPr`/`colPr` 마다 같은
+/// 8유닛을 센다. HWP3 파서는 두 컨트롤을 텍스트 스트림 밖에서 합성해 왔는데
+/// (SectionDef 는 아예 미합성 — HWP5 직렬화기가 임시 사본으로 보완, #1915),
+/// 위치 계상이 빠져 h2x 저장-재파싱에서 구역 첫 문단의 char_shapes 경계가 컨트롤
+/// 몫만큼 어긋났다(hwp3-curve·hwp3-sample5 paragraph[0]: +16, --verify exit 3).
+/// 좌표만 전진시키고 SectionDef 컨트롤이 없으면, HWPX 직렬화기의 hidden-슬롯 정합
+/// (#1591 v2: slot_count == 가시 + hidden)이 증거 불일치로 mismatch 폴백에 빠져
+/// 저장 lineseg 가 억제된다 — 컨트롤 합성과 좌표 계상은 한 몸이다.
+///
+/// 직렬화기는 같은 좌표계(char_offsets)로 텍스트를 사상하므로 출력 run 구조는
+/// 불변이고, 저장 linesegarray 의 textpos 만 재파싱 좌표와 정합하게 된다.
+fn account_hwp3_section_leading_control_units(
+    paragraphs: &mut [crate::model::paragraph::Paragraph],
+    section_def: crate::model::document::SectionDef,
+) {
+    use crate::model::control::Control;
+
+    let Some(first) = paragraphs.first_mut() else {
+        return;
+    };
+    // SectionDef 존재 = 이미 이 보정을 거친(또는 좌표가 계상된 HWP5/HWPX 계열)
+    // 문단 — 재적용해도 좌표를 다시 밀지 않는다(멱등).
+    if first
+        .controls
+        .iter()
+        .any(|control| matches!(control, Control::SectionDef(_)))
+    {
+        return;
+    }
+    first
+        .controls
+        .insert(0, Control::SectionDef(Box::new(section_def)));
+    // ctrl_data_records[i] ↔ controls[i] 병렬 계약 유지 (#3214).
+    if !first.ctrl_data_records.is_empty() {
+        first.ctrl_data_records.insert(0, None);
+    }
+
+    // 재파싱이 세게 될 앞머리 슬롯(secd·cold 연쇄) 수만큼 좌표를 전진시킨다.
+    let slots = first
+        .controls
+        .iter()
+        .take_while(|control| matches!(control, Control::SectionDef(_) | Control::ColumnDef(_)))
+        .count() as u32;
+    let shift = slots * 8;
+    if shift == 0 {
+        return;
+    }
+    for offset in &mut first.char_offsets {
+        *offset += shift;
+    }
+    for char_shape in &mut first.char_shapes {
+        // 선두 대표 글자모양(start_pos=0)은 컨트롤 슬롯까지 덮으므로 0 을 유지한다.
+        if char_shape.start_pos > 0 {
+            char_shape.start_pos += shift;
+        }
+    }
+    for line_seg in &mut first.line_segs {
+        if line_seg.text_start > 0 {
+            line_seg.text_start += shift;
+        }
+    }
+    first.char_count += shift;
 }
 
 fn ensure_hwp3_initial_body_column_def(paragraphs: &mut [crate::model::paragraph::Paragraph]) {
@@ -4288,6 +4364,11 @@ fn ensure_hwp3_initial_body_column_def(paragraphs: &mut [crate::model::paragraph
     first_paragraph
         .controls
         .insert(0, Control::ColumnDef(hwp3_default_body_column_def()));
+    // ctrl_data_records[i] ↔ controls[i] 병렬 계약 유지 (#3214) — 앞삽입이
+    // 기존 Some(data) 의 대응을 밀지 않게 한다.
+    if !first_paragraph.ctrl_data_records.is_empty() {
+        first_paragraph.ctrl_data_records.insert(0, None);
+    }
 }
 
 fn fixup_hwp3_answer_column_def(
@@ -5032,12 +5113,19 @@ mod tests {
 
         fixup_hwp3_notes(&mut doc, &Hwp3DocInfo::default());
         let controls = &doc.sections[0].paragraphs[0].controls;
+        // [#5542] 구역 첫 문단은 secd → cold 연쇄로 시작한다(HWP5 파서 IR 동형).
         assert!(
-            matches!(controls.first(), Some(Control::ColumnDef(_))),
-            "미주가 없어도 HWP3 구역 첫 문단은 cold로 시작해야 한다"
+            matches!(controls.first(), Some(Control::SectionDef(_))),
+            "HWP3 구역 첫 문단은 secd로 시작해야 한다"
         );
+        assert!(
+            matches!(controls.get(1), Some(Control::ColumnDef(_))),
+            "미주가 없어도 HWP3 구역 첫 문단은 secd 뒤 cold가 있어야 한다"
+        );
+        let char_count_after_first = doc.sections[0].paragraphs[0].char_count;
 
-        // parser fixup이 재적용되어도 이미 존재하는 cold를 중복하지 않는다.
+        // parser fixup이 재적용되어도 이미 존재하는 secd/cold를 중복하지 않고,
+        // [#5542] 슬롯 좌표 계상(char_count 전진)도 다시 밀지 않는다(멱등).
         fixup_hwp3_notes(&mut doc, &Hwp3DocInfo::default());
         assert_eq!(
             doc.sections[0].paragraphs[0]
@@ -5046,6 +5134,18 @@ mod tests {
                 .filter(|control| matches!(control, Control::ColumnDef(_)))
                 .count(),
             1
+        );
+        assert_eq!(
+            doc.sections[0].paragraphs[0]
+                .controls
+                .iter()
+                .filter(|control| matches!(control, Control::SectionDef(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            doc.sections[0].paragraphs[0].char_count,
+            char_count_after_first
         );
     }
 

--- a/tests/cases/issue_5542_hwp3_section_slot_units.rs
+++ b/tests/cases/issue_5542_hwp3_section_slot_units.rs
@@ -1,0 +1,96 @@
+//! [#5542/#5532] HWP3 구역 첫 문단의 secd/cold 8유닛 슬롯 계상 계약.
+//!
+//! HWP5/HWPX 위치 좌표계는 구역 첫 문단 앞머리의 확장 컨트롤(secd·cold)을
+//! 8유닛씩 계상한다. HWP3 파서는 두 컨트롤을 스트림 밖에서 합성하므로 종전에는
+//! 계상이 빠졌고, h2x 저장-재파싱에서 첫 문단 char_shapes 경계가 컨트롤 몫만큼
+//! 어긋났다(hwp3-curve·hwp3-sample5: +16, `--verify` exit 3). SectionDef 컨트롤
+//! 합성 없이 좌표만 밀면 HWPX 직렬화기의 hidden-슬롯 정합이 깨져 저장 lineseg 가
+//! 억제된다 — 계약은 CLI `--verify` 왕복 무차이로 고정한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use rhwp::model::control::Control;
+use rhwp::wasm_api::HwpDocument;
+
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
+}
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn temp(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "rhwp-5542-{tag}-{}-{}.hwpx",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn verify_roundtrip_clean(sample: &str) {
+    let out_path = temp(sample.trim_end_matches(".hwp"));
+    let output = Command::new(rhwp_bin())
+        .arg("export-hwpx")
+        .arg(repo_path(&format!("samples/{sample}")))
+        .arg(&out_path)
+        .arg("--verify")
+        .output()
+        .expect("export-hwpx 실행");
+    let _ = std::fs::remove_file(&out_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.code() == Some(0) && stdout.contains("IR 차이 없음"),
+        "{sample} h2x --verify 왕복이 깨졌다 (exit={:?}):\n{stdout}\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn hwp3_curve_roundtrip_char_shapes_clean() {
+    // [#5542] 종전: paragraph[0] char_shapes (10,·)→(26,·) — secd+cold 16유닛 미계상.
+    verify_roundtrip_clean("hwp3-curve.hwp");
+}
+
+#[test]
+fn hwp3_sample5_roundtrip_char_shapes_clean() {
+    // [#5532] 종전: paragraph[0] char_shapes +16 동형.
+    verify_roundtrip_clean("hwp3-sample5.hwp");
+}
+
+#[test]
+fn hwp3_first_paragraph_carries_section_def_control() {
+    // IR 계약(HWP5 파서 동형): 구역 첫 문단 controls 는 SectionDef 로 시작하고,
+    // char_shapes 의 후속 경계는 앞머리 슬롯(8×n)을 포함한 좌표다.
+    let bytes = std::fs::read(repo_path("samples/hwp3-curve.hwp")).expect("샘플 읽기");
+    let doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let first = &doc.document().sections[0].paragraphs[0];
+    assert!(
+        matches!(first.controls.first(), Some(Control::SectionDef(_))),
+        "구역 첫 문단 앞머리에 SectionDef 컨트롤이 없다: {:?}",
+        first
+            .controls
+            .iter()
+            .map(std::mem::discriminant)
+            .collect::<Vec<_>>()
+    );
+    let leading_slots = first
+        .controls
+        .iter()
+        .take_while(|c| matches!(c, Control::SectionDef(_) | Control::ColumnDef(_)))
+        .count() as u32;
+    assert!(leading_slots >= 2, "secd+cold 연쇄가 없다: {leading_slots}");
+    // 두 번째 char_shapes 경계(텍스트 10자 뒤)는 슬롯 좌표를 포함해야 한다.
+    let second = first.char_shapes.get(1).expect("경계 2개");
+    assert_eq!(
+        second.start_pos,
+        leading_slots * 8 + 10,
+        "char_shapes 경계가 슬롯 좌표를 계상하지 않았다"
+    );
+}


### PR DESCRIPTION
# fix(parser/hwp3): 구역 첫 문단에 SectionDef 를 합성하고 secd/cold 8유닛 슬롯을 좌표에 계상한다 (#5542, #5532)

## 근인

HWP5/HWPX 의 문단 위치 좌표계(char_offsets·char_shapes·lineseg textpos·char_count)는 구역 첫 문단 앞머리의 확장 컨트롤(`secd`·`cold`)을 **8유닛씩 계상**한다 — HWP5 원본은 PARA_TEXT 에 그 코드가 실제로 있고, HWPX 파서도 `secPr`/`colPr` 마다 8유닛을 전진시킨다. HWP3 파서는 두 컨트롤을 텍스트 스트림 밖에서 합성하므로(`SectionDef` 는 아예 미합성 — HWP5 직렬화기가 임시 사본으로 보완해 온 #1915 폴백) 계상이 빠졌고, h2x 저장-재파싱에서 구역 첫 문단의 char_shapes 경계가 컨트롤 몫만큼 어긋났다:

- #5542 `hwp3-curve.hwp`: expected `(10,·)` → actual `(26,·)` (+16 = secPr+colPr)
- #5532 `hwp3-sample5.hwp`: `(4,·),(9,·)` → `(20,·),(25,·)` (+16 동형)

## 수정

구역 첫 문단에 `Control::SectionDef` 를 합성하고(HWP5 파서와 IR 동형), 앞머리 secd/cold 연쇄 수 × 8 만큼 문단 좌표를 일괄 전진시킨다. 두 가지가 **한 몸**임을 중간 실측으로 확인했다 — 좌표만 밀면 HWPX 직렬화기의 hidden-슬롯 정합(#1591 v2, slot_count 증거 대조)이 불일치로 mismatch 폴백에 빠져 **저장 lineseg 가 통째로 억제**된다(`linesegs: count expected=1 actual=0`). 앞삽입 시 `ctrl_data_records[i] ↔ controls[i]` 병렬 계약(#3214)도 유지한다(기존 `ensure_hwp3_initial_body_column_def` 의 같은 누락도 함께 보정).

직렬화기는 같은 좌표계로 텍스트를 사상하므로 출력 run 구조는 불변이고, 저장 linesegarray 의 textpos 만 재파싱 좌표와 정합하게 된다 — 한글의 lineseg-텍스트 정합 계약(#4778)과 같은 방향이다.

## 실측

- #5542·#5532 두 샘플: `--verify` **IR 차이 없음** (exit 0)
- #5537 `hwp3-sample10-hwp5.hwp`: 5건 → **2건** (해소 3건도 같은 축이었음). 잔여 2건은 **HWPX 로 표현되지 않는 컨트롤에 HWP3 파서가 계상한 8유닛**이 재파싱에서 사라지는 별개 서브클래스 — 이슈에 좌표·구조 실측을 코멘트로 남긴다
- #5422 `SO-SUEOP.hwp`: 통과 유지
- 10k 코퍼스 HWP3 전수 A/B(38문서): **쪽수 변화 0 · `--verify` 차이 수 변화 0 · 1쪽 SVG 해시 전량 동일 · h2h 변환 산출 해시 전량 동일** — 렌더·HWP5 변환 완전 불변(h2h 동일성은 본 합성이 HWP5 직렬화기의 #1915 폴백과 바이트 동형임을 뜻한다)

## 게이트

- 계약 테스트 `issue_5542_hwp3_section_slot_units`(신규 3건): 두 샘플 `--verify` 무차이 + 첫 문단 SectionDef/좌표 계상 계약. **음성 대조: 수정 없이 전부 FAIL**
- 기존 `issue_3676_no_endnote_...` 단위 테스트를 새 IR 계약으로 갱신(첫 문단 = secd→cold 연쇄) + **멱등성 확장**(fixup 재적용 시 secd 미중복·좌표 미재전진 — 첫 구현이 이 테스트의 2회 호출 검증에 걸려 멱등 가드를 세웠다)
- rustfmt(변경 파일)·`cargo check --target wasm32 --lib`·manifest/tier 체크·manifest 단위 테스트 통과
- clippy `-D warnings`·nextest 전체: 결과는 아래 코멘트로 갱신
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(변경 파일 rustfmt 직접 검사로 대체)

이슈 #5542·#5532 해소, #5537 부분 개선(발견·보고: kevin9327 자동 스윕)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
