### PR TITLE
fix(serializer/hwp5): 개체 공통 attr 의 의미 비트를 IR 에서 병합해 배치 수정 유실을 막는다 (#5592)

### DIFF
--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2158,18 +2158,40 @@ fn serialize_text_box_if_present(drawing: &DrawingObjAttr, level: u16, records: 
 // ============================================================
 
 /// CommonObjAttr 직렬화
+/// [#5592] `pack_common_attr_bits` 가 의미 필드에서 재구성하는 비트 전체.
+///
+/// 이 마스크 안은 IR enum/bool 필드가 정본이고, 밖(예: bit 1·27·31, 캡션 bit 29 —
+/// 방출 직전 `apply_caption_attr_bit` 가 강제, 잠금 bit 30 — pack 미방출이라 raw 보존)
+/// 은 파스 시점 raw 를 보존한다.
+const COMMON_ATTR_SEMANTIC_MASK: u32 = 0x01            // treat_as_char
+    | (1 << 2)                                          // affect_line_spacing
+    | (0x03 << 3)                                       // vert_rel_to
+    | (0x07 << 5)                                       // vert_align
+    | (0x03 << 8)                                       // horz_rel_to
+    | (0x07 << 10)                                      // horz_align
+    | (1 << 13)                                         // flow_with_text
+    | (1 << 14)                                         // allow_overlap
+    | (0x07 << 15)                                      // width_criterion
+    | (0x03 << 18)                                      // height_criterion
+    | (1 << 20)                                         // size_protect
+    | (0x07 << 21)                                      // text_wrap
+    | (0x03 << 24)                                      // text_flow
+    | (1 << 26)                                         // hwp5_gen_shape_attr_bit26
+    | (1 << 28); // hwp5_gen_shape_attr_bit28
+
 fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
     let mut w = ByteWriter::new();
+    // [#5592] raw attr 를 통째로 우선하면 IR enum 필드(text_wrap·vert_rel_to·
+    // treat_as_char 등)의 수정이 HWP5 저장에서 전량 유실된다 — #4495 봉인이
+    // "common 직접 수정 → IR 합성" 을 약속해도, 합성기가 파스 시점 캐시(attr)를
+    // 다시 우선해 약속이 깨졌다(종전엔 sync_anchor_bits/sync_text_wrap_bits 를
+    // 부른 편집 커맨드만 살아남았다). HWPX 직렬화기와 같은 원칙으로 통일한다:
+    // **알려진 의미 비트는 IR 이 정본, 미지 비트만 raw 를 보존한다.** 파서가
+    // 같은 비트를 그대로 해독하므로 무수정 문서는 병합 결과가 raw 와 동일하다
+    // (범위 밖 원시값 — 예: text_wrap 4~7 — 만 파서 폴백값으로 정규화된다).
     let attr = if common.attr != 0 {
-        // HWPX parser can materialize this compatibility bit semantically while
-        // retaining a non-zero raw attr captured before that materialization.
-        // Keep raw-first serialization, but do not drop an asserted bit 28.
-        common.attr
-            | if common.hwp5_gen_shape_attr_bit28 {
-                1 << 28
-            } else {
-                0
-            }
+        (common.attr & !COMMON_ATTR_SEMANTIC_MASK)
+            | (pack_common_attr_bits(common) & COMMON_ATTR_SEMANTIC_MASK)
     } else {
         pack_common_attr_bits(common)
     };

--- a/tests/cases/issue_5592_hwp5_common_attr_save.rs
+++ b/tests/cases/issue_5592_hwp5_common_attr_save.rs
@@ -1,0 +1,95 @@
+//! [#5592] IR 에서 수정한 개체 공통 배치 속성의 HWP5 저장 보존 계약.
+//!
+//! CTRL_HEADER attr 는 파스 시점 raw(u32)가 `common.attr` 에 캐시되는데, 종전
+//! 직렬화기는 attr != 0 이면 그 캐시를 통째로 우선해 IR enum 필드(text_wrap·
+//! vert_rel_to·treat_as_char 등)의 수정이 HWP5 저장에서 전량 유실됐다(HWPX
+//! 저장은 보존 — #5592 비대칭). #4495 봉인이 "직접 수정 → IR 합성" 을 약속해도
+//! 합성기가 캐시를 다시 우선해 약속이 깨졌다. 수정 후 계약: 알려진 의미 비트는
+//! IR 이 정본, 미지 비트만 raw 보존.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+
+use rhwp::model::control::Control;
+use rhwp::model::shape::{TextWrap, VertRelTo};
+use rhwp::wasm_api::HwpDocument;
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn load_sample() -> HwpDocument {
+    let bytes = std::fs::read(repo_path("samples/hwp_table_test-m.hwp")).expect("샘플 읽기");
+    HwpDocument::from_bytes(&bytes).expect("샘플 파싱")
+}
+
+fn first_table_common(doc: &HwpDocument) -> &rhwp::model::shape::CommonObjAttr {
+    doc.document()
+        .sections
+        .iter()
+        .flat_map(|s| s.paragraphs.iter())
+        .find_map(|p| {
+            p.controls.iter().find_map(|c| match c {
+                Control::Table(t) => Some(&t.common),
+                _ => None,
+            })
+        })
+        .expect("표")
+}
+
+#[test]
+fn mutated_placement_attrs_survive_hwp5_roundtrip() {
+    let mut doc = load_sample();
+    {
+        let para = doc
+            .document_mut()
+            .sections
+            .iter_mut()
+            .flat_map(|s| s.paragraphs.iter_mut())
+            .find(|p| p.controls.iter().any(|c| matches!(c, Control::Table(_))))
+            .expect("표 문단");
+        let table = para
+            .controls
+            .iter_mut()
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표");
+        table.common.treat_as_char = false;
+        table.common.text_wrap = TextWrap::Square;
+        table.common.vert_rel_to = VertRelTo::Para;
+        table.common.vertical_offset = 1904;
+    }
+
+    let bytes = doc.export_hwp().expect("HWP5 저장");
+    let rt = HwpDocument::from_bytes(&bytes).expect("재파싱");
+    let common = first_table_common(&rt);
+    assert!(
+        !common.treat_as_char
+            && matches!(common.text_wrap, TextWrap::Square)
+            && matches!(common.vert_rel_to, VertRelTo::Para)
+            && common.vertical_offset == 1904,
+        "HWP5 저장이 IR 배치 수정을 유실했다: tac={} wrap={:?} vrel={:?} voff={}",
+        common.treat_as_char,
+        common.text_wrap,
+        common.vert_rel_to,
+        common.vertical_offset
+    );
+}
+
+#[test]
+fn unmodified_roundtrip_keeps_original_placement_attrs() {
+    // 무수정 왕복 — 병합이 원본 의미를 바꾸지 않는다(raw ↔ pack 항등 확인).
+    let mut doc = load_sample();
+    let before = first_table_common(&doc).clone();
+    let _ = &mut doc;
+    let bytes = doc.export_hwp().expect("HWP5 저장");
+    let rt = HwpDocument::from_bytes(&bytes).expect("재파싱");
+    let after = first_table_common(&rt);
+    assert_eq!(before.attr, after.attr, "무수정 attr 이 변형됐다");
+    assert_eq!(before.treat_as_char, after.treat_as_char);
+    assert_eq!(before.text_wrap, after.text_wrap);
+    assert_eq!(before.vert_rel_to, after.vert_rel_to);
+    assert_eq!(before.vertical_offset, after.vertical_offset);
+}


### PR DESCRIPTION
# fix(serializer/hwp5): 개체 공통 attr 의 의미 비트를 IR 에서 병합해 배치 수정 유실을 막는다 (#5592)

## 근인

CTRL_HEADER 의 개체 공통 속성 attr(u32)는 파스 시점 raw 가 `common.attr` 에 캐시된다. HWP5 직렬화기(`serialize_common_obj_attr`)는 `attr != 0` 이면 **캐시를 통째로 우선**해, IR enum 필드(`text_wrap`·`vert_rel_to`·`treat_as_char` 등)의 수정이 HWP5 저장에서 전량 유실됐다 — HWPX 저장은 같은 수정을 `hp:pos` 로 보존하는 비대칭(#5592 실측). #4495 의 raw 봉인이 "common 직접 수정 → raw 대신 IR 합성" 을 약속하지만, 그 합성기가 다시 캐시를 우선해 약속이 깨졌다. 종전에는 `sync_anchor_bits`/`sync_text_wrap_bits` 를 명시 호출한 편집 커맨드 경로만 살아남았다(#3781 계열의 반복 발병 구조).

## 수정

`pack_common_attr_bits` 가 다루는 의미 비트 전체를 `COMMON_ATTR_SEMANTIC_MASK` 로 정의하고, **알려진 의미 비트는 IR 을 정본으로 병합, 미지 비트만 raw 보존**:

```
attr = (raw & !MASK) | (pack_common_attr_bits(common) & MASK)
```

- 마스크 밖: bit 1·27·31(미지 — raw 보존), 캡션 bit 29(방출 직전 `apply_caption_attr_bit` 가 실캡션과 강제 일치), 잠금 bit 30(pack 미방출 — raw 보존)
- 파서(`parse_common_obj_attr`)가 같은 비트를 그대로 해독하므로 **무수정 문서는 병합 결과가 raw 와 동일**하다(범위 밖 원시값 — 예: text_wrap 4~7 — 만 파서 폴백값으로 정규화). 종전 bit 28 특례는 pack 경유로 흡수.

## 실측·게이트

- 계약 테스트 2건(신규): ① 변조(wrap=Square·vertRelTo=Para·vertOffset=1904·tac=false) HWP5 왕복 보존 — **음성 대조: 수정 제거 시 FAIL**, ② 무수정 왕복의 attr 항등(병합이 원본을 바꾸지 않음)
- 10k 코퍼스 무작위 300문서 `convert`(h2h) 산출 **바이트 해시 A/B: 296/296 전량 동일, 차이 0**(비교 불가 4건은 양측 공통) — raw↔pack 항등의 전수 실증
- rustfmt(변경 파일)·clippy `-D warnings`·wasm check·manifest 체크·nextest 전체: 결과는 아래 코멘트로 갱신
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(변경 파일 rustfmt 직접 검사로 대체)

이슈 #5592 (발견 경위: #5566 계약 테스트 픽스처 조사, #2055 계열 잔존 축)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
