### PR TITLE
fix: #3230 #5607 에서 빠진 보정 4건 — 양식 모드 우회·그림 회전 저장바이트 회귀

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -713,6 +713,45 @@ function executeAbsolutePropChange(
   });
 }
 
+/**
+ * [Task #3230] 속성 왕복이 **참인 역연산인 대상**인지.
+ *
+ * 도형은 참이다 — `rotationAngle` 은 평범한 필드 대입이고 flip 은 비트를 대칭으로 set/clear
+ * 한다(`document_core/commands/object_ops/shape.rs`). 같은 값을 다시 넣으면 원래 상태다.
+ *
+ * **그림·OLE 는 아니다.** `rotationAngle` 이 섞이면 `refresh_picture_rotation_layout_for_save`
+ * 가 각도와 무관하게 — 0 으로 되돌리는 경우까지 — `rotate_image = true` 와
+ * `flip |= 0x0008_0000` 을 세운다(`object_ops/picture.rs:242-243`). 이 둘을 다시 내리는 경로는
+ * 저장소에 없어서, 90° 돌렸다 되돌린 그림은 화면은 같아도 저장 바이트가 원본과 달라진다
+ * (HWPX `hp:rotationInfo rotateimage`·HWP5 `HWPTAG_SHAPE_COMPONENT` 의 flip 비트).
+ * 대칭도 `TRANSFORM_KEYS`(picture.rs:176-184)에 걸려 `raw_rendering`·`render_*` 캐시를
+ * 기본값으로 리셋한다.
+ *
+ * 속성 bag 만으로는 이것들을 복원할 수 없다. 문서를 통째로 되돌리는 스냅샷이라야 정확하므로
+ * 그림·OLE 는 종전 경로를 유지한다 — 되돌리기의 정확성이 스냅샷 비용보다 앞선다.
+ */
+function absolutePropChangeIsInvertible(ref: PictureRef): boolean {
+  return ref.type === 'shape';
+}
+
+/** 역연산이 참이면 커맨드로, 아니면 종전 스냅샷으로 기록한다. */
+function applyAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  operationType: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  if (absolutePropChangeIsInvertible(ref)) {
+    executeAbsolutePropChange(ih, ref, before, after);
+    return;
+  }
+  recordObjectMutation(ih, operationType, (wasm) => {
+    setObjectProps(wasm, ref, after);
+  });
+}
+
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
@@ -726,9 +765,11 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
-  // 절대값이라 되돌리기가 자명하다.
-  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  // [Task #3230] 도형은 역연산, 그림·OLE 는 스냅샷 유지(`absolutePropChangeIsInvertible`).
+  // `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가 절대값이라 되돌리기가 자명하다.
+  applyAbsolutePropChange(
+    services, ih, ref, 'rotateObject', { rotationAngle: cur }, { rotationAngle: next },
+  );
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -741,5 +782,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
+  applyAbsolutePropChange(services, ih, ref, 'flipObject', { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -454,7 +454,10 @@ export const insertCommands: CommandDef[] = [
           captionIncludeMargin: false,
         };
         let result: any;
-        result = setProps(services, ref, captionProps);
+        // [Task #3230] `setProps` 래퍼가 사라져 공유 라우팅을 직접 부른다. 이 경로는 종전부터
+        // 라우터를 거치지 않고 직접 적용하고 `document-changed` 를 스스로 emit 한다 —
+        // 회전/대칭과 달리 이번 변경 대상이 아니라 종전 동작 그대로 둔다.
+        result = setObjectProps(services.wasm, ref, captionProps);
         // "그림 N " 끝 위치를 Rust가 반환
         charOffset = result?.captionCharOffset ?? 4;
         services.eventBus.emit('document-changed');

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -685,31 +685,26 @@ function changeZOrder(
   ih.exitPictureObjectSelectionAndAfterEdit();
 }
 
-function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  return setObjectProps(services.wasm, ref, props);
-}
-
 /**
- * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ * [Task #3230] 절대 속성 하나를 **역연산 커맨드로** 적용하고 기록한다.
  *
- * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * 스냅샷(`recordObjectMutation`) 대신 `kind:'command'`를 쓴다 — 되돌릴 것이 스칼라 하나인데
  * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
- * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다. setter를 라우터 전에 직접 호출하지 않아야
+ * 양식 모드의 편집 허용 검사가 실제 변경보다 먼저 실행된다.
  *
- * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
- * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
- * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ * refresh 를 'full' 로 명시한다 — command 라우팅의 자동 판정에 맡기면 개체 회전/대칭의 화면 반영이
+ * 보장되지 않는다. 종전 스냅샷 라우팅의 'full' 이 `afterEdit()` → `document-changed` 를 대신
+ * emit 해 주고 있었다(그래서 호출부의 수동 emit 이 [undo P3 정리] 에서 제거됐다).
  */
-function recordAbsolutePropChange(
-  services: import('../types').CommandServices,
+function executeAbsolutePropChange(
   ih: InputHandler,
   ref: PictureRef,
   before: Record<string, unknown>,
   after: Record<string, unknown>,
 ): void {
-  setProps(services, ref, after);
   ih.executeOperation({
-    kind: 'record',
+    kind: 'command',
     command: new SetObjectPropsCommand(ref, before, after),
     meta: { refresh: 'full' },
   });
@@ -730,7 +725,7 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   if (next > 180) next -= 360;
   // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
   // 절대값이라 되돌리기가 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -743,5 +738,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
+  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1981,6 +1981,26 @@ export class SetObjectPropsCommand implements EditCommand {
   }
 
   /**
+   * 적용해도 달라질 것이 없으면 무변경이다 (#2370 규약).
+   *
+   * 히스토리는 커맨드에게 이 질문을 하고(`history.ts` 의 `command.isNoOp?.()`), 답하지 않으면
+   * "항상 바꾼다" 로 읽는다. before 와 after 가 같은데 침묵하면 그 자체가 거짓 응답이고,
+   * 팬텀 엔트리가 Ctrl+Z 한 번을 무효과로 소모하며 redo 스택까지 파기한다.
+   *
+   * 지금 호출부(±90° 회전·`!cur` 토글)는 항상 before ≠ after 라 이 분기를 타지 않는다. 그래도
+   * 답은 커맨드가 해야 한다 — before/after 를 아는 것은 이 객체뿐이고, 호출부마다 같은 비교를
+   * 되풀이하는 것은 판정을 소비자로 흘리는 일이다.
+   *
+   * `after` 의 키만 본다. `execute` 가 적용하는 것이 그것뿐이므로 `before` 에만 있는 키는
+   * 이 연산의 결과를 바꾸지 않는다.
+   */
+  isNoOp(): boolean {
+    const keys = Object.keys(this.after);
+    if (keys.length === 0) return true;
+    return keys.every((key) => Object.is(this.before[key], this.after[key]));
+  }
+
+  /**
    * 병합하지 않는다. 회전 15° 를 네 번 누른 것과 60° 를 한 번 누른 것은 한컴에서도 undo
    * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
    */

--- a/rhwp-studio/src/engine/object-props.ts
+++ b/rhwp-studio/src/engine/object-props.ts
@@ -1,11 +1,14 @@
 /**
  * 선택 개체의 속성 조회·변경 라우팅 (Task #3230).
  *
- * 개체는 어디에 있느냐에 따라 setter/getter 가 넷으로 갈린다 — 본문 도형, 본문 그림, 셀 안
+ * 개체는 어디에 있느냐에 따라 setter/getter 가 갈린다 — 본문 도형, 본문 그림, 셀 안
  * (`cellPath`), 머리말/꼬리말(`headerFooter`, [Task #831]). 이 분기는 지금까지
  * `command/commands/insert.ts` 안에만 있었는데, **역연산 커맨드도 undo 시점에 같은 분기가
  * 필요하다.** 커맨드는 `services` 가 아니라 `WasmBridge` 만 받으므로 여기서 `wasm` 기준으로
  * 두고 양쪽이 함께 쓴다.
+ *
+ * 원본의 분기 구조를 조건·인자 순서까지 그대로 옮겼다. 그래서 원본이 갖고 있던 비대칭
+ * (도형 분기가 `headerFooter` 를 보지 않는 것)도 그대로다 — `getObjectProps` 주석 참고.
  *
  * 분기가 갈라지면 적용과 되돌리기가 서로 다른 개체를 만지게 된다 — HF 그림이 그 예다
  * (본문 lookup 으로 떨어지면 조용히 아무것도 안 바뀐다).
@@ -24,7 +27,17 @@ export type ObjectPropsRef = {
   headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
 };
 
-/** 선택 개체의 현재 속성. */
+/**
+ * 선택 개체의 현재 속성.
+ *
+ * **분기가 대칭이 아니다** — `type === 'shape'` 는 `cellPath` 만 보고 `headerFooter` 는 보지
+ * 않는다(그림 분기는 본다). 머리말/꼬리말 안의 도형은 본문 lookup 으로 떨어질 수 있다.
+ * 이 비대칭은 `command/commands/insert.ts` 에 있던 원본 그대로이며(옮기면서 조건·인자 순서를
+ * 바꾸지 않았다) 이 모듈이 만든 것이 아니다. 고치려면 HF 안에 도형이 실제로 놓이는지와
+ * `getSelectedPictureRef` 가 도형에 `headerFooter` 를 채우는 경로가 있는지부터 확인해야 해서
+ * 별건으로 둔다. `setObjectProps` 도 같은 비대칭을 그대로 갖는다 — 조회와 적용이 갈리면
+ * 되돌리기가 다른 개체를 만지므로 **둘은 반드시 같은 모양이어야 한다.**
+ */
 export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<string, unknown> {
   if (ref.type === 'shape') {
     if (ref.cellPath && ref.cellPath.length > 0) {
@@ -49,7 +62,12 @@ export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<st
   return wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
 }
 
-/** 선택 개체에 속성을 적용한다. `getObjectProps` 와 같은 분기를 쓴다. */
+/**
+ * 선택 개체에 속성을 적용한다.
+ *
+ * `getObjectProps` 와 **같은 분기**를 쓴다(HF 비대칭까지 포함해서). 조회 경로와 적용 경로가
+ * 갈리면 before 를 읽은 개체와 되돌리는 개체가 달라진다.
+ */
 export function setObjectProps(
   wasm: WasmBridge,
   ref: ObjectPropsRef,

--- a/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
+++ b/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
 
@@ -88,6 +90,46 @@ test('[#3230] 스냅샷 예산을 쓰지 않는다', () => {
     '역연산 커맨드가 예산을 쓰면 스냅샷에서 옮긴 의미가 없다',
   );
   assert.equal(cmd.discard, undefined, '해제할 WASM 스냅샷 id 가 없어야 한다');
+});
+
+test('[#3230] 달라질 것이 없으면 무변경으로 답한다', () => {
+  // 히스토리는 `command.isNoOp?.()` 로 묻고, 답이 없으면 "항상 바꾼다" 로 읽는다(#2370).
+  // 같은 값을 넣는 커맨드가 침묵하면 Ctrl+Z 한 번을 무효과로 소모하는 팬텀 엔트리가 남는다.
+  const same = new SetObjectPropsCommand(bodyImage, { rotationAngle: 90 }, { rotationAngle: 90 });
+  assert.equal(same.isNoOp(), true);
+
+  const changed = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 90 });
+  assert.equal(changed.isNoOp(), false);
+
+  const flipSame = new SetObjectPropsCommand(bodyImage, { horzFlip: true }, { horzFlip: true });
+  assert.equal(flipSame.isNoOp(), true);
+
+  // `before` 에만 있는 키는 `execute` 가 적용하지 않으므로 판정에 넣지 않는다.
+  const extraBefore = new SetObjectPropsCommand(
+    bodyImage, { rotationAngle: 90, vertFlip: false }, { rotationAngle: 90 },
+  );
+  assert.equal(extraBefore.isNoOp(), true);
+
+  // 적용할 것이 아예 없는 커맨드도 무변경이다.
+  assert.equal(new SetObjectPropsCommand(bodyImage, {}, {}).isNoOp(), true);
+});
+
+test('[#3230] 양식 모드에서 setObjectProps 는 허용 목록에 없다', () => {
+  // `4c668b93` 이 kind:'record' → kind:'command' 로 옮긴 이유가 이것이다 — command 라우팅은
+  // `isOperationAllowedInEditMode` 를 거치고, 그 switch 의 default 가 막는다. 허용 목록에
+  // 'setObjectProps' 가 추가되면 양식 모드에서 개체 회전/대칭이 다시 통과한다.
+  const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+  const start = src.indexOf('private isOperationAllowedInEditMode');
+  assert.notEqual(start, -1, 'isOperationAllowedInEditMode 가 있어야 함');
+  const body = src.slice(start, src.indexOf('\n  }', start));
+
+  assert.doesNotMatch(
+    body,
+    /case\s*'setObjectProps'/,
+    "'setObjectProps' 를 허용하면 양식 모드 개체 편집 차단이 뚫린다",
+  );
+  assert.match(body, /default:\s*\n?\s*return false;/, 'command 는 기본적으로 막혀야 함');
 });
 
 test('[#3230] 회전 15° 를 네 번 눌러도 병합하지 않는다', () => {

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,19 +77,36 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /applyAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /applyAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
+});
+
+// [Task #3230 후속] 역연산은 **왕복이 참인 대상에만** 쓴다. 그림·OLE 는
+// `refresh_picture_rotation_layout_for_save` 가 각도와 무관하게 `rotate_image`·flip 0x80000 을
+// 세우고 되돌리는 경로가 없어(object_ops/picture.rs:242-243) 속성 bag 으로 복원되지 않는다.
+test('그림·OLE 는 스냅샷을 유지한다 — 속성 왕복이 참인 역연산이 아니다', () => {
+  const gate = functionBodyFrom(insertSrc, 'function absolutePropChangeIsInvertible');
+  assert.match(
+    gate,
+    /ref\.type === 'shape'/,
+    "역연산 대상은 도형뿐 — 그림·OLE 로 넓히면 rotate_image 가 되돌아가지 않는다",
+  );
+
+  const apply = functionBodyFrom(insertSrc, 'function applyAbsolutePropChange');
+  assert.match(apply, /absolutePropChangeIsInvertible\(ref\)/, '대상 판정을 거쳐야 한다');
+  assert.match(apply, /executeAbsolutePropChange\(/, '참이면 역연산 커맨드');
+  assert.match(apply, /recordObjectMutation\(/, '아니면 종전 스냅샷');
 });
 
 test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,14 +77,14 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
     /\bsetProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
     /\bsetProps\s*\(/,
@@ -92,13 +92,14 @@ test('회전/대칭은 역연산으로 기록한다', () => {
   );
 });
 
-test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
-  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
-  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function executeAbsolutePropChange');
+  assert.match(block, /kind:\s*'command'/, '속성 적용도 편집 허용 검사를 거치는 command 라우터에서 실행');
   assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
   assert.match(
     block,
     /refresh:\s*'full'/,
-    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+    '개체 회전/대칭 뒤 전체 화면 갱신을 유지한다',
   );
+  assert.doesNotMatch(block, /\bsetProps\s*\(/, 'setter를 라우터 전에 호출하면 양식 모드 편집 차단을 우회한다');
 });


### PR DESCRIPTION
관련 이슈: #3230

## 문제

통합 PR #5607 이 #5570 의 **원본 커밋만** 체리픽하면서 뒤에 붙은 보정 넷이 빠졌고, 그 결과 devel
에 결함 두 개가 들어갔습니다. 이 PR 은 빠진 넷을 그대로 다시 얹습니다.

빠진 커밋 중 하나는 **메인테이너께서 직접 올리신 `4c668b93`** 이라, 저자 정보가 남도록 `-x`
체리픽으로 가져왔습니다(squash 하지 않았습니다).

### 1. 양식 모드 개체 편집 차단 우회

devel `rhwp-studio/src/command/commands/insert.ts:703` 이 지금 이 모양입니다.

```ts
function recordAbsolutePropChange(services, ih, ref, before, after): void {
  setProps(services, ref, after);          // ← 라우터보다 먼저 적용
  ih.executeOperation({ kind: 'record', command: new SetObjectPropsCommand(...), ... });
}
```

`isOperationAllowedInEditMode` 는 `desc.kind === 'record'` 를 **항상 허용**합니다
(`input-handler.ts:3890`) — 이미 적용된 뮤테이션을 드롭하면 undo 불가한 미기록 편집으로 남기
때문입니다. 그래서 setter 를 라우터 앞에서 부르면 양식 모드에서 차단돼야 할 개체 회전·대칭이
그대로 문서를 바꿉니다.

`4c668b93` 이 `kind:'command'` 로 옮겨(라우터가 커맨드를 실행 → 편집 허용 검사가 실제 변경보다
먼저) 닫았던 구멍입니다.

### 2. 그림 회전 왕복이 저장 바이트를 바꿈

devel 에는 대상 판정이 없어 **그림·OLE 도 역연산 경로**를 탑니다. 그런데 그림은 속성 왕복이 참인
역연산이 아닙니다.

```rust
// document_core/commands/object_ops/picture.rs:1058-1060
if rotation_changed { Self::refresh_picture_rotation_layout_for_save(pic); }

// picture.rs:242-243 — 각도와 무관하게, 0 으로 되돌릴 때까지 포함해서
pic.shape_attr.rotate_image = true;
pic.shape_attr.flip |= 0x0008_0000;
```

`rotate_image` 를 다시 `false` 로 내리는 경로는 저장소에 없습니다(`Default` 와 HWPX 파서만 값을
씁니다). `common.width/height/offset` 은 각도 기반 재계산이라 왕복으로 복원되지만 이 둘은 단조
증가만 합니다. 그리고 둘 다 파일로 나갑니다 — `serializer/hwpx/picture.rs:181` 의
`hp:rotationInfo rotateimage`, `serializer/control.rs:2486` 의 HWP5 `HWPTAG_SHAPE_COMPONENT` flip.

**재현**: 그림 90° 회전 → Ctrl+Z → 저장. 화면은 원본과 같은데 저장 바이트가 다릅니다(원본에 없던
`rotateimage=1` 과 0x80000 비트가 남음). 스냅샷 경로일 때는 `Document` 를 통째로 되돌려 이 문제가
없었습니다.

대칭도 인접 문제가 있습니다 — `horzFlip`/`vertFlip` 은 `TRANSFORM_KEYS`(picture.rs:176-184)에 걸려
`raw_rendering` 과 `render_tx/ty/sx/sy/b/c` 를 기본값으로 리셋합니다(picture.rs:1008-1016). 속성
bag 에 그 값이 없어 undo 로 복원되지 않습니다(저장 결과까지 바꾸는지는 미확인).

## 원인

`kind:'record'` 는 "호출부가 이미 적용했다" 는 계약이라 **라우터의 게이트를 건너뜁니다.** 원본
커밋이 그 계약을 쓰면서 setter 를 호출부에서 직접 불렀고, 그것이 1번입니다.

2번은 "절대 setter 이므로 같은 값을 다시 넣으면 원래 상태" 라는 전제가 **그림에는 성립하지
않는다**는 것입니다. 도형은 성립합니다 — `object_ops/shape.rs:434-452` 는 `rotationAngle` 을
평범한 필드 대입으로 넣고 flip 비트를 `|= 1` / `&= !1` 로 대칭 처리하며, 뒤따르는 레이아웃
refresh 도 부수 플래그도 없습니다.

## 변경

빠진 커밋 넷을 devel 위에 그대로 얹습니다.

| 커밋 | 저자 | 내용 |
|---|---|---|
| `4c668b93` | jangster77 | `kind:'record'` → `kind:'command'`, `setProps` 선행 호출 제거 |
| `302f8609` | | 캡션 경로 `setObjectProps` 호출 복구 |
| `c6a4966f` | | 역연산 대상을 도형으로 좁힘 |
| `56ee07df` | | `isNoOp` 구현 · 양식 모드 가드 · 계약 문서 정정 |

**`302f8609` 는 `4c668b93` 과 짝입니다.** `4c668b93` 이 `setProps` 래퍼를 없애는데
`insert:caption-toggle`(insert.ts:457)에 호출부가 하나 더 남아 있어, 전자만 얹으면 `tsc` 가
`TS2552: Cannot find name 'setProps'` 로 빌드에 실패합니다. 래퍼를 되살리지 않고 공유 라우팅
(`setObjectProps`)을 직접 부르는 쪽으로 고쳤습니다 — 래퍼를 두면 `4c668b93` 이 없애려던 "라우터
앞에서 setter 를 부르는 통로" 가 그대로 돌아옵니다.

`c6a4966f` 는 `absolutePropChangeIsInvertible(ref)` 를 두어 **도형에만** 역연산을 쓰고 그림·OLE 는
종전 스냅샷(`recordObjectMutation`)을 유지합니다. 되돌리기의 정확성이 스냅샷 비용보다 앞섭니다.

`56ee07df` 는 리뷰 대응입니다 — `SetObjectPropsCommand.isNoOp()` 를 구현하고(히스토리가
`command.isNoOp?.()` 로 묻는데 답하지 않으면 "항상 바꾼다" 로 읽혀 #2370 이 끊어 둔 팬텀 엔트리가
돌아옵니다), 양식 모드 허용 목록에 `'setObjectProps'` 가 없는지 가드로 고정하고,
`object-props.ts` 가 덮고 있던 분기 비대칭(도형 분기는 `headerFooter` 를 보지 않음)을 명시했습니다.

## 검증

devel `681703f4edffc111a8701a2723f8fbd07d2f1589` 기준.

- **수정 전 실패 증명**: 이 PR 의 테스트를 devel 소스에 그대로 걸면 **15개 중 4개 실패**.
  - `달라질 것이 없으면 무변경으로 답한다` (isNoOp 부재)
  - `회전/대칭은 역연산으로 기록한다`
  - `그림·OLE 는 스냅샷을 유지한다 — 속성 왕복이 참인 역연산이 아니다`
  - `executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다` ← **1번 결함을 고정하는 가드**
  이 브랜치에서는 15개 전부 통과.
- `npm --prefix rhwp-studio run test` — **1000 tests, 0 fail** (skipped 1 은 기존 테스트).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

## 범위 외

- **`refresh_picture_rotation_layout_for_save` 가 0° 에서도 `rotate_image` 를 세우는 것** —
  회전을 푼 그림이 "회전됨" 으로 저장되는 셈이라 그 자체로 의심스럽지만, 한컴 호환을 위해
  의도된 플래그일 수 있어 오라클 확인이 먼저입니다. 그것이 정리되면 그림도 역연산으로 옮길 수
  있습니다.
- **`insert:caption-toggle` 미라우팅** — devel 이전부터 라우터를 거치지 않고 직접 적용한 뒤
  `document-changed` 를 스스로 emit 합니다. 히스토리에도 양식 모드 게이트에도 걸리지 않습니다.
  이번 빌드 실패가 정확히 그 사각지대에서 났습니다. 별건으로 나누는 편이 맞다고 봅니다.
- **도형 분기의 `headerFooter` 미검사** — 원본 `insert.ts` 부터 있던 비대칭이라 이 PR 이 만든
  것이 아닙니다. 고치려면 HF 안에 도형이 실제로 놓이는지, `getSelectedPictureRef` 가 도형에
  `headerFooter` 를 채우는 경로가 있는지부터 확인해야 합니다.
