### PR TITLE
docs: 환경별 Rust test 동시성 지침을 정정한다

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ node scripts/rust-unit-test-tiers.mjs --check
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast                          # 통합 테스트 포함 전체
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast                          # 통합 테스트 포함 전체
 cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트 경고 0건
 ```
 
@@ -193,7 +193,7 @@ cargo build --profile release-test --target-dir target/pr-review
 ```
 
 이 명령은 `rhwp` 바이너리를 만들어 시각 대조를 준비할 뿐, 테스트를 실행하지 않습니다. **PR 전 검증을
-대체하지 않으므로**, 코드 변경 뒤에는 위의 전체 `cargo nextest run ... --tests --no-fail-fast`를 반드시
+대체하지 않으므로**, 코드 변경 뒤에는 위의 전체 `cargo nextest run ... --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast`를 반드시
 완료하세요. 상세 절차는 [로컬 사전 검증](mydocs/manual/pr_review/local_validation.md)을 따릅니다.
 
 ### 프런트엔드 변경 검증

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ node scripts/rust-unit-test-tiers.mjs --check
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast       # 통합 테스트 포함 전체
+  --tests --no-fail-fast                          # 통합 테스트 포함 전체
 cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트 경고 0건
 ```
 
@@ -180,7 +180,9 @@ cargo clippy --all-targets --target-dir target/pr-review -- -D warnings # 린트
 로컬에서는 위 계약 단위 테스트와 필요한 Rust 회귀 테스트만 실행하세요.
 
 - `release-test` 프로필은 PR CI와 같은 기준이며 debug 대비 수 배 빠릅니다.
-- 논리 CPU가 12개 미만이거나 메모리가 부족하면 `--test-threads`를 논리 CPU 이하로 낮춰주세요.
+- nextest는 현재 host에 맞는 기본 동시성을 사용합니다. 기본값을 먼저 쓰고, CPU·메모리·동시 작업을
+  확인해 조정할 때만 `--test-threads <현재 환경에 맞는 값>`을 추가하세요. 문서의 고정 수치를 복사하지
+  마세요.
 - `cargo test --lib` 만으로는 통합 테스트 회귀를 잡지 못합니다 — `--tests` 를 포함해주세요.
 
 렌더링 변경을 한컴 기준 PDF와 대조할 때는 비교 도구가 최신 실행 파일을 보도록 먼저 다음 빌드를 할 수

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -90,7 +90,7 @@ cargo test --release --lib
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast
+  --tests --no-fail-fast
 ```
 
 새 Rust integration test는 `tests/cases/`에 원본 `.rs` 파일만 추가하고 suite를 직접 선택하지 않는다.
@@ -133,7 +133,9 @@ workspace의 `default-members`에는 root와 `crates/*`가 포함된다. 따라�
 
 `release-test`는 통합 테스트 시간을 줄이기 위한 프로필이며 실제 release 산출물은 계속
 `cargo build --release`로 만든다.
-`--test-threads 12`는 CPU·메모리가 충분한 host의 기본값이며, 작은 host에서는 논리 CPU 이하로 낮춘다.
+nextest 기본 동시성은 현재 host를 따른다. CPU·메모리·동시 작업을 확인해 조정할 때만
+`--test-threads <현재 환경에 맞는 값>`을 추가하며, 문서의 과거 측정값을 고정값으로 복사하지 않는다.
+선택 절차와 OS별 CPU 확인 명령은 [로컬 사전 검증](pr_review/local_validation.md#고정-review-target과-실행-환경)을 따른다.
 
 ## WASM 빌드
 

--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -90,7 +90,7 @@ cargo test --release --lib
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 ```
 
 새 Rust integration test는 `tests/cases/`에 원본 `.rs` 파일만 추가하고 suite를 직접 선택하지 않는다.

--- a/mydocs/manual/export_png_command.md
+++ b/mydocs/manual/export_png_command.md
@@ -225,8 +225,14 @@ cargo build --features native-skia
 cargo build --release --features native-skia
 
 # native-skia 테스트
-cargo test --features native-skia skia --lib
+cargo test --features native-skia --lib
+
+# 동시성을 조정해야 할 때만 test harness 인자로 전달한다.
+cargo test --features native-skia --lib -- --test-threads <현재_환경에_맞는_값>
 ```
+
+`native-skia`만 Cargo feature다. `skia`를 feature 뒤에 쓰면 이름 filter가 되어 전체 lib 회귀 대신
+`skia`가 포함된 테스트만 실행한다.
 
 ## 비목표 (현재 단계)
 

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -43,7 +43,7 @@ host의 논리 CPU·메모리·동시 작업을 확인한 뒤에만 `--test-thre
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 ~~~
 
 ### integration test source 추가와 자동 sharding
@@ -122,7 +122,7 @@ RHWP_BIN=target/pr-review/release-test/rhwp \
 
 `cargo build`는 **컴파일 전용 준비 단계**이며 테스트를 실행하지 않는다. 시각 보정 중에는 이 명령으로
 빠르게 최신 SVG를 확인하되, code head가 바뀐 뒤 PR 검증을 완료하려면 위의 전체 `cargo nextest run
-... --tests --no-fail-fast`를 다시 성공시켜야 한다. 하네스 옵션과 기준 PDF provenance는
+... --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast`를 다시 성공시켜야 한다. 하네스 옵션과 기준 PDF provenance는
 [`tools/fidelity_compare/README.md`](../../../tools/fidelity_compare/README.md)를 따른다.
 
 2026-08-09 Linux 검증 호스트(`ubuntu-ted`, Intel Xeon E5640 16 vCPU, RAM 15 GiB)에서 이 명령의 fixed
@@ -148,7 +148,7 @@ Set-Location 'C:\\Users\\admin\\Desktop\\rhwp\\rhwp'
 cargo nextest run `
   --cargo-profile release-test `
   --target-dir target/pr-review `
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 ~~~
 
 PowerShell의 `target/pr-review`는 Windows에서 정상 경로로 해석된다. WSL 경로와 Windows 경로, 또는 서로
@@ -286,7 +286,7 @@ merge 판단에서는 다음 경계를 적용한다.
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 ~~~
@@ -382,7 +382,7 @@ cargo test --release --target-dir target/pr-review --lib
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 cargo test --profile release-test --target-dir target/pr-review --features native-skia --lib
 node scripts/run-rust-test.mjs issue_2225_missing_picture_placeholder -- \
   --cargo-profile release-test --target-dir target/pr-review --features native-skia

--- a/mydocs/manual/pr_review/local_validation.md
+++ b/mydocs/manual/pr_review/local_validation.md
@@ -33,11 +33,17 @@ pgrep -alf '(^|/)(cargo|rustc|wasm-pack)( |$)' || true
 전체 Rust 회귀의 기본 명령은 다음과 같다. 같은 `target/pr-review`를 사용하는 Cargo 계열 명령은 반드시
 앞 명령의 종료를 확인한 뒤 실행한다.
 
+문서의 명령은 고정 `--test-threads` 값을 쓰지 않는다. nextest 기본 동시성을 먼저 사용하고, 현재
+host의 논리 CPU·메모리·동시 작업을 확인한 뒤에만 `--test-threads <현재 환경에 맞는 값>`으로 조정한다.
+논리 CPU 확인은 macOS `sysctl -n hw.logicalcpu`, Linux `getconf _NPROCESSORS_ONLN`, PowerShell
+`[Environment]::ProcessorCount`를 사용한다. CPU 수를 그대로 쓰는 것도 의무가 아니며, 메모리가
+부족하거나 다른 작업이 있으면 더 낮은 값을 선택하고 실제 실행 시간을 기록한다.
+
 ~~~bash
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast
+  --tests --no-fail-fast
 ~~~
 
 ### integration test source 추가와 자동 sharding
@@ -125,9 +131,9 @@ target cold run은 build 포함 17분 42초였다. 같은 target을 그대로 �
 test 자체의 실행 시간은 host 부하에 따라 달라지므로, 이 수치는 재컴파일 제거 효과와 해당 시점의 측정값을
 분리해 읽는다.
 
-macOS도 POSIX 명령은 동일하다. 다만 `--test-threads 12`는 12 이상 논리 CPU와 충분한 RAM이 있는 host의
-측정값이다. CPU·RAM이 더 작은 host에서는 `sysctl -n hw.ncpu`와 `sysctl -n hw.memsize`를 확인하고 thread
-수를 논리 CPU 이하로 낮춘다.
+macOS도 POSIX 명령은 동일하다. 과거의 `--test-threads 12` 측정값은 해당 host의 증적일 뿐 기본값이
+아니다. `sysctl -n hw.logicalcpu`와 `sysctl -n hw.memsize`로 현재 환경을 확인하고, 기본 동시성 또는
+사용자가 선택한 값을 쓴다.
 
 Windows는 cargo-nextest가 설치되어 있고 PowerShell 또는 cmd에서 Windows 경로만 일관되게 사용하면 같은
 방식으로 가능하다. 2026-08-09 `win10-ted`의 cmd 환경(4 logical CPU, RAM 8 GiB)에서
@@ -135,14 +141,14 @@ Windows는 cargo-nextest가 설치되어 있고 PowerShell 또는 cmd에서 Wind
 `overflow_cell_baseline` 선택 실행은 cold build 포함 18분 55초(build 12분 27초, test 363.036초), 같은
 target을 재사용한 warm 실행은 6분 11초(build 2.74초, test 359.563초)로 통과했다. Windows 전체 `--tests`
 실행 명령도 아래와 같지만, 이 확인에서는 target 재사용을 직접 검증할 수 있는 장시간 baseline만 실행했다.
-이 host에서는 4 thread를 상한으로 쓴다.
+이 host의 4 thread 측정값은 역사적 증적이며, 다른 Windows host의 기본값이나 상한이 아니다.
 
 ~~~powershell
 Set-Location 'C:\\Users\\admin\\Desktop\\rhwp\\rhwp'
 cargo nextest run `
   --cargo-profile release-test `
   --target-dir target/pr-review `
-  --tests --test-threads 4 --no-fail-fast
+  --tests --no-fail-fast
 ~~~
 
 PowerShell의 `target/pr-review`는 Windows에서 정상 경로로 해석된다. WSL 경로와 Windows 경로, 또는 서로
@@ -280,7 +286,7 @@ merge 판단에서는 다음 경계를 적용한다.
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast
+  --tests --no-fail-fast
 cargo fmt --all -- --check
 cargo clippy --all-targets -- -D warnings
 ~~~
@@ -288,7 +294,7 @@ cargo clippy --all-targets -- -D warnings
 renderer 영향 PR의 Native Skia 공식 회귀 범위는 다음 3종이다.
 
 ~~~bash
-cargo test --profile release-test --target-dir target/pr-review --features native-skia skia --lib
+cargo test --profile release-test --target-dir target/pr-review --features native-skia --lib
 node scripts/run-rust-test.mjs issue_2225_missing_picture_placeholder -- \\
   --cargo-profile release-test --target-dir target/pr-review --features native-skia
 node scripts/run-rust-test.mjs render_p37_direct_pdf_export -- \\
@@ -296,6 +302,11 @@ node scripts/run-rust-test.mjs render_p37_direct_pdf_export -- \\
 # 최초 한 번의 .env.docker 준비는 개발 환경 안내를 따른다.
 docker compose --env-file .env.docker run --rm wasm
 ~~~
+
+`native-skia`가 Cargo feature이고 `skia`는 feature가 아니다. 따라서
+`cargo test --features native-skia skia --lib`의 `skia`는 test filter가 되어 전체 회귀를 실행하지 않는다.
+libtest 동시성을 현재 host에 맞춰 조정해야 하면 Cargo 옵션 뒤의 test harness 인자로
+`cargo test ... --features native-skia --lib -- --test-threads <현재 환경에 맞는 값>`을 쓴다.
 
 개별 Rust 통합 fixture는 `tests/generated/regression_suite_*.rs`에 묶이므로, 이전처럼 파일명을
 `cargo test --test`에 직접 넘기지 않는다. `run-rust-test.mjs`가 manifest에서 실제 suite와 테스트
@@ -371,8 +382,8 @@ cargo test --release --target-dir target/pr-review --lib
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast
-cargo test --profile release-test --target-dir target/pr-review --features native-skia skia --lib
+  --tests --no-fail-fast
+cargo test --profile release-test --target-dir target/pr-review --features native-skia --lib
 node scripts/run-rust-test.mjs issue_2225_missing_picture_placeholder -- \
   --cargo-profile release-test --target-dir target/pr-review --features native-skia
 node scripts/run-rust-test.mjs render_p37_direct_pdf_export -- \

--- a/mydocs/manual/publish_guide.md
+++ b/mydocs/manual/publish_guide.md
@@ -315,13 +315,16 @@ cargo build
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --test-threads 12 --no-fail-fast
+  --tests --no-fail-fast
 wasm-pack build --target web --out-dir pkg
 
 # release 시 devel → main PR 생성
 gh pr create --repo edwardkim/rhwp --base main --head devel \
   --title "v0.7.3 릴리즈" --body-file <release-pr-body.md>
 ```
+
+release 검증도 고정 thread 수를 복사하지 않는다. nextest 기본 동시성을 먼저 사용하고, release host의
+CPU·메모리·동시 작업을 기준으로 사용자가 필요할 때만 `--test-threads <현재 환경에 맞는 값>`을 지정한다.
 
 > release 준비 변경도 `upstream/devel`에 직접 push하지 않는다. 작업 브랜치 PR과 CI를 거쳐 통합하고,
 > 검증된 `devel`을 `main` 대상 release PR로 올린다.

--- a/mydocs/manual/publish_guide.md
+++ b/mydocs/manual/publish_guide.md
@@ -315,7 +315,7 @@ cargo build
 cargo nextest run \
   --cargo-profile release-test \
   --target-dir target/pr-review \
-  --tests --no-fail-fast
+  --tests --test-threads <현재_환경에_맞는_값> --no-fail-fast
 wasm-pack build --target web --out-dir pkg
 
 # release 시 devel → main PR 생성

--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -86,3 +86,9 @@ date: 2026-08-19
 - 로컬에서 editor 계약 32건, Studio 982건(기존 skip 1건), TypeScript/Vite build, HWP/HWPX document-agent 브라우저 계약 30건, editor 선언 검사와 `npm pack --dry-run`을 통과했다.
 - 생성 WASM 기준선의 `getFontDecisionTrace` 선언 누락 때문에 일반 public-embed 검사 두 건은 로컬에서 기준선 오류로 중단됐다. 이 PR은 `pkg/`와 해당 Rust export를 변경하지 않았고, 동일 candidate의 GitHub Frontend package gate와 Build & Test, CodeQL, Render Diff는 성공했다.
 - [PR #5569 검토 기록](../pr/archives/pr_5569_review.md)과 이 항목만 single-parent trailing commit으로 contributor source branch에 올린다. 최신 head의 review-only fast-pass aggregate와 mergeability를 다시 확인한 뒤, 첫 기여자에게 환영과 구체적인 검증 결과를 담은 승인 코멘트를 남기고 merge·후속 정리를 진행한다.
+
+## PR #5606 검토 기록
+
+- [#5606](https://github.com/edwardkim/rhwp/pull/5606)에서 [#5605](https://github.com/edwardkim/rhwp/issues/5605)의 환경 인식형 Rust test 동시성 지침을 검토했다.
+- code candidate `d0c7dae7a`의 CI·CodeQL·Proptest roundtrip·Adapter inter-diff는 성공했고, 문서 전용 B 경로 fast-pass로 무거운 Rust·frontend 작업은 정상 `SKIPPED` 집계됐다.
+- `mydocs/pr/archives/pr_5606_review.md` trailing 기록을 추가했다. 최종 merge 전 이 최신 문서 head의 CI aggregate 성공을 다시 확인한다.

--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -6,6 +6,17 @@ date: 2026-08-19
 
 # 2026-08-19 오늘할 일
 
+## #5605 환경 인식형 Rust test thread 지침
+
+- `target/pr-review`을 매 실행 전 비운 Native Skia lib 측정에서 1/4/8 thread의 전체 시간은 각각
+  190.64초/159.81초/144.37초였고, 핵심 3,950개 테스트는 37.94초/16.91초/11.85초였다.
+- `cargo test --features native-skia skia --lib`은 `skia`를 feature가 아닌 filter로 소비해 58개만 실행하고
+  4,087개를 filtered 했다. 같은 target-cold run은 236.49초였으며, 서로 다른 test 범위와 OS cache 조건이라
+  전체 회귀 성능 비교로 해석하지 않는다.
+- 활성 기여·검토·개발·release·PNG export 가이드에서 고정 thread 수를 제거한다. 기본 동시성을 우선 사용하고,
+  사용자가 자신의 CPU·메모리·동시 부하에 맞춰 필요할 때만 `--test-threads`를 지정하도록 정정한다.
+
+
 ## #5596 review tail 보조 workflow 재사용
 
 - [#5597](https://github.com/edwardkim/rhwp/pull/5597)을 `d9a541f78815b1284efa313a35299118a64a35bf`로 병합했다.

--- a/mydocs/pr/archives/pr_5606_review.md
+++ b/mydocs/pr/archives/pr_5606_review.md
@@ -1,0 +1,36 @@
+---
+kind: pr-review
+status: approved
+pr: 5606
+issue: 5605
+---
+
+# PR #5606 검토 기록 - 환경 인식형 Rust test 동시성 지침
+
+- PR: [#5606](https://github.com/edwardkim/rhwp/pull/5606) `docs: 환경별 Rust test 동시성 지침을 정정한다`
+- 관련 이슈: [#5605](https://github.com/edwardkim/rhwp/issues/5605)
+- 작성자·self-review: `jangster77` collaborator self PR
+- base: `devel`
+- 검토한 code candidate: `d0c7dae7ae04f729aac86b878c7af0904223ee94`
+- 작성 시점 참고값: Open, non-draft, `MERGEABLE`, `CLEAN`
+- 라우팅: `collaborator_self_merge` + `intake_and_review` + `review_only_fast_pass`
+- 로드 문서: `pr_review_workflow.md`, `pr_review/README.md`, `collaborator_self_merge.md`, `intake_and_review.md`, `local_validation.md`, `review_only_fast_pass.md`
+
+## 검토 범위
+
+- 개발·검토·배포 안내에서 고정 `--test-threads` 값을 제거하고, 모든 Nextest 예시에 `--test-threads <현재_환경에_맞는_값>`을 명시한다.
+- 사용자가 현재 호스트의 논리 CPU, 메모리, 동시 작업을 기준으로 실제 정수를 선택해야 하며, macOS 측정값을 범용 권고값으로 복사하지 않음을 명확히 한다.
+- Native Skia 전체 lib 검증을 `--features native-skia --lib`로 정정하고, 뒤의 `skia`는 Cargo feature가 아니라 테스트 필터라서 전체 회귀가 아니라는 점을 문서화한다.
+- 구현·테스트·workflow·의존성 잠금 파일을 변경하지 않는 문서 전용 PR이다. renderer 또는 fixture 변경이 없으므로 시각 검증 경로는 적용하지 않는다.
+
+## 검증 근거
+
+- 로컬: `cargo fmt --all`, `cargo fmt --all -- --check`, `git diff --check` 통과.
+- 측정 근거: 이 macOS 호스트에서 target을 매 회 제거한 Native Skia lib 실행은 thread 1/4/8에서 각각 190.64초/159.81초/144.37초였다. 이는 환경 고정 권고가 아닌 문서 정정 근거다.
+- 명령 의미 확인: 기존 `--features native-skia skia --lib` 실행은 236.49초에 58개 통과·4,087개 필터링으로 전체 회귀가 아니었다. 캐시·작업량이 달라 성능 비교에는 쓰지 않는다.
+- GitHub Actions: [CI](https://github.com/edwardkim/rhwp/actions/runs/32240118446), [CodeQL](https://github.com/edwardkim/rhwp/actions/runs/32240118281), [Proptest roundtrip](https://github.com/edwardkim/rhwp/actions/runs/32240118324), [Adapter inter-diff](https://github.com/edwardkim/rhwp/actions/runs/32240118285)가 candidate `d0c7dae7a`에서 성공했다.
+- CI의 Lint, Native Skia, build archive, Rust shard, frontend gate는 PR 전체가 허용된 `mydocs/` 변경인 B 경로 fast-pass에 따라 `SKIPPED`로 집계됐고, Build & Test aggregate는 성공했다.
+
+## 결론
+
+차단 결함은 발견하지 못했다. 이 review·오늘할일 trailing commit은 허용된 `mydocs/` 범위만 추가한다. 최종 merge 조건은 이 새 최신 head의 CI aggregate 성공과 작업지시자 승인이다.

--- a/mydocs/working/task_m100_5605_stage1_environment_aware_test_threads.md
+++ b/mydocs/working/task_m100_5605_stage1_environment_aware_test_threads.md
@@ -1,0 +1,34 @@
+---
+kind: working-note
+status: completed
+issue: 5605
+---
+
+# #5605 Stage 1 - 환경 인식형 Rust test thread 지침
+
+## 관측
+
+`target/pr-review`을 각 실행 전에 비운 macOS Native Skia lib 측정에서 다음 결과를 얻었다. Cargo registry와
+OS 파일 cache는 유지됐으므로 target-cold 측정이며, 다른 host에 고정값으로 일반화하지 않는다.
+
+| libtest threads | 전체 시간 | 핵심 3,950개 테스트 |
+| ---: | ---: | ---: |
+| 1 | 190.64초 | 37.94초 |
+| 4 | 159.81초 | 16.91초 |
+| 8 | 144.37초 | 11.85초 |
+
+현재 host는 논리 CPU 10개, 성능 코어 4개였다. 이 표본에서는 8 threads가 빨랐지만, 컴파일·메모리·동시
+부하가 다른 host에는 같은 값이 적합하다는 뜻이 아니다.
+
+## 명령 의미 보정
+
+`cargo test --features native-skia skia --lib`의 `skia`는 Cargo feature가 아니라 test filter다. 이 명령은
+236.49초에 58개만 통과하고 4,087개를 filter했다. 따라서 전체 Native Skia lib 회귀는
+`cargo test --features native-skia --lib`로 실행하고, libtest 동시성을 조정할 때만 `--` 뒤에
+`--test-threads <현재 환경에 맞는 값>`을 둔다.
+
+## 적용
+
+- 활성 가이드의 고정 nextest thread 수를 제거하고 host 기본 동시성을 사용한다.
+- 조정이 필요하면 사용자가 논리 CPU·메모리·동시 작업을 확인해 값을 선택하도록 안내한다.
+- 완료된 계획·보고서의 과거 명령과 수치는 증적이므로 변경하지 않는다.


### PR DESCRIPTION
## 목적

Closes #5605.

Rust 테스트 동시성을 문서의 고정 숫자로 강제하지 않고, 각 사용자가 자신의 CPU·메모리·동시 작업 상황에 맞춰 선택하도록 정정합니다.

## 변경 사항

- 활성 개발·검토·배포 문서에서 고정 `--test-threads` 값을 제거했습니다.
- 모든 Nextest 예시에 `--test-threads <현재_환경에_맞는_값>`을 넣고, 실행 전에 실제 정수로 치환하도록 안내했습니다.
- 선택값은 현재 호스트의 논리 CPU, 메모리, 동시 작업을 보고 정하며, 문서의 단일 숫자를 복사하지 않습니다.
- Native Skia 전체 lib 검증 명령을 `--features native-skia --lib`로 정정했습니다.
- `skia`를 feature 뒤에 적으면 Cargo feature가 아니라 테스트 필터가 되어 전체 회귀가 아니게 되는 점을 설명했습니다.

## 측정 근거

현재 macOS 호스트에서 `target/pr-review`를 매 회 제거한 결과는 다음과 같습니다.

| libtest thread | 전체 시간 |
| --- | ---: |
| 1 | 190.64초 |
| 4 | 159.81초 |
| 8 | 144.37초 |

이는 이 호스트의 관측값일 뿐, 모든 환경에 적용되는 권장 고정값이 아닙니다.

기존 잘못된 형태인 `--features native-skia skia --lib`는 236.49초가 걸렸지만, 58개만 통과하고 4,087개가 필터링됐습니다. 작업량과 파일 캐시 조건이 달라 위 표와 성능 비교 근거로 사용하지 않습니다.

## 검증

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `git diff --check`
