### PR TITLE
fix: lpaiu-cs #5556·#5570 통합

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -6,6 +6,23 @@ date: 2026-08-19
 
 # 2026-08-19 오늘할 일
 
+## #5607 lpaiu-cs #5556·#5570 통합
+
+- 통합 PR은 [#5607](https://github.com/edwardkim/rhwp/pull/5607)이며, 최신
+  `upstream/devel@9208c03b5` 위로 충돌 없이 리베이스했다.
+- 실제 체리픽 입력은 [#5556](https://github.com/edwardkim/rhwp/pull/5556)의
+  `6607e42220194a293b209699c10d48f602c681aa`와 [#5570](https://github.com/edwardkim/rhwp/pull/5570)의
+  `6c3ae7522c8d8ab20b3c158622d8678c3fc74051`이다. #5570의 현재 후속 head와 기존 메인터너 보정은
+  작업지시대로 포함하지 않았다.
+- #2225 Native Skia test selector가 독립 target을 suite 내부 test로 잘못 해석한 결함은
+  `suite-policy.json` 예외와 매니페스트 회귀 계약으로 보정했다. 같은 명령은 2/2 통과했다.
+- 로컬에서 release build·lib, 전체 nextest 7,313건, Native Skia, 직접 PDF, fmt·diff·clippy·doctest,
+  Studio TypeScript·997개 테스트를 통과했다. Docker 대신 `wasm-pack build --target web --out-dir pkg`도
+  성공했다.
+- 최초 code candidate의 GitHub Build & Test, Lint, Native Skia, Canvas visual diff, CodeQL, archive,
+  slow·regular shard, Proptest, adapter inter-diff는 모두 통과했다. 이 [PR #5607 검토 기록](../pr/archives/pr_5607_review.md)과
+  오늘할일을 trailing commit으로 push한 뒤 최신 head의 required CI를 확인하고 merge·후속 정리를 진행한다.
+
 ## #5605 환경 인식형 Rust test thread 지침
 
 - `target/pr-review`을 매 실행 전 비운 Native Skia lib 측정에서 1/4/8 thread의 전체 시간은 각각

--- a/mydocs/pr/archives/pr_5607_review.md
+++ b/mydocs/pr/archives/pr_5607_review.md
@@ -1,0 +1,69 @@
+---
+kind: pr-review
+status: active
+canonical: mydocs/manual/pr_review_workflow.md
+last_verified: 2026-08-19
+---
+
+# PR #5607 검토 - lpaiu-cs #5556·#5570 통합
+
+## 접수 메타데이터
+
+| 항목 | 검토 시점 참고값 |
+| --- | --- |
+| PR / 작성자 | [#5607](https://github.com/edwardkim/rhwp/pull/5607) / jangster77 |
+| base / 통합 branch | `devel` / `integration/lpaiu-cs-20260819` |
+| 최신 기준선 | `upstream/devel@9208c03b5` |
+| 원 PR | [#5556](https://github.com/edwardkim/rhwp/pull/5556), [#5570](https://github.com/edwardkim/rhwp/pull/5570) / lpaiu-cs |
+| 체리픽 입력 | `6607e42220194a293b209699c10d48f602c681aa`, `6c3ae7522c8d8ab20b3c158622d8678c3fc74051` |
+| 메인터너 보정 | `#2225` Native Skia 함수 게이트를 독립 test target으로 분리 |
+
+## 통합 판정
+
+차단 결함은 발견하지 못했다. 두 원 PR은 최신 `upstream/devel` 위로 충돌 없이 누적했고, 검토 중
+발견한 #2225 선택기 결함은 suite policy의 독립 target 예외와 회귀 계약으로 보정했다.
+
+## 범위와 제외 사항
+
+- #5556은 `PageRenderer`의 문서 범위 파생 상태를 문서 경계에서 회수하는 변경을 포함한다.
+- #5570은 개체 회전·대칭을 스냅샷 저장 대신 역연산으로 기록해 스냅샷 예산을 줄이는 변경을 포함한다.
+- #5570의 체리픽 입력은 검토 시작 시점 원본 `6c3ae752`로 고정했다. 현재 원 PR head
+  `56ee07dfd4ce03a836477ee7ee81a05d91bffa41`의 후속 변경은 포함하지 않았다.
+- 기존 메인터너 보정 `4c668b939632374f723c9a5ba2617f32caf17c66`도 작업지시대로 참고만 하고
+  통합 branch에 넣지 않았다.
+
+## #2225 메인터너 보정
+
+`tests/issue_2225_missing_picture_placeholder.rs`는 독립 integration target인데, suite policy가
+일반 generated suite로 배정해 `run-rust-test.mjs`가 `regression_suite_014` 내부 선택기로 실행했다.
+그 결과 Native Skia 공식 명령은 `0 tests run`과 exit 4로 실패했다.
+
+`tests/suites/suite-policy.json`에 독립 target 예외를 추가하고,
+`scripts/tests/rust-test-suite-manifest.test.mjs`에 target과 인자 구성을 고정하는 회귀 계약을
+추가했다. 보정 뒤 같은 명령은 2개 테스트를 선택해 모두 통과했다.
+
+## 검증
+
+| 범위 | 결과 |
+| --- | --- |
+| release build / release lib | 통과 |
+| 전체 `nextest --no-fail-fast` | 7,313 passed, 38 skipped |
+| Native Skia lib / #2225 / 직접 PDF | 58 passed / 2 passed / 4 passed |
+| suite manifest 계약 | 17 passed |
+| fmt, diff check, clippy, doctest | 통과 |
+| Studio TypeScript / `npm test` | 통과 / 997 passed |
+| WASM | Docker 미사용 환경에서 `wasm-pack build --target web --out-dir pkg` 통과 |
+
+전체 `nextest`는 #2225 선택기 보정 전에 이미 `--no-fail-fast`로 통과했다. 보정은 test target
+메타데이터만 바꾸므로 중복 전체 실행 대신 manifest 계약과 실패했던 #2225 명령만 재검증했다.
+
+초기 code candidate CI는 Build & Test, Lint, Native Skia, Canvas visual diff, CodeQL, test archive,
+slow·regular shard, Proptest, adapter inter-diff를 포함해 모두 통과했다. 영향 정책상 Frontend unit과
+GitHub WASM job은 skipped였고, 로컬 WASM 빌드로 대체 검증했다.
+
+## 계보와 후속
+
+- 최초 code candidate CI 성공 뒤 `upstream/devel@9208c03b5`로 다시 충돌 없이 리베이스했다.
+- 이 review archive와 오늘할일은 trailing commit으로 push한다.
+- trailing head의 required CI가 성공하면 #5607을 merge하고 원 PR #5556·#5570의 통합 근거,
+  branch 정리와 작업 기록 상태를 후속 절차에 따라 처리한다.

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -14,7 +14,8 @@ import type { ShapeType } from '@/ui/shape-picker';
 import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
-import type { RefreshPolicy } from '@/engine/command';
+import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -615,39 +616,17 @@ export const insertCommands: CommandDef[] = [
   },
 ];
 
-/** 선택 개체 ref 타입 — cursor.selectedPictureRef 와 정합 (headerFooter optional, [Task #831]) */
-type PictureRef = {
-  sec: number;
-  ppi: number;
-  ci: number;
-  type: string;
-  cellPath?: CellPathLike;
-  headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
-};
+/**
+ * 선택 개체 ref 타입 — cursor.selectedPictureRef 와 정합 (headerFooter optional, [Task #831]).
+ *
+ * [Task #3230] 분기 본체는 `engine/object-props.ts` 로 옮겼다 — 역연산 커맨드가 undo 시점에
+ * 같은 분기를 써야 하는데, 커맨드는 `services` 가 아니라 `WasmBridge` 만 받기 때문이다.
+ */
+type PictureRef = ObjectPropsRef;
 
-/** 선택 개체의 속성을 조회/변경 헬퍼 (shape/picture 분기) */
+/** 선택 개체의 속성 조회 (shape/picture·셀·머리말꼬리말 분기). */
 function getProps(services: import('../types').CommandServices, ref: PictureRef): Record<string, unknown> {
-  if (ref.type === 'shape') {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.getCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
-    }
-    return services.wasm.getShapeProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
-  }
-  // [Task #831] 머리말/꼬리말 picture 의 경우 별도 API 호출 (PR #832 의 wasm-bridge).
-  // 미적용 시 본문 lookup 실패 → props 빈/stale → 회전/대칭 무동작.
-  if (ref.headerFooter) {
-    return services.wasm.getHeaderFooterPictureProperties(
-      ref.sec,
-      ref.headerFooter.outerParaIdx,
-      ref.headerFooter.outerControlIdx,
-      ref.ppi,
-      ref.ci,
-    ) as unknown as Record<string, unknown>;
-  }
-  if (ref.cellPath && ref.cellPath.length > 0) {
-    return services.wasm.getCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
-  }
-  return services.wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+  return getObjectProps(services.wasm, ref);
 }
 
 /**
@@ -707,27 +686,33 @@ function changeZOrder(
 }
 
 function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  if (ref.type === 'shape') {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.setCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
-    }
-    return services.wasm.setShapeProperties(ref.sec, ref.ppi, ref.ci, props);
-  } else if (ref.headerFooter) {
-    // [Task #831] 머리말/꼬리말 picture setter — 5-tuple lookup 으로 IR 갱신.
-    return services.wasm.setHeaderFooterPictureProperties(
-      ref.sec,
-      ref.headerFooter.outerParaIdx,
-      ref.headerFooter.outerControlIdx,
-      ref.ppi,
-      ref.ci,
-      props,
-    );
-  } else {
-    if (ref.cellPath && ref.cellPath.length > 0) {
-      return services.wasm.setCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
-    }
-    return services.wasm.setPictureProperties(ref.sec, ref.ppi, ref.ci, props);
-  }
+  return setObjectProps(services.wasm, ref, props);
+}
+
+/**
+ * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ *
+ * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ *
+ * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
+ * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
+ * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ */
+function recordAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  setProps(services, ref, after);
+  ih.executeOperation({
+    kind: 'record',
+    command: new SetObjectPropsCommand(ref, before, after),
+    meta: { refresh: 'full' },
+  });
 }
 
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
@@ -743,9 +728,9 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // recordObjectMutation → executeOperation snapshot 의 'full' refresh 가 afterEdit()→
-  // 'document-changed' 를 이미 emit 한다. 수동 emit 은 중복(이중 렌더)이라 제거. [undo P3 정리]
-  recordObjectMutation(ih, 'rotateObject', () => setProps(services, ref, { rotationAngle: next }));
+  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
+  // 절대값이라 되돌리기가 자명하다.
+  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -757,6 +742,6 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   const props = getProps(services, ref);
   if (props.sizeProtect) return;
   const cur = !!props[key];
-  // 위 rotate 와 동일 — snapshot 라우팅이 이미 refresh 하므로 수동 emit 제거. [undo P3 정리]
-  recordObjectMutation(ih, 'flipObject', () => setProps(services, ref, { [key]: !cur }));
+  // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
+  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -7,6 +7,7 @@ import type {
 import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
+import { setObjectProps, type ObjectPropsRef } from './object-props';
 
 /** 편집 명령 공통 인터페이스 */
 export interface EditCommand {
@@ -1935,6 +1936,54 @@ export class MoveLineEndpointCommand implements EditCommand {
     return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
   }
 
+  mergeWith(): null { return null; }
+}
+
+/**
+ * [Task #3230] 개체 속성 변경의 역연산 명령 (kind:'record' 용, #2337 계열).
+ *
+ * 스냅샷 대신 쓰는 이유는 비용이다. 스냅샷 1개는 `Document` 통째 클론이라 문서에 비례하고
+ * (실측: 30KB 공문 0.43 MB · 10MB 행정편람 10.59 MB), `SnapshotCommand` 는 before/after 로
+ * 2개를 쓴다. 회전 한 번에 최대 21 MB 를 스택에 얹는 셈인데, 실제로 되돌려야 하는 것은
+ * **스칼라 속성 하나**다.
+ *
+ * 역연산이 자명한 조건은 셋이고 회전·대칭은 셋을 다 만족한다.
+ *  - setter 가 **절대값**이다(누적·토글이 아니라 `rotationAngle = 30`, `horzFlip = true`).
+ *  - 호출부가 적용 **전에 현재 값을 이미 읽는다**(다음 각도·토글 반대값을 그것으로 만든다).
+ *  - 그 속성만 바뀐다 — 파생 상태(레이아웃·앵커)는 setter 가 다시 계산한다.
+ *
+ * 뮤테이션은 호출부가 적용하고 이 명령은 기록만 담당한다(`execute` 는 redo 경로에서만 재적용).
+ */
+export class SetObjectPropsCommand implements EditCommand {
+  readonly type = 'setObjectProps';
+  readonly timestamp: number;
+
+  constructor(
+    private ref: ObjectPropsRef,
+    private before: Record<string, unknown>,
+    private after: Record<string, unknown>,
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  private apply(wasm: WasmBridge, props: Record<string, unknown>): DocumentPosition {
+    setObjectProps(wasm, this.ref, props);
+    return { sectionIndex: this.ref.sec, paragraphIndex: this.ref.ppi, charOffset: 0 };
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    return this.apply(wasm, this.after);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    return this.apply(wasm, this.before);
+  }
+
+  /**
+   * 병합하지 않는다. 회전 15° 를 네 번 누른 것과 60° 를 한 번 누른 것은 한컴에서도 undo
+   * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
+   */
   mergeWith(): null { return null; }
 }
 

--- a/rhwp-studio/src/engine/object-props.ts
+++ b/rhwp-studio/src/engine/object-props.ts
@@ -1,0 +1,78 @@
+/**
+ * 선택 개체의 속성 조회·변경 라우팅 (Task #3230).
+ *
+ * 개체는 어디에 있느냐에 따라 setter/getter 가 넷으로 갈린다 — 본문 도형, 본문 그림, 셀 안
+ * (`cellPath`), 머리말/꼬리말(`headerFooter`, [Task #831]). 이 분기는 지금까지
+ * `command/commands/insert.ts` 안에만 있었는데, **역연산 커맨드도 undo 시점에 같은 분기가
+ * 필요하다.** 커맨드는 `services` 가 아니라 `WasmBridge` 만 받으므로 여기서 `wasm` 기준으로
+ * 두고 양쪽이 함께 쓴다.
+ *
+ * 분기가 갈라지면 적용과 되돌리기가 서로 다른 개체를 만지게 된다 — HF 그림이 그 예다
+ * (본문 lookup 으로 떨어지면 조용히 아무것도 안 바뀐다).
+ */
+
+import type { CellPathLike } from '@/core/types';
+import type { WasmBridge } from '@/core/wasm-bridge';
+
+/** 선택 개체 ref — `cursor.selectedPictureRef` 와 정합 (headerFooter optional, [Task #831]). */
+export type ObjectPropsRef = {
+  sec: number;
+  ppi: number;
+  ci: number;
+  type: string;
+  cellPath?: CellPathLike;
+  headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
+};
+
+/** 선택 개체의 현재 속성. */
+export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<string, unknown> {
+  if (ref.type === 'shape') {
+    if (ref.cellPath && ref.cellPath.length > 0) {
+      return wasm.getCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
+    }
+    return wasm.getShapeProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+  }
+  // [Task #831] 머리말/꼬리말 picture 는 별도 API. 미적용 시 본문 lookup 실패 → props 빈/stale
+  // → 회전/대칭 무동작.
+  if (ref.headerFooter) {
+    return wasm.getHeaderFooterPictureProperties(
+      ref.sec,
+      ref.headerFooter.outerParaIdx,
+      ref.headerFooter.outerControlIdx,
+      ref.ppi,
+      ref.ci,
+    ) as unknown as Record<string, unknown>;
+  }
+  if (ref.cellPath && ref.cellPath.length > 0) {
+    return wasm.getCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci) as unknown as Record<string, unknown>;
+  }
+  return wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
+}
+
+/** 선택 개체에 속성을 적용한다. `getObjectProps` 와 같은 분기를 쓴다. */
+export function setObjectProps(
+  wasm: WasmBridge,
+  ref: ObjectPropsRef,
+  props: Record<string, unknown>,
+): unknown {
+  if (ref.type === 'shape') {
+    if (ref.cellPath && ref.cellPath.length > 0) {
+      return wasm.setCellShapePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
+    }
+    return wasm.setShapeProperties(ref.sec, ref.ppi, ref.ci, props);
+  }
+  if (ref.headerFooter) {
+    return wasm.setHeaderFooterPictureProperties(
+      ref.sec,
+      ref.headerFooter.outerParaIdx,
+      ref.headerFooter.outerControlIdx,
+      ref.ppi,
+      ref.ci,
+      props,
+    );
+  }
+  if (ref.cellPath && ref.cellPath.length > 0) {
+    return wasm.setCellPicturePropertiesByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci, props);
+  }
+  return wasm.setPictureProperties(ref.sec, ref.ppi, ref.ci, props);
+}

--- a/rhwp-studio/src/view/flow-image-url-cache.ts
+++ b/rhwp-studio/src/view/flow-image-url-cache.ts
@@ -28,13 +28,7 @@
  * 그대로 둔다.
  */
 
-/** 캐시가 어느 문서의 것인지 — `WasmBridge` 의 문서 신원과 같은 재료를 쓴다. */
-export interface FlowImageDocumentIdentity {
-  /** `WasmBridge.documentDigest`. 문서를 모르는 상태(`null`)에서는 캐시하지 않는다. */
-  digest: string | null;
-  /** 같은 원본 파일을 다시 연 경우까지 구분하는 `WasmBridge.documentGeneration`. */
-  generation: number;
-}
+import { isSameRenderDocument, type RenderDocumentIdentity } from './render-document-identity.ts';
 
 export class FlowImageUrlCache {
   private urls = new Map<string, string>();
@@ -48,12 +42,8 @@ export class FlowImageUrlCache {
    * 둔다. 신원을 모르면(`digest === null`) 항목을 어느 문서 것이라고 표시할 수 없으므로 이후
    * 조회는 캐시하지 않고 되돌린다.
    */
-  beginDocument(document: FlowImageDocumentIdentity): void {
-    if (
-      this.identity !== null
-      && this.identity.digest === document.digest
-      && this.identity.generation === document.generation
-    ) return;
+  beginDocument(document: RenderDocumentIdentity): void {
+    if (isSameRenderDocument(this.identity, document)) return;
 
     this.releaseAll();
     if (document.digest === null) return;

--- a/rhwp-studio/src/view/image-prefetch-signature.ts
+++ b/rhwp-studio/src/view/image-prefetch-signature.ts
@@ -7,6 +7,8 @@
  * (`getPageSourceImageKeys`, 수백 바이트)을 서명으로 쓴다.
  */
 
+import { isSameRenderDocument } from './render-document-identity.ts';
+
 export interface PrefetchSignature {
   /**
    * 이 서명이 설명하는 문서 (`WasmBridge.documentDigest`).
@@ -87,8 +89,12 @@ export function shouldSkipImagePrefetch(
   currentRawSvgCount: number,
 ): boolean {
   if (imageKeys === null || documentDigest === null || !cached) return false;
-  if (cached.documentDigest !== documentDigest) return false;
-  if (cached.documentGeneration !== documentGeneration) return false;
+  if (
+    !isSameRenderDocument(
+      { digest: cached.documentDigest, generation: cached.documentGeneration },
+      { digest: documentDigest, generation: documentGeneration },
+    )
+  ) return false;
   // 그림 키가 덮지 못하는 rawSvg가 현재 새로 생긴 경우도 전체 JSON을 다시 읽어야 한다.
   if (currentRawSvgCount > 0) return false;
   if (cached.hadRawSvg) return false;

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -24,6 +24,7 @@ import {
 import { FlowImageUrlCache } from './flow-image-url-cache';
 import { drawPageMarginGuides, type PageSpaceRect } from './page-margin-guides';
 import type { RenderBackend } from './render-backend';
+import { isSameRenderDocument, type RenderDocumentIdentity } from './render-document-identity.ts';
 
 interface LayerPlaneSummary {
   hasBehind: boolean;
@@ -82,9 +83,9 @@ export class PageRenderer {
    * prefetch 를 끝낸 페이지의 그림 서명 (Task #3315).
    *
    * 내용에서 유도된 키라 스스로 무효화된다 — 편집 때 비우지 않는다. 비우면 서명을 두는
-   * 의미가 사라진다. 문서 경계는 서명이 들고 다니는 `documentDigest` 로 갈린다 —
-   * `PageRenderer` 는 문서보다 오래 살고 문서 로드 경로가 이 맵을 비우지 않으므로,
-   * 비우기에 기대지 않고 항목 자체가 어느 문서의 것인지 말하게 한다.
+   * 의미가 사라진다. 서명은 자기가 어느 문서의 것인지(`documentDigest`) 함께 들고 다니므로
+   * 옛 문서의 항목이 새 문서에서 잘못 맞아떨어지지 않는다. 다만 **맞지 않을 뿐 사라지지도
+   * 않으므로**, 수명은 `beginDocument` 가 문서 경계에서 거둔다.
    */
   private prefetchedImageSignatures = new Map<number, PrefetchSignature>();
   /**
@@ -94,6 +95,14 @@ export class PageRenderer {
    * `beginDocument` 가 가른다.
    */
   private flowImageUrls = new FlowImageUrlCache();
+  /**
+   * 위 페이지 단위 파생 상태가 어느 문서의 것인지 (Task #3315).
+   *
+   * `beginDocument` 가 이 값과 현재 문서를 견줘 거둘지 말지 정한다. 항목마다 신원이 박혀 있는
+   * 것과 별개로 필요하다 — 항목의 신원은 "새 문서에서 잘못 맞지 않게" 하고, 이 값은 "옛 문서의
+   * 항목을 언제 버릴지"를 정한다.
+   */
+  private documentScope: RenderDocumentIdentity | null = null;
   private prefetchRequestTokens = new Map<number, number>();
   private nextPrefetchRequestToken = 0;
   private flowSplitSupported: boolean | null = null;
@@ -129,17 +138,38 @@ export class PageRenderer {
   /**
    * 문서 (재)로드 경계 — `CanvasView.prepareDocumentLoad` 가 부른다 (Task #3315).
    *
-   * 문서 범위 자원 가운데 브라우저가 명시적 회수까지 붙들고 있는 것(flow 그림 object URL)을
-   * 여기서 넘긴다. 조회 시점으로 미루면 새 문서가 flow 그림을 한 장도 조회하지 않을 때
-   * (그림 없는 문서·CanvasKit 경로) 옛 문서의 URL 이 그대로 남는다.
+   * **문서 범위 파생 상태의 수명을 정하는 유일한 자리다.** `PageRenderer` 는 문서보다 오래
+   * 살므로, 여기서 거두지 않으면 세션이 끝날 때까지 남는다 — `dispose()` 는 문서 닫기·뷰 교체
+   * 기능이 생길 때를 위한 자리라 지금은 호출부가 없다(`CanvasView.dispose`).
    *
-   * 같은 문서를 다시 로드한 경우에는 캐시가 신원을 보고 그대로 둔다.
+   * 거두는 것은 셋이다.
+   *
+   * - flow 그림 object URL — 브라우저가 명시적 회수까지 붙들고 있다. 조회 시점으로 미루면 새
+   *   문서가 flow 그림을 한 장도 조회하지 않을 때(그림 없는 문서·CanvasKit 경로) 옛 문서의
+   *   URL 이 그대로 남는다.
+   * - 재시도 키(`imageRetryCounts`)·prefetch 서명(`prefetchedImageSignatures`) — 둘 다 키에
+   *   문서 신원이 박혀 있어 새 문서에서 **잘못 맞아떨어지지는 않는다.** 그래서 이건 정확성이
+   *   아니라 수명 문제다. 다시 읽히지 않을 항목이 문서를 열 때마다 페이지 수만큼 쌓인다.
+   *
+   * 편집(문서 revision 변화)으로는 거두지 않는다 — 그 경계는 `resetImageRetryState` 이고,
+   * 거기서 재시도 키를 비우면 페이지마다 재렌더가 한 번 더 돈다(#3672). 페이지가 풀에서
+   * 빠질 때도 거두지 않는다 — 같은 이유로 페이지를 다시 볼 때마다 재렌더가 한 번 더 돈다.
+   *
+   * 같은 문서를 다시 로드한 경우에는 신원이 같으므로 그대로 둔다.
    */
   beginDocument(): void {
-    this.flowImageUrls.beginDocument({
+    const identity: RenderDocumentIdentity = {
       digest: this.wasm.documentDigest,
       generation: this.wasm.documentGeneration,
-    });
+    };
+    this.flowImageUrls.beginDocument(identity);
+    if (isSameRenderDocument(this.documentScope, identity)) return;
+
+    this.imageRetryCounts.clear();
+    this.prefetchedImageSignatures.clear();
+    // 신원을 모르면(`digest === null`) 항목이 어느 문서 것인지 표시할 수 없다. 그 상태에서는
+    // `buildImageRetryKey` 도 서명 기록도 멈추므로 지킬 것이 없다 — 범위를 비워 둔다.
+    this.documentScope = identity.digest === null ? null : identity;
   }
 
   invalidateDocumentRevision(): void {
@@ -1252,8 +1282,11 @@ export class PageRenderer {
    * (`refreshPages` → `releaseAllRenderedPages`) 불리므로, 비우면 페이지마다 재렌더가 한 번 더
    * 돈다 — prefetch 가 서명으로 건너뛰어 `finish()` 가 즉시 불리고 다시 그린다.
    *
-   * 문서 경계와 그림 내용 변화는 재시도 키가 직접 든다(`buildImageRetryKey`). 그래서 바깥에서
-   * 비워 줄 시점을 맞출 필요가 없다 — 맞춰야 하는 계약이 #3648·P1 에서 깨진 그 계약이다.
+   * 문서 경계와 그림 내용 변화는 재시도 키가 직접 든다(`buildImageRetryKey`). 그래서 **편집
+   * 시점에** 비워 줄 필요가 없다 — 맞춰야 하는 계약이 #3648·P1 에서 깨진 그 계약이다.
+   *
+   * 다만 "잘못 맞지 않는다"와 "사라진다"는 다르다. 다시 읽히지 않을 항목을 거두는 자리는
+   * 문서 경계인 `beginDocument` 다.
    */
   resetImageRetryState(): void {
     this.prefetchRequestTokens.clear();
@@ -1269,6 +1302,7 @@ export class PageRenderer {
     this.layerSummaryCache.clear();
     this.canvaskitDiagnosticsByPage.clear();
     this.flowImageUrls.releaseAll();
+    this.documentScope = null;
     this.canvaskitRenderer = null;
   }
 }

--- a/rhwp-studio/src/view/render-document-identity.ts
+++ b/rhwp-studio/src/view/render-document-identity.ts
@@ -1,0 +1,35 @@
+/**
+ * 렌더러가 들고 있는 파생 상태가 **어느 문서의 것인지** (Task #3315).
+ *
+ * `PageRenderer` 는 문서보다 오래 산다. 그래서 페이지 단위로 캐시한 항목은 자기가 어느 문서의
+ * 것인지 함께 들고 다녀야 한다 — `bin_data_id` 는 문서마다 1 부터, 세대 번호는 0 부터 다시
+ * 매겨져서 두 문서의 0쪽 첫 그림이 똑같이 `bin:0:1:src` 이기 때문이다.
+ *
+ * 같은 판정이 세 곳에서 필요하다 — flow 그림 object URL 캐시(`FlowImageUrlCache`), 그림 prefetch
+ * 서명(`shouldSkipImagePrefetch`), 그리고 문서 경계에서 파생 상태를 거두는
+ * `PageRenderer.beginDocument`. 규칙이 갈라지면 한쪽만 옛 문서의 항목을 살려 두게 되므로 한 곳에
+ * 둔다.
+ */
+
+/** 문서 인스턴스의 신원 — `WasmBridge` 가 내주는 재료를 그대로 쓴다. */
+export interface RenderDocumentIdentity {
+  /** `WasmBridge.documentDigest`. 문서를 모르는 상태는 `null` 이다. */
+  digest: string | null;
+  /** 같은 원본 파일을 다시 연 경우까지 가르는 `WasmBridge.documentGeneration`. */
+  generation: number;
+}
+
+/**
+ * 두 신원이 같은 문서 인스턴스를 가리키는지.
+ *
+ * 문서를 모르는 상태(`digest === null`)는 **어느 것과도 같지 않다.** 신원을 모르면 들고 있던
+ * 항목이 그 문서의 것이라고 말할 수 없으므로, 재사용하지 않는 쪽(=거두는 쪽)으로 판정한다.
+ */
+export function isSameRenderDocument(
+  a: RenderDocumentIdentity | null,
+  b: RenderDocumentIdentity | null,
+): boolean {
+  if (a === null || b === null) return false;
+  if (a.digest === null || b.digest === null) return false;
+  return a.digest === b.digest && a.generation === b.generation;
+}

--- a/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
+++ b/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
@@ -1,0 +1,166 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+// `engine/command.ts` 는 constructor parameter property 를 쓰므로 Node 의 타입 스트리핑으로는
+// 못 읽는다(`page-margin-guides.test.ts` 와 같은 이유·같은 방식으로 vite SSR 로 띄운다).
+const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+let SetObjectPropsCommand: any;
+let getObjectProps: any;
+let setObjectProps: any;
+
+test('모듈 로드', async () => {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    ({ SetObjectPropsCommand } = await vite.ssrLoadModule('/src/engine/command.ts'));
+    ({ getObjectProps, setObjectProps } = await vite.ssrLoadModule('/src/engine/object-props.ts'));
+  } finally {
+    await vite.close();
+  }
+  assert.equal(typeof SetObjectPropsCommand, 'function');
+});
+
+// [#3230] 개체 속성 변경을 스냅샷에서 역연산으로.
+//
+// 스냅샷 1개는 `Document` 통째 클론이라 문서에 비례한다 — 실측으로 30KB 공문 0.43 MB,
+// 10MB 행정편람 10.59 MB. `SnapshotCommand` 는 before/after 로 2개를 쓰므로 회전 한 번이
+// 최대 21 MB 다. 실제로 되돌려야 하는 것은 스칼라 속성 하나뿐이다.
+//
+// 여기서 고정하는 것은 둘이다 — 역연산이 왕복하는가, 그리고 스냅샷 예산을 쓰지 않는가.
+
+interface Call { fn: string; args: unknown[] }
+
+function recordingWasm(): { wasm: any; calls: Call[] } {
+  const calls: Call[] = [];
+  const rec = (fn: string) => (...args: unknown[]) => {
+    calls.push({ fn, args });
+    return { ok: true };
+  };
+  return {
+    calls,
+    wasm: {
+      setShapeProperties: rec('setShapeProperties'),
+      setPictureProperties: rec('setPictureProperties'),
+      setCellShapePropertiesByPath: rec('setCellShapePropertiesByPath'),
+      setCellPicturePropertiesByPath: rec('setCellPicturePropertiesByPath'),
+      setHeaderFooterPictureProperties: rec('setHeaderFooterPictureProperties'),
+      getShapeProperties: rec('getShapeProperties'),
+      getPictureProperties: rec('getPictureProperties'),
+      getCellShapePropertiesByPath: rec('getCellShapePropertiesByPath'),
+      getCellPicturePropertiesByPath: rec('getCellPicturePropertiesByPath'),
+      getHeaderFooterPictureProperties: rec('getHeaderFooterPictureProperties'),
+    },
+  };
+}
+
+const bodyImage = { sec: 0, ppi: 3, ci: 1, type: 'image' as const };
+
+test('[#3230] undo 는 적용 전 값으로, redo 는 적용 값으로 되돌린다', () => {
+  const { wasm, calls } = recordingWasm();
+  const cmd = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 15 });
+
+  const undoPos = cmd.undo(wasm);
+  assert.deepEqual(calls.at(-1), {
+    fn: 'setPictureProperties',
+    args: [0, 3, 1, { rotationAngle: 0 }],
+  });
+  assert.deepEqual(undoPos, { sectionIndex: 0, paragraphIndex: 3, charOffset: 0 });
+
+  cmd.execute(wasm);
+  assert.deepEqual(calls.at(-1), {
+    fn: 'setPictureProperties',
+    args: [0, 3, 1, { rotationAngle: 15 }],
+  });
+});
+
+test('[#3230] 스냅샷 예산을 쓰지 않는다', () => {
+  const cmd = new SetObjectPropsCommand(bodyImage, { horzFlip: false }, { horzFlip: true }) as any;
+  // 히스토리는 `cmd.snapshotResourceCount?.() ?? 0` 로 예산을 센다(engine/history.ts).
+  assert.equal(
+    cmd.snapshotResourceCount?.() ?? 0,
+    0,
+    '역연산 커맨드가 예산을 쓰면 스냅샷에서 옮긴 의미가 없다',
+  );
+  assert.equal(cmd.discard, undefined, '해제할 WASM 스냅샷 id 가 없어야 한다');
+});
+
+test('[#3230] 회전 15° 를 네 번 눌러도 병합하지 않는다', () => {
+  const cmd = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 15 });
+  assert.equal(
+    cmd.mergeWith(),
+    null,
+    '한컴도 누른 횟수만큼 되돌린다 — 묶으면 되돌리기 단위가 어긋난다',
+  );
+});
+
+test('[#3230] 적용과 되돌리기는 같은 개체를 만진다 — 셀 안', () => {
+  const { wasm, calls } = recordingWasm();
+  const cellPath = [{ controlIndex: 2, cellIndex: 5, cellParaIndex: 0 }];
+  const ref = { sec: 0, ppi: 7, ci: 0, type: 'shape' as const, cellPath };
+  const cmd = new SetObjectPropsCommand(ref, { rotationAngle: 90 }, { rotationAngle: 180 });
+
+  cmd.execute(wasm);
+  cmd.undo(wasm);
+
+  assert.deepEqual(calls.map((c) => c.fn), [
+    'setCellShapePropertiesByPath',
+    'setCellShapePropertiesByPath',
+  ], '셀 안 도형은 양방향 모두 by-path setter 여야 한다');
+  assert.deepEqual(calls[0].args, [0, 7, cellPath, 0, { rotationAngle: 180 }]);
+  assert.deepEqual(calls[1].args, [0, 7, cellPath, 0, { rotationAngle: 90 }]);
+});
+
+test('[#3230] 적용과 되돌리기는 같은 개체를 만진다 — 머리말/꼬리말', () => {
+  const { wasm, calls } = recordingWasm();
+  const ref = {
+    sec: 0,
+    ppi: 1,
+    ci: 0,
+    type: 'image' as const,
+    headerFooter: { kind: 'header' as const, outerParaIdx: 4, outerControlIdx: 2 },
+  };
+  const cmd = new SetObjectPropsCommand(ref, { vertFlip: false }, { vertFlip: true });
+
+  cmd.execute(wasm);
+  cmd.undo(wasm);
+
+  // [Task #831] HF 그림이 본문 lookup 으로 떨어지면 조용히 아무것도 바뀌지 않는다.
+  assert.deepEqual(calls.map((c) => c.fn), [
+    'setHeaderFooterPictureProperties',
+    'setHeaderFooterPictureProperties',
+  ]);
+  assert.deepEqual(calls[0].args, [0, 4, 2, 1, 0, { vertFlip: true }]);
+  assert.deepEqual(calls[1].args, [0, 4, 2, 1, 0, { vertFlip: false }]);
+});
+
+test('[#3230] 조회와 적용이 같은 분기를 쓴다', () => {
+  // before 를 읽은 경로와 되돌릴 때 쓰는 경로가 갈리면 되돌리기가 다른 개체를 만진다.
+  const cases: Array<[any, string, string]> = [
+    [{ sec: 0, ppi: 0, ci: 0, type: 'shape' }, 'getShapeProperties', 'setShapeProperties'],
+    [{ sec: 0, ppi: 0, ci: 0, type: 'image' }, 'getPictureProperties', 'setPictureProperties'],
+    [
+      { sec: 0, ppi: 0, ci: 0, type: 'image', headerFooter: { kind: 'footer', outerParaIdx: 1, outerControlIdx: 0 } },
+      'getHeaderFooterPictureProperties',
+      'setHeaderFooterPictureProperties',
+    ],
+    [
+      { sec: 0, ppi: 0, ci: 0, type: 'image', cellPath: [{ controlIndex: 0, cellIndex: 0, cellParaIndex: 0 }] },
+      'getCellPicturePropertiesByPath',
+      'setCellPicturePropertiesByPath',
+    ],
+  ];
+  for (const [ref, getFn, setFn] of cases) {
+    const { wasm, calls } = recordingWasm();
+    getObjectProps(wasm, ref);
+    setObjectProps(wasm, ref, { rotationAngle: 10 });
+    assert.deepEqual(calls.map((c) => c.fn), [getFn, setFn], `${ref.type} 분기 불일치`);
+    // locator 인자(속성 bag 앞부분)가 양쪽에서 같아야 한다.
+    assert.deepEqual(calls[0].args, calls[1].args.slice(0, -1));
+  }
+});

--- a/rhwp-studio/tests/issue-3315-document-scope.test.ts
+++ b/rhwp-studio/tests/issue-3315-document-scope.test.ts
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+import {
+  isSameRenderDocument,
+  type RenderDocumentIdentity,
+} from '../src/view/render-document-identity.ts';
+
+// [#3315] 문서 범위 파생 상태의 수명은 문서 경계가 정한다.
+//
+// `imageRetryCounts`·`prefetchedImageSignatures` 는 항목마다 문서 신원(digest·generation)을 들고
+// 다닌다. 그래서 새 문서에서 **잘못 맞아떨어지지는 않는다** — 정확성은 이미 서 있다.
+//
+// 문제는 수명이다. 두 맵을 비우는 자리는 `dispose()` 뿐인데 `CanvasView.dispose` 에는 호출부가
+// 없다(문서 닫기·뷰 교체 기능이 생길 때를 위한 자리다). 그래서 문서를 열 때마다 그 문서의 페이지
+// 수만큼 항목이 쌓이고, 세션이 끝날 때까지 하나도 줄지 않는다.
+//
+// 거두는 자리는 편집 경계(`resetImageRetryState`)도, 페이지 풀 해제도 아니다 — 둘 다 페이지마다
+// 재렌더를 한 번 더 돌게 만든다(#3672 가 없앤 그 비용). 문서 경계(`beginDocument`)다.
+
+const studioRoot = fileURLToPath(new URL('..', import.meta.url));
+
+const DOC_A: RenderDocumentIdentity = { digest: 'blake3:aaaa', generation: 1 };
+const DOC_B: RenderDocumentIdentity = { digest: 'blake3:bbbb', generation: 2 };
+
+const signature = (identity: RenderDocumentIdentity) => ({
+  documentDigest: identity.digest,
+  documentGeneration: identity.generation,
+  imageKeys: '{"keys":["bin:0:1:src"]}',
+  hadRawSvg: false,
+});
+
+/** 두 맵에 페이지 항목을 심는다 (private 필드 — 런타임에는 평범한 속성이다). */
+const seedPageEntries = (renderer: any, identity: RenderDocumentIdentity, pages: number): void => {
+  for (let pageIdx = 0; pageIdx < pages; pageIdx += 1) {
+    renderer.imageRetryCounts.set(pageIdx, `${identity.digest}|${identity.generation}|k`);
+    renderer.prefetchedImageSignatures.set(pageIdx, signature(identity));
+  }
+};
+
+const entryCounts = (renderer: any): { retry: number; prefetch: number } => ({
+  retry: renderer.imageRetryCounts.size,
+  prefetch: renderer.prefetchedImageSignatures.size,
+});
+
+async function withPageRenderer(
+  run: (make: (wasm: any) => any) => void | Promise<void>,
+): Promise<void> {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    const { PageRenderer } = await vite.ssrLoadModule('/src/view/page-renderer.ts');
+    await run((wasm: any) => new PageRenderer(wasm));
+  } finally {
+    await vite.close();
+  }
+}
+
+test('[#3315] 문서가 갈리면 옛 문서의 페이지 항목을 거둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 40);
+    assert.deepEqual(entryCounts(renderer), { retry: 40, prefetch: 40 });
+
+    // 다음 문서를 연다 — 세대는 로드마다 오르므로 신원이 반드시 갈린다.
+    wasm.documentDigest = DOC_B.digest;
+    wasm.documentGeneration = DOC_B.generation;
+    renderer.beginDocument();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 0, prefetch: 0 },
+      '옛 문서의 항목은 새 문서에서 다시 읽히지 않는다 — 읽히지 않을 뿐 사라지지도 않으면 '
+        + '세션 내내 쌓인다',
+    );
+  });
+});
+
+test('[#3315] 긴 문서를 본 뒤 짧은 문서를 열면 긴 문서의 페이지가 남지 않는다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    // 400쪽짜리 그림 문서를 끝까지 훑는다.
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 400);
+
+    // 그리고 5쪽짜리 문서를 연다. 페이지 색인이 겹치는 0..4 는 덮이지만 5..399 는 덮을
+    // 항목이 없다 — 거두지 않으면 그 395개가 세션 내내 남는다.
+    wasm.documentDigest = DOC_B.digest;
+    wasm.documentGeneration = DOC_B.generation;
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_B, 5);
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 5, prefetch: 5 },
+      '항목 수는 지금 열린 문서의 페이지 수여야 한다 — 세션에서 본 가장 긴 문서의 페이지 수가 '
+        + '아니다',
+    );
+  });
+});
+
+test('[#3315] 같은 문서를 다시 준비하면 항목을 그대로 둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 12);
+    renderer.beginDocument();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 12, prefetch: 12 },
+      '신원이 같으면 거둘 이유가 없다 — 거두면 같은 페이지를 다시 데우고 다시 그린다',
+    );
+  });
+});
+
+test('[#3315] 편집 경계는 여전히 재시도 키를 비우지 않는다 (#3672 회귀 방지)', async () => {
+  await withPageRenderer((make) => {
+    const wasm = { documentDigest: DOC_A.digest, documentGeneration: DOC_A.generation };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 8);
+    // `refreshPages` → `releaseAllRenderedPages` 가 편집마다 부르는 자리.
+    renderer.resetImageRetryState();
+
+    assert.deepEqual(
+      entryCounts(renderer),
+      { retry: 8, prefetch: 8 },
+      '편집마다 비우면 페이지마다 재렌더가 한 번 더 돈다 — #3672 가 없앤 비용이다',
+    );
+  });
+});
+
+test('[#3315] 문서 신원을 모르면 범위를 비워 둔다', async () => {
+  await withPageRenderer((make) => {
+    const wasm: { documentDigest: string | null; documentGeneration: number } = {
+      documentDigest: DOC_A.digest,
+      documentGeneration: DOC_A.generation,
+    };
+    const renderer = make(wasm);
+
+    renderer.beginDocument();
+    seedPageEntries(renderer, DOC_A, 5);
+
+    // 신원을 알 수 없는 문서(digest 계산 실패). 항목을 어느 문서 것이라 표시할 수 없다.
+    wasm.documentDigest = null;
+    wasm.documentGeneration = 3;
+    renderer.beginDocument();
+
+    assert.deepEqual(entryCounts(renderer), { retry: 0, prefetch: 0 });
+    // 그리고 그 상태가 "같은 문서"로 굳지 않아야 한다 — 다음 준비에서도 거둔다.
+    seedPageEntries(renderer, DOC_A, 5);
+    renderer.beginDocument();
+    assert.deepEqual(entryCounts(renderer), { retry: 0, prefetch: 0 });
+  });
+});
+
+test('[#3315] 문서 신원 판정은 한 규칙이다', () => {
+  assert.equal(isSameRenderDocument(DOC_A, { ...DOC_A }), true);
+  assert.equal(isSameRenderDocument(DOC_A, DOC_B), false);
+  // 세대만 달라도 다른 문서 인스턴스다 — 같은 파일을 다시 연 경우가 여기 걸린다.
+  assert.equal(isSameRenderDocument(DOC_A, { digest: DOC_A.digest, generation: 2 }), false);
+  // 신원을 모르면 어느 것과도 같지 않다 — 두 `null` 도 같지 않다.
+  assert.equal(isSameRenderDocument({ digest: null, generation: 1 }, { digest: null, generation: 1 }), false);
+  assert.equal(isSameRenderDocument(null, DOC_A), false);
+});

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -73,9 +73,32 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
   );
 });
 
-test('회전/대칭도 recordObjectMutation 으로 기록한다', () => {
+// [Task #3230] 회전/대칭은 스냅샷에서 **역연산**으로 옮겼다. 가드의 뜻은 그대로다 —
+// "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
+test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordObjectMutation\(ih, 'rotateObject'/, '회전을 snapshot 으로 기록');
+  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.doesNotMatch(
+    rot,
+    /\bsetProps\s*\(/,
+    '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
+  );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordObjectMutation\(ih, 'flipObject'/, '대칭을 snapshot 으로 기록');
+  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.doesNotMatch(
+    flip,
+    /\bsetProps\s*\(/,
+    '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
+  );
+});
+
+test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
+  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+  assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
+  assert.match(
+    block,
+    /refresh:\s*'full'/,
+    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+  );
 });

--- a/scripts/tests/rust-test-suite-manifest.test.mjs
+++ b/scripts/tests/rust-test-suite-manifest.test.mjs
@@ -136,6 +136,21 @@ test('경로 의존 case는 기존 target 이름을 유지한다', () => {
   assert.equal(nextestArguments(plan).includes('-E'), false);
 });
 
+test('Native Skia 함수 게이트 case는 독립 target으로 실행한다', () => {
+  const plan = resolveCasePlan('issue_2225_missing_picture_placeholder');
+  assert.deepEqual(plan, {
+    caseName: 'issue_2225_missing_picture_placeholder',
+    target: 'issue_2225_missing_picture_placeholder',
+    grouped: false,
+  });
+  assert.deepEqual(nextestArguments(plan), [
+    'nextest',
+    'run',
+    '--test',
+    'issue_2225_missing_picture_placeholder',
+  ]);
+});
+
 test('CI slow archive case는 독립 target과 nextest 우선순위를 함께 유지한다', () => {
   const manifest = loadManifest();
   assert.deepEqual(manifest.nextestPriorities, [

--- a/tests/suites/suite-policy.json
+++ b/tests/suites/suite-policy.json
@@ -65,6 +65,14 @@
       ]
     },
     {
+      "target": "issue_2225_missing_picture_placeholder",
+      "path": "tests/issue_2225_missing_picture_placeholder.rs",
+      "manual": false,
+      "reasons": [
+        "function_gated_native_skia"
+      ]
+    },
+    {
       "target": "issue_4055_b1_chart_edit_probe",
       "path": "tests/issue_4055_b1_chart_edit_probe.rs",
       "manual": false,


### PR DESCRIPTION
## 통합 범위

- #5556: `6607e42220194a293b209699c10d48f602c681aa`
- #5570: `6c3ae7522c8d8ab20b3c158622d8678c3fc74051`
- 기존 메인터너 보정 `4c668b939632374f723c9a5ba2617f32caf17c66`은 작업지시대로 참고만 하고 포함하지 않았습니다.
- 메인터너 보정: `1f510d688`에서 #2225 Native Skia 함수 게이트를 독립 test target으로 분리했습니다.

## 기준선

- `upstream/devel@161820019` 위로 충돌 없이 리베이스했습니다.

## 로컬 검증

- release build·release lib·전체 nextest: 통과 (`7,313 passed`)
- Native Skia lib 58건, #2225 2건, 직접 PDF 4건: 통과
- fmt·diff check·clippy·doctest: 통과
- Studio TypeScript 및 `npm test`: 997 passed
- Docker 미사용 환경에서 `wasm-pack build --target web --out-dir pkg`: 통과

검토 기록과 오늘할일 문서는 code candidate CI 성공 뒤 trailing commit으로 추가합니다.