### PR TITLE
fix(serializer/hwpx): 앞 run 소유의 제목 차례 표시를 조각 말미에 방출한다 (#5537)

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -797,6 +797,10 @@ pub(crate) struct InlineCursor<'a> {
     pub tab_idx: usize,
     /// 문단의 제목 차례 표시 전체 (문자 인덱스 오름차순)
     pub title_marks: &'a [TitleMark],
+    /// [#5537] `title_marks[i]` 가 **앞(닫히는) run 소유**인가 — char_shapes 경계
+    /// 유닛이 표시 끝 유닛과 일치하면 원본은 표시까지를 앞 run 에 뒀다는 증거다.
+    /// 비어 있으면 전부 false(종전 동작: 다음 run 머리 방출).
+    pub mark_owned_by_prev: &'a [bool],
     /// 다음에 방출할 `title_marks` 인덱스
     pub mark_idx: usize,
     /// 지금까지 방출한 문단 텍스트의 문자 수
@@ -821,6 +825,34 @@ impl InlineCursor<'_> {
             if m.char_idx > self.char_idx {
                 break;
             }
+            flush_buf(t_xml, buf);
+            t_xml.push_str(&format!(
+                r#"<hp:titleMark ignore="{}"/>"#,
+                if m.ignore { 1 } else { 0 }
+            ));
+            self.mark_idx += 1;
+        }
+    }
+
+    /// [#5537] 다음 미방출 표시가 현재 위치에 걸려 있고 **닫히는 run 소유**
+    /// (char_shapes 경계 유닛 == 표시 끝 유닛 — 원본이 표시를 앞 run 에 뒀다는
+    /// 증거)인가. 조각 말미 flush 의 발동 조건이다.
+    fn has_pending_prev_owned_mark(&self) -> bool {
+        self.title_marks
+            .get(self.mark_idx)
+            .is_some_and(|m| m.char_idx == self.char_idx)
+            && self
+                .mark_owned_by_prev
+                .get(self.mark_idx)
+                .copied()
+                .unwrap_or(false)
+    }
+
+    /// [#5537] 조각 말미에서 닫히는 run 소유의 표시만 방출한다 — 나머지는
+    /// 종전대로 다음 run 머리에서 flush 된다(한컴 실측 두 형태 공존).
+    fn flush_prev_owned_marks_at_fragment_end(&mut self, t_xml: &mut String, buf: &mut String) {
+        while self.has_pending_prev_owned_mark() {
+            let m = &self.title_marks[self.mark_idx];
             flush_buf(t_xml, buf);
             t_xml.push_str(&format!(
                 r#"<hp:titleMark ignore="{}"/>"#,
@@ -916,6 +948,9 @@ pub(crate) fn render_hp_t_content(
             c => buf.push(hancom_symbol_for_hwpx(c)),
         }
     }
+    // [#5537] 조각 말미 — 닫히는 run 소유의 표시(경계 유닛 = 표시 끝 유닛)는 여기서
+    // 방출한다. 다음 run 머리로 넘기면 재파싱 char_shapes 경계가 8유닛 무너진다.
+    cursor.flush_prev_owned_marks_at_fragment_end(&mut t_xml, &mut buf);
     flush_buf(&mut t_xml, &mut buf);
     t_xml.push_str("</hp:t>");
     t_xml
@@ -1275,8 +1310,24 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> (String, bool) {
     // [#4677] 책갈피는 이제 위치 슬롯이라(`occupies_hwpx_slot_axis`) 슬롯 루프가 제자리에
     // 방출한다. 종전의 별도 방출(문단 시작 hoist / slot 사이 in-order, Task #1591·#1627)은
     // 슬롯 축이 책갈피를 잡지 못하던 시절의 우회였고, 그대로 두면 이중 방출이 된다.
+    // [#5537] 표시별 소유 run 판별 — 표시 끝 유닛(= 다음 문자의 char_offsets 값)에
+    // char_shapes 경계가 정확히 걸리면, 원본은 표시까지를 **앞 run** 에 뒀다
+    // (hwp3-sample10-hwp5 pi=14164: 유닛 7..15 표시 + 경계 15 = run(39) 소유.
+    // 다음 run 머리로 넘기면 재파싱 경계가 15→7 로 무너진다). 표시가 문자 갭
+    // 없이 놓인 합성 IR(char_offsets 에 8유닛 갭 없음)은 어느 경계에도 안 걸려
+    // 종전 동작(다음 run 머리) 그대로다.
+    let mark_owned_by_prev: Vec<bool> = para
+        .title_marks
+        .iter()
+        .map(|m| {
+            para.char_offsets.get(m.char_idx).is_some_and(|&end_unit| {
+                end_unit >= 8 && para.char_shapes.iter().any(|cs| cs.start_pos == end_unit)
+            })
+        })
+        .collect();
     let mut cursor = InlineCursor {
         title_marks: &para.title_marks,
+        mark_owned_by_prev: &mark_owned_by_prev,
         // [#4895] 출처가 제어 표기였던 문단만 `<hp:hyphen/>` 로 되돌린다.
         soft_hyphen_as_element: para.control_mask & (1u32 << 0x0018) != 0,
         // [#5174] 같은 계약 — 출처가 제어·요소 표기였던 문단만 `<hp:nbSpace/>` 로 되돌린다.
@@ -1850,7 +1901,10 @@ fn flush_text_fragment(
     tab_extended: &[[u16; 7]],
     cursor: &mut InlineCursor<'_>,
 ) {
-    if !text_buf.is_empty() {
+    // [#5537] 닫히는 run 소유의 제목 차례 표시(경계 유닛 = 표시 끝 유닛)가 걸려
+    // 있으면 버퍼가 비어도 조각을 방출한다 — 건너뛰면 표시가 다음 run 머리로
+    // 넘어가 재파싱 char_shapes 경계가 표시 폭(8유닛)만큼 무너진다.
+    if !text_buf.is_empty() || cursor.has_pending_prev_owned_mark() {
         out.push_str(&render_hp_t_content(text_buf, tab_extended, cursor));
         text_buf.clear();
     }
@@ -3402,6 +3456,48 @@ mod tests {
         };
         let xml = render_hp_t_content("가나", &[], &mut cursor);
         assert_eq!(xml, "<hp:t><hp:titleMark ignore=\"1\"/>가나</hp:t>");
+    }
+
+    /// [#5537] 닫히는 run 소유의 제목 차례 표시(char_shapes 경계 유닛 == 표시 끝
+    /// 유닛)는 앞 run 조각 말미에 방출된다 — 다음 run 머리로 넘기면 재파싱
+    /// char_shapes 경계가 표시 폭(8유닛)만큼 무너진다(hwp3-sample10-hwp5
+    /// pi=14164: 경계 15→7 붕괴 실측).
+    #[test]
+    fn prev_owned_title_mark_is_emitted_at_fragment_end() {
+        let mut cursor = InlineCursor {
+            title_marks: &[TitleMark {
+                char_idx: 2,
+                ignore: true,
+            }],
+            mark_owned_by_prev: &[true],
+            ..Default::default()
+        };
+        // 표시 char_idx=2 == 조각 끝 — 소유 플래그가 서 있으면 이 조각 말미에 실린다.
+        let xml = render_hp_t_content("가나", &[], &mut cursor);
+        assert_eq!(
+            xml, "<hp:t>가나<hp:titleMark ignore=\"1\"/></hp:t>",
+            "닫히는 run 소유 표시는 조각 말미에 방출되어야 한다"
+        );
+        // 이미 소비됐으므로 다음 조각 머리에는 다시 실리지 않는다.
+        let xml2 = render_hp_t_content("다라", &[], &mut cursor);
+        assert_eq!(xml2, "<hp:t>다라</hp:t>");
+    }
+
+    /// [#5537] 소유 플래그가 없으면 종전 동작 — 표시는 다음 run 머리에 실린다
+    /// (한컴 실측 두 형태 공존: `<hp:t><hp:titleMark/>텍스트</hp:t>`).
+    #[test]
+    fn unowned_boundary_title_mark_stays_at_next_fragment_head() {
+        let mut cursor = InlineCursor {
+            title_marks: &[TitleMark {
+                char_idx: 2,
+                ignore: true,
+            }],
+            ..Default::default()
+        };
+        let xml = render_hp_t_content("가나", &[], &mut cursor);
+        assert_eq!(xml, "<hp:t>가나</hp:t>");
+        let xml2 = render_hp_t_content("다라", &[], &mut cursor);
+        assert_eq!(xml2, "<hp:t><hp:titleMark ignore=\"1\"/>다라</hp:t>");
     }
 
     /// `ignore="0"`(`Mign`)도 구별해 낸다 — 한글 2022 양방향 실측(06699).


### PR DESCRIPTION
# fix(serializer/hwpx): 앞 run 소유의 제목 차례 표시를 조각 말미에 방출한다 (#5537)

## 근인

제목 차례 표시(8유닛 인라인 컨트롤, `<hp:titleMark>`)가 run 경계에 걸릴 때 직렬화기의 `InlineCursor` 는 **문자 인덱스만 보고 항상 다음 run 머리**에 방출했다. 그런데 한컴 원본에는 표시까지를 **앞 run** 에 두는 형태가 공존한다 — 판별 증거는 유닛 좌표다: `char_shapes` 경계 유닛이 표시 끝 유닛(= 다음 문자의 `char_offsets` 값)과 일치하면 원본 run 은 표시를 포함한다.

`hwp3-sample10-hwp5.hwp`(HWP5) 실측:

| 문단 | IR(원본) | 종전 재파싱 | 구조 |
|---|---|---|---|
| pi=14164 | `[(0,39),(15,29)]` | `[(0,39),(7,29)]` | 표시(유닛 7..15)가 run(39) 소유인데 run(29) 머리로 넘어가 경계 15→7 붕괴 |
| pi=25845 | `[(0,29),(8,88),(44,29)]` | `[(0,29),(0,88),(44,29)]` | 선두 빈 run(29)이 표시를 소유하는데 `<hp:t></hp:t>` 리터럴 경로가 flush 를 건너뛰어 run(88) 머리로 |

이슈의 char_shapes 5건이 전부 이 형상이다.

## 수정

1. 표시별 소유 판별(`mark_owned_by_prev`): 경계 유닛 == 표시 끝 유닛 → 앞 run 소유.
2. 소유 표시는 조각 말미(`render_hp_t_content` 종단)에 방출.
3. 경계 절단 시 소유 표시가 걸려 있으면 빈 버퍼라도 조각을 방출(선두 빈 run 소유 케이스 — 종전엔 빈 `<hp:t></hp:t>` 리터럴 경로가 커서를 우회).

판별자가 안 서는 문단(경계 비일치·합성 IR)은 종전 동작(다음 run 머리) 그대로다 — 한컴 실측 두 형태 공존을 그대로 보존한다.

## 실측

- `hwp3-sample10-hwp5.hwp`: `--verify` char_shapes 5건 → **IR 차이 없음** (본 수정 단독; 음성 대조 — 수정 제거 시 5건 재현). 동반 증상 쪽수 763→764 는 독립 축으로 잔존(이슈에 기록).
- 10k 코퍼스 HWP5 무작위 200문서 h2x `--verify` 차이 수 A/B: **악화 0 · 변화 0**(비교 불가 3건은 양측 공통) — 판별자가 서는 형상이 코퍼스에 드물어 영향 반경이 좁다.

## 게이트

- 단위 테스트 2건(신규): 소유 표시의 조각 말미 방출 + 비소유 표시의 종전 동작 보존. 기존 titleMark 계열 테스트 전부 통과
- rustfmt(변경 파일)·clippy `-D warnings`·`cargo check --target wasm32 --lib`·manifest 체크·nextest 전체: 결과는 아래 코멘트로 갱신
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(변경 파일 rustfmt 직접 검사로 대체)

이슈 #5537 의 char_shapes 축 해소 (같은 이슈의 쪽수 +1 은 잔존; 관련 #5542/#5532=PR #5604 — 독립 축·독립 브랜치)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
