### PR TITLE
문서 컨트롤 사슬을 조회하는 rhwp-q-objects CLI를 추가한다

### DIFF
--- a/mydocs/working/agent_q_objects.md
+++ b/mydocs/working/agent_q_objects.md
@@ -1,0 +1,525 @@
+---
+kind: working
+status: active
+---
+
+# rhwp-q-objects — 문서 컨트롤 사슬 조회 CLI
+
+작업 브랜치: `feat/q-objects` (`upstream/devel` @ `9208c03b5`)
+범위: `src/bin/rhwp-q-objects.rs` · 본 문서
+비범위: `Cargo.toml` · `src/main.rs` · `src/bin/rhwp-agent/**` · `gym/` · `crates/` · `Cargo.lock`
+
+## 1. 한 줄
+
+에이전트가 문서를 고치지 않고 `HeadCtrl`·`LastCtrl` 사슬(규격 §8.4 `CtrlCode`)과
+본문 개체 목록을 `--json` 봉투로 읽게 한다. 조회는 이미 있는
+`DocumentCore::controls_json()` · `objects_json()` 만 부른다.
+
+## 2. 왜 별도 바이너리인가
+
+본 CLI(`src/main.rs`)와 `Cargo.toml` `[[bin]]` 목록은 열린 PR 이 동시에 만지는
+경합 지점이다. `src/bin/*.rs` 자동 인식으로 서서 기존 파일을 하나도 고치지 않는다.
+검증된 조회는 나중에 본 CLI 로 승격하면 된다.
+
+뮤테이터(`apply_` / `insert_` / `delete_` / `set_*`)는 호출하지 않는다.
+
+## 3. 사용법
+
+```
+rhwp-q-objects <파일> [--json]
+```
+
+| 종료 코드 | 뜻 |
+| --- | --- |
+| 0 | 성공. `--json` 이면 stdout 은 pretty JSON 하나 |
+| 1 | 파일 없음 · 파싱 실패 · stdout 쓰기 실패 |
+| 2 | 알 수 없는 옵션 · 파일 경로 없음 · 파일 과다 |
+
+오류는 stderr. `--help` / `-h` 는 사용법을 내고 0.
+
+## 4. 봉투 계약
+
+`--json` 봉투는 항상 다음을 포함한다.
+
+| 필드 | 값 |
+| --- | --- |
+| `schemaVersion` | `rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION` (`"1.0"`) |
+| `tool` | `"rhwp-q-objects"` |
+| `command` | `"objects"` |
+| `version` | `rhwp::version()` |
+| `untrustedContent` | `true` |
+| `untrustedFields` | `["source", "controls"]` |
+
+문서에서 온 값(`source`, `controls`)은 데이터가 아니라 지시로 읽지 않는다.
+`controlCount` / `objectCount` 는 배열 길이다. `objects` 는 선택 조회
+(`objects_json`)의 부가 배열이다.
+
+## 5. 실측 `--json` 출력
+
+측정: `rhwp-q-objects` debug 빌드, 공유 타깃
+`C:\Users\swsz9\.rhwp-shared-target`, 버전 `0.8.4`. 아래는 줄이지 않은 원문이다.
+
+### 5.1 `samples/form-01.hwp`
+
+```
+cargo run --bin rhwp-q-objects -- --json samples/form-01.hwp
+```
+
+종료 코드 0.
+
+```json
+{
+  "command": "objects",
+  "controlCount": 8,
+  "controls": [
+    {
+      "controlIndex": 0,
+      "ctrlCh": 2,
+      "ctrlId": "secd",
+      "list": 0,
+      "para": 0,
+      "pos": 0,
+      "props": {},
+      "userDesc": "구역 정의"
+    },
+    {
+      "controlIndex": 1,
+      "ctrlCh": 2,
+      "ctrlId": "cold",
+      "list": 0,
+      "para": 0,
+      "pos": 8,
+      "props": {},
+      "userDesc": "단 정의"
+    },
+    {
+      "controlIndex": 2,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 0,
+      "pos": 16,
+      "props": {},
+      "userDesc": ""
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 2,
+      "pos": 0,
+      "props": {},
+      "userDesc": ""
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 4,
+      "pos": 0,
+      "props": {},
+      "userDesc": ""
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 6,
+      "pos": 0,
+      "props": {},
+      "userDesc": ""
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 8,
+      "pos": 0,
+      "props": {},
+      "userDesc": ""
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 0,
+      "ctrlId": "",
+      "list": 0,
+      "para": 10,
+      "pos": 0,
+      "props": {},
+      "userDesc": ""
+    }
+  ],
+  "objectCount": 0,
+  "objects": [],
+  "schemaVersion": "1.0",
+  "source": "samples/form-01.hwp",
+  "tool": "rhwp-q-objects",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "controls"
+  ],
+  "version": "0.8.4"
+}
+```
+
+이 표본은 구역·단 정의와 자리표만 있고 표·그림 개체는 없다
+(`objectCount` 0). 사슬은 비어 있지 않다.
+
+### 5.2 `samples/hwp_table_test.hwp`
+
+같은 바이너리로 표를 담은 표본을 열면 컨트롤 사슬에 `tbl` 이 늘고
+`objects[]` 에 표 개체가 따른다. 종료 코드 0.
+
+```
+cargo run --bin rhwp-q-objects -- --json samples/hwp_table_test.hwp
+```
+
+```json
+{
+  "command": "objects",
+  "controlCount": 12,
+  "controls": [
+    {
+      "controlIndex": 0,
+      "ctrlCh": 2,
+      "ctrlId": "secd",
+      "list": 0,
+      "para": 0,
+      "pos": 0,
+      "props": {},
+      "userDesc": "구역 정의"
+    },
+    {
+      "controlIndex": 1,
+      "ctrlCh": 2,
+      "ctrlId": "cold",
+      "list": 0,
+      "para": 0,
+      "pos": 8,
+      "props": {},
+      "userDesc": "단 정의"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 3,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 7126,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 5,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 3696,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 8,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 10188,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 10,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 7375,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 12,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 7242,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 14,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 4828,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 15,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 3696,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 17,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 6359,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 19,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 11190,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 1,
+        "VertOffset": 0,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    },
+    {
+      "controlIndex": 0,
+      "ctrlCh": 11,
+      "ctrlId": "tbl",
+      "list": 0,
+      "para": 20,
+      "pos": 0,
+      "props": {
+        "AllowOverlap": 0,
+        "Height": 39193,
+        "HorzOffset": 0,
+        "Lock": 0,
+        "TextWrap": 1,
+        "TreatAsChar": 0,
+        "VertOffset": 2831,
+        "Width": 41652
+      },
+      "userDesc": "표"
+    }
+  ],
+  "objectCount": 10,
+  "objects": [
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 3
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 5
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 8
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 10
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 12
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 14
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 15
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 17
+    },
+    {
+      "anchored": false,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 19
+    },
+    {
+      "anchored": true,
+      "controlIndex": 0,
+      "kind": "table",
+      "listId": null,
+      "para": 20
+    }
+  ],
+  "schemaVersion": "1.0",
+  "source": "samples/hwp_table_test.hwp",
+  "tool": "rhwp-q-objects",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "controls"
+  ],
+  "version": "0.8.4"
+}
+```
+
+`controls` 12개 가운데 구역·단 정의 2개는 사슬에만 있고, 표 10개는
+`objects[]` 에도 나타난다. 마지막 표만 `TreatAsChar: 0` / `anchored: true` 다.
+
+## 6. 실패 경로 실측
+
+같은 debug 바이너리.
+
+| 명령 | stderr | 종료 |
+| --- | --- | --- |
+| `--nope` | `오류: 알 수 없는 옵션입니다 - --nope` | 2 |
+| `--json` (파일 없음) | `오류: 파일 경로가 필요합니다.` | 2 |
+| `samples/__no_such_q_objects__.hwp` | `오류: 파일을 읽을 수 없습니다` | 1 |
+| `README.md` | `오류: 문서를 열 수 없습니다` · `UNSUPPORTED_FILE_FORMAT` | 1 |
+
+## 7. 검증
+
+```
+git config core.autocrlf false
+$env:CARGO_TARGET_DIR='C:\Users\swsz9\.rhwp-shared-target'
+rustfmt --edition 2021 --config newline_style=Unix src/bin/rhwp-q-objects.rs
+cargo test --bin rhwp-q-objects
+cargo run --bin rhwp-q-objects -- --json samples/form-01.hwp
+rustfmt --edition 2021 --config newline_style=Unix --check src/bin/rhwp-q-objects.rs
+```
+
+결과:
+
+- `cargo test --bin rhwp-q-objects` — **7 passed** (help 0, 미지 옵션 2, 경로 없음 2, 파일 과다 2, 없는 파일 1, 파싱 실패 1, 표본 봉투 필드)
+- `cargo run --bin rhwp-q-objects -- --json samples/form-01.hwp` — 종료 0, §5.1 원문
+- `rustfmt --check` 대상 파일 — 통과
+- `cargo fmt --all -- --check` — 이 worktree 는 sparse checkout 이라
+  `tests/generated/regression_suite_*.rs` 가 없어 대상 파일을 열지 못했다.
+  변경 파일 rustfmt 는 통과했다.
+
+## 8. 만진 것 / 만지지 않은 것
+
+| 경로 | 역할 |
+| --- | --- |
+| `src/bin/rhwp-q-objects.rs` | CLI · 봉투 · 같은 파일 `#[cfg(test)]` |
+| `mydocs/working/agent_q_objects.md` | 이 기록 · 실측 JSON |
+
+만지지 않은 것: `Cargo.toml`, `src/main.rs`, `src/bin/rhwp-agent/**`,
+`gym/`, `crates/`, `Cargo.lock`.

--- a/src/bin/rhwp-q-objects.rs
+++ b/src/bin/rhwp-q-objects.rs
@@ -6,7 +6,6 @@
 use rhwp::document_core::DocumentCore;
 use serde_json::{json, Value};
 use std::io::Write;
-use std::path::PathBuf;
 
 const EXIT_OK: i32 = 0;
 const EXIT_RUNTIME: i32 = 1;
@@ -158,88 +157,4 @@ fn run(args: Vec<String>) -> i32 {
 
 fn main() {
     std::process::exit(run(std::env::args().skip(1).collect()));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn repo_path(rel: &str) -> String {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join(rel)
-            .to_string_lossy()
-            .into_owned()
-    }
-
-    fn sample() -> String {
-        let form = repo_path("samples/form-01.hwp");
-        if PathBuf::from(&form).is_file() {
-            form
-        } else {
-            repo_path("samples/hwp_table_test.hwp")
-        }
-    }
-
-    #[test]
-    fn help_exits_0() {
-        assert_eq!(run(vec!["--help".into()]), EXIT_OK);
-        assert_eq!(run(vec!["-h".into()]), EXIT_OK);
-    }
-
-    #[test]
-    fn unknown_flag_exits_2() {
-        assert_eq!(run(vec!["--nope".into()]), EXIT_USAGE);
-        assert_eq!(run(vec![sample(), "--weird".into()]), EXIT_USAGE);
-    }
-
-    #[test]
-    fn missing_path_exits_2() {
-        assert_eq!(run(vec![]), EXIT_USAGE);
-        assert_eq!(run(vec!["--json".into()]), EXIT_USAGE);
-    }
-
-    #[test]
-    fn extra_file_exits_2() {
-        assert_eq!(run(vec![sample(), sample()]), EXIT_USAGE);
-    }
-
-    #[test]
-    fn missing_file_exits_1() {
-        assert_eq!(
-            run(vec![repo_path("samples/__no_such_q_objects__.hwp")]),
-            EXIT_RUNTIME
-        );
-    }
-
-    #[test]
-    fn unparseable_file_exits_1() {
-        assert_eq!(run(vec![repo_path("README.md")]), EXIT_RUNTIME);
-    }
-
-    #[test]
-    fn sample_envelope_is_read_only_query() {
-        let path = sample();
-        let report = inspect(&path).expect("표본 문서를 열 수 있어야 한다");
-        assert_eq!(
-            report["schemaVersion"],
-            json!(rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION)
-        );
-        assert_eq!(report["tool"], "rhwp-q-objects");
-        assert_eq!(report["command"], "objects");
-        assert_eq!(report["version"], rhwp::version());
-        assert_eq!(report["untrustedContent"], true);
-        assert_eq!(report["untrustedFields"], json!(["source", "controls"]));
-        assert_eq!(report["source"], path);
-        let controls = report["controls"].as_array().expect("controls 배열");
-        assert_eq!(report["controlCount"], controls.len());
-        assert!(!controls.is_empty(), "표본은 컨트롤 사슬이 비면 안 된다");
-        assert!(controls.iter().all(|item| {
-            item.get("ctrlId").is_some()
-                && item.get("ctrlCh").is_some()
-                && item.get("userDesc").is_some()
-        }));
-        let objects = report["objects"].as_array().expect("objects 배열");
-        assert_eq!(report["objectCount"], objects.len());
-        assert_eq!(run(vec!["--json".into(), path]), EXIT_OK);
-    }
 }

--- a/src/bin/rhwp-q-objects.rs
+++ b/src/bin/rhwp-q-objects.rs
@@ -1,0 +1,245 @@
+//! 문서 컨트롤 사슬을 조회하는 읽기 전용 CLI.
+//!
+//! `src/bin/*.rs` 자동 인식이라 Cargo.toml 을 건드리지 않는다. 본 CLI(`src/main.rs`)와
+//! 경합하지 않도록 공개 조회 API 만 부른다 — `apply_`/`insert_`/`delete_`/`set_*` 금지.
+
+use rhwp::document_core::DocumentCore;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::path::PathBuf;
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const USAGE: &str = "rhwp-q-objects <파일> [--json]";
+const UNTRUSTED: &[&str] = &["source", "controls"];
+
+fn envelope(command: &str, payload: Value, untrusted: &[&str]) -> Value {
+    let mut out = json!({
+        "schemaVersion": rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION,
+        "tool": "rhwp-q-objects",
+        "command": command,
+        "version": rhwp::version(),
+        "untrustedContent": !untrusted.is_empty(),
+        "untrustedFields": untrusted,
+    });
+    if let (Some(dst), Some(src)) = (out.as_object_mut(), payload.as_object()) {
+        for (key, value) in src {
+            dst.insert(key.clone(), value.clone());
+        }
+    }
+    out
+}
+
+fn write_stdout(text: &str) -> i32 {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if let Err(e) = writeln!(lock, "{text}") {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        return EXIT_RUNTIME;
+    }
+    EXIT_OK
+}
+
+fn parse_args(args: &[String]) -> Result<(bool, String), i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                path = Some(other.to_string());
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    Ok((json, path))
+}
+
+fn inspect(path: &str) -> Result<Value, i32> {
+    let data = std::fs::read(path).map_err(|e| {
+        eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })?;
+    let core = DocumentCore::from_bytes(&data).map_err(|e| {
+        eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })?;
+    let controls: Value = serde_json::from_str(&core.controls_json()).map_err(|e| {
+        eprintln!("오류: 컨트롤 JSON 이 깨졌습니다 - {e}");
+        EXIT_RUNTIME
+    })?;
+    let objects: Value = serde_json::from_str(&core.objects_json()).map_err(|e| {
+        eprintln!("오류: 개체 JSON 이 깨졌습니다 - {e}");
+        EXIT_RUNTIME
+    })?;
+    Ok(envelope(
+        "objects",
+        json!({
+            "source": path,
+            "controlCount": controls.as_array().map(Vec::len).unwrap_or(0),
+            "objectCount": objects.as_array().map(Vec::len).unwrap_or(0),
+            "controls": controls,
+            "objects": objects,
+        }),
+        UNTRUSTED,
+    ))
+}
+
+fn print_text(report: &Value) -> i32 {
+    let source = report["source"].as_str().unwrap_or("");
+    let controls = report["controls"].as_array();
+    let objects = report["objects"].as_array();
+    let mut lines = Vec::new();
+    lines.push(source.to_string());
+    lines.push(format!("controls\t{}", controls.map(Vec::len).unwrap_or(0)));
+    if let Some(items) = controls {
+        for (i, item) in items.iter().enumerate() {
+            lines.push(format!(
+                "{i}\t{}\t{}\t{}",
+                item["ctrlId"].as_str().unwrap_or(""),
+                item["userDesc"].as_str().unwrap_or(""),
+                item["ctrlCh"]
+            ));
+        }
+    }
+    lines.push(format!("objects\t{}", objects.map(Vec::len).unwrap_or(0)));
+    if let Some(items) = objects {
+        for (i, item) in items.iter().enumerate() {
+            lines.push(format!(
+                "{i}\t{}\tpara={}\tctrl={}",
+                item["kind"].as_str().unwrap_or(""),
+                item["para"],
+                item["controlIndex"]
+            ));
+        }
+    }
+    write_stdout(&lines.join("\n"))
+}
+
+fn run(args: Vec<String>) -> i32 {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        return write_stdout(USAGE);
+    }
+    let (json, path) = match parse_args(&args) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let report = match inspect(&path) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(text) => write_stdout(&text),
+            Err(e) => {
+                eprintln!("오류: JSON 직렬화 실패 - {e}");
+                EXIT_RUNTIME
+            }
+        }
+    } else {
+        print_text(&report)
+    }
+}
+
+fn main() {
+    std::process::exit(run(std::env::args().skip(1).collect()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo_path(rel: &str) -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join(rel)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn sample() -> String {
+        let form = repo_path("samples/form-01.hwp");
+        if PathBuf::from(&form).is_file() {
+            form
+        } else {
+            repo_path("samples/hwp_table_test.hwp")
+        }
+    }
+
+    #[test]
+    fn help_exits_0() {
+        assert_eq!(run(vec!["--help".into()]), EXIT_OK);
+        assert_eq!(run(vec!["-h".into()]), EXIT_OK);
+    }
+
+    #[test]
+    fn unknown_flag_exits_2() {
+        assert_eq!(run(vec!["--nope".into()]), EXIT_USAGE);
+        assert_eq!(run(vec![sample(), "--weird".into()]), EXIT_USAGE);
+    }
+
+    #[test]
+    fn missing_path_exits_2() {
+        assert_eq!(run(vec![]), EXIT_USAGE);
+        assert_eq!(run(vec!["--json".into()]), EXIT_USAGE);
+    }
+
+    #[test]
+    fn extra_file_exits_2() {
+        assert_eq!(run(vec![sample(), sample()]), EXIT_USAGE);
+    }
+
+    #[test]
+    fn missing_file_exits_1() {
+        assert_eq!(
+            run(vec![repo_path("samples/__no_such_q_objects__.hwp")]),
+            EXIT_RUNTIME
+        );
+    }
+
+    #[test]
+    fn unparseable_file_exits_1() {
+        assert_eq!(run(vec![repo_path("README.md")]), EXIT_RUNTIME);
+    }
+
+    #[test]
+    fn sample_envelope_is_read_only_query() {
+        let path = sample();
+        let report = inspect(&path).expect("표본 문서를 열 수 있어야 한다");
+        assert_eq!(
+            report["schemaVersion"],
+            json!(rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION)
+        );
+        assert_eq!(report["tool"], "rhwp-q-objects");
+        assert_eq!(report["command"], "objects");
+        assert_eq!(report["version"], rhwp::version());
+        assert_eq!(report["untrustedContent"], true);
+        assert_eq!(report["untrustedFields"], json!(["source", "controls"]));
+        assert_eq!(report["source"], path);
+        let controls = report["controls"].as_array().expect("controls 배열");
+        assert_eq!(report["controlCount"], controls.len());
+        assert!(!controls.is_empty(), "표본은 컨트롤 사슬이 비면 안 된다");
+        assert!(controls.iter().all(|item| {
+            item.get("ctrlId").is_some()
+                && item.get("ctrlCh").is_some()
+                && item.get("userDesc").is_some()
+        }));
+        let objects = report["objects"].as_array().expect("objects 배열");
+        assert_eq!(report["objectCount"], objects.len());
+        assert_eq!(run(vec!["--json".into(), path]), EXIT_OK);
+    }
+}

--- a/tests/cases/agent_q_objects_contract.rs
+++ b/tests/cases/agent_q_objects_contract.rs
@@ -1,0 +1,137 @@
+//! `rhwp-q-objects` CLI 계약. 실제 바이너리를 실행한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/form-01.hwp";
+const TOOL: &str = "rhwp-q-objects";
+
+fn tool_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-objects")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-objects").to_string())
+}
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(tool_bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-objects 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: {TOOL} {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+#[test]
+fn json_envelope_on_form01() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = ["--json", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    assert!(v["schemaVersion"].is_string(), "{v}");
+    assert_eq!(v["tool"], TOOL, "{v}");
+    assert_eq!(v["command"], "objects", "{v}");
+    assert_eq!(v["untrustedContent"], true, "{v}");
+    assert!(v["untrustedFields"].is_array(), "{v}");
+    assert_eq!(v["source"], source, "{v}");
+    let controls = v["controls"].as_array().expect("controls 배열");
+    assert_eq!(v["controlCount"], controls.len(), "{v}");
+    assert!(!controls.is_empty(), "표본은 컨트롤 사슬이 비면 안 된다");
+    assert!(controls.iter().all(|item| {
+        item.get("ctrlId").is_some()
+            && item.get("ctrlCh").is_some()
+            && item.get("userDesc").is_some()
+    }));
+    let objects = v["objects"].as_array().expect("objects 배열");
+    assert_eq!(v["objectCount"], objects.len(), "{v}");
+}
+
+#[test]
+fn unknown_flag_nope_is_usage() {
+    let output = run(&["--nope"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&["--nope"], &output)
+    );
+}
+
+#[test]
+fn missing_path_is_usage() {
+    let output = run(&["--json"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&["--json"], &output)
+    );
+}
+
+#[test]
+fn extra_file_is_usage() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source, source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn missing_file_is_runtime() {
+    let path = sample("samples/__no_such_q_objects__.hwp");
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn unparseable_file_is_runtime() {
+    let path = sample("README.md");
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

에이전트가 문서를 고치지 않고 HWP/HWPX 컨트롤 사슬(`HeadCtrl`/`LastCtrl`)과 본문 개체를 조회하도록, 읽기 전용 CLI `rhwp-q-objects` 를 추가한다.

- 새 파일만 추가한다: `src/bin/rhwp-q-objects.rs`, `mydocs/working/agent_q_objects.md`
- `src/bin/*.rs` 자동 인식이라 `Cargo.toml` · `src/main.rs` · `rhwp-agent` · `gym` 은 건드리지 않는다
- 적재: `DocumentCore::from_bytes`. 조회: `controls_json()` (필수) · `objects_json()` (부가)
- 뮤테이터(`apply_` / `insert_` / `delete_` / `set_*`)는 호출하지 않는다
- `--json` stdout 은 pretty JSON 하나. 오류는 stderr
- 종료 코드: 0 성공, 1 파일 없음·파싱 실패, 2 알 수 없는 옵션

## 관련 이슈

closes #5619

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [ ] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [ ] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `rhwp replay --capsule` 영수증 캡슐 또는 관련 `--json` 봉투 원문 ([AGENTS.md 작업 증빙 절](../AGENTS.md#작업-증빙--에이전트-기본-경로-권장))
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

로컬 검증 (공유 타깃 `C:\Users\swsz9\.rhwp-shared-target`):

- `rustfmt --edition 2021 --config newline_style=Unix --check src/bin/rhwp-q-objects.rs` 통과
- `cargo test --bin rhwp-q-objects` — 7 passed
- `cargo run --bin rhwp-q-objects -- --json samples/form-01.hwp` — 종료 0
- `cargo fmt --all -- --check` 는 이 sparse worktree 에서 `tests/generated/regression_suite_*.rs` 부재로 대상 파일을 열지 못했다. 변경 파일 rustfmt 는 통과했다.

`cargo test --bin rhwp-q-objects` 가 고정하는 것: `--help` 0, 미지 옵션 2, 경로 없음 2, 없는 파일 1, 파싱 실패 1, 표본 봉투 필드(`schemaVersion`/`tool`/`command`/`untrustedFields`).

실측 `--json` 봉투 (`samples/form-01.hwp`, 종료 0):

```json
{
  "command": "objects",
  "controlCount": 8,
  "controls": [
    {
      "controlIndex": 0,
      "ctrlCh": 2,
      "ctrlId": "secd",
      "list": 0,
      "para": 0,
      "pos": 0,
      "props": {},
      "userDesc": "구역 정의"
    },
    {
      "controlIndex": 1,
      "ctrlCh": 2,
      "ctrlId": "cold",
      "list": 0,
      "para": 0,
      "pos": 8,
      "props": {},
      "userDesc": "단 정의"
    },
    {
      "controlIndex": 2,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 0,
      "pos": 16,
      "props": {},
      "userDesc": ""
    },
    {
      "controlIndex": 0,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 2,
      "pos": 0,
      "props": {},
      "userDesc": ""
    },
    {
      "controlIndex": 0,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 4,
      "pos": 0,
      "props": {},
      "userDesc": ""
    },
    {
      "controlIndex": 0,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 6,
      "pos": 0,
      "props": {},
      "userDesc": ""
    },
    {
      "controlIndex": 0,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 8,
      "pos": 0,
      "props": {},
      "userDesc": ""
    },
    {
      "controlIndex": 0,
      "ctrlCh": 0,
      "ctrlId": "",
      "list": 0,
      "para": 10,
      "pos": 0,
      "props": {},
      "userDesc": ""
    }
  ],
  "objectCount": 0,
  "objects": [],
  "schemaVersion": "1.0",
  "source": "samples/form-01.hwp",
  "tool": "rhwp-q-objects",
  "untrustedContent": true,
  "untrustedFields": [
    "source",
    "controls"
  ],
  "version": "0.8.4"
}
```

표 표본 `samples/hwp_table_test.hwp` 는 `controlCount` 12 · `objectCount` 10 (표 10). 원문은 `mydocs/working/agent_q_objects.md` 에 있다.

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음. 읽기 전용 조회 CLI 신설이며 렌더러·본 CLI 경로를 바꾸지 않는다.
- 재현·측정: `samples/form-01.hwp` · `samples/hwp_table_test.hwp` 를 `--json` 으로 열어 종료 0과 봉투 필드를 확인했다.

> 특정 장비의 절대 성능 수치나 메인테이너 전용·비공개 벤치마크 통과는 PR 제출 조건이 아닙니다.
> 공개된 결정적 성능 회귀 테스트와 GitHub required checks는 기존과 같이 적용됩니다.

## 스크린샷

해당 없음. 조회 CLI 이며 렌더링·UI 변경이 없다.