### PR TITLE
fix(renderer): OLE 차트 Contents 파싱 실패를 폴백 사유로 강등해 EMF 미리보기에 도달하게 한다 (#5582)

### DIFF
--- a/src/parser/ole_container.rs
+++ b/src/parser/ole_container.rs
@@ -64,6 +64,23 @@ pub fn parse_ole_container(cfb_bytes: &[u8]) -> Option<OleContainer> {
     if cfb_bytes.len() < 8 {
         return None;
     }
+    // [#5582] HWPX 의 `BinData/*.ole` 는 CFB 앞에 u32 LE 길이 프리픽스를 붙인다
+    // (00128 실측: `00 B8 02 00` = 178,176 = 뒤따르는 CFB 크기). HWPX 적재 경로는
+    // `normalize_ole_bytes`(#2263)가 이미 벗기지만, 이 함수는 다른 유입 경로
+    // (HWP5 bindata·도구성 호출)도 받으므로 방어적으로 같은 정규화를 둔다.
+    // 선언 길이가 실제 잔여 길이와 일치할 때만 벗긴다 — 우연히 D0CF 로 이어지는
+    // 다른 형식을 오인하지 않게.
+    const CFB_MAGIC: [u8; 4] = [0xD0, 0xCF, 0x11, 0xE0];
+    let cfb_bytes = if cfb_bytes[0..4] != CFB_MAGIC
+        && cfb_bytes.len() >= 12
+        && cfb_bytes[4..8] == CFB_MAGIC
+        && u32::from_le_bytes([cfb_bytes[0], cfb_bytes[1], cfb_bytes[2], cfb_bytes[3]]) as usize
+            == cfb_bytes.len() - 4
+    {
+        &cfb_bytes[4..]
+    } else {
+        cfb_bytes
+    };
     let cursor = Cursor::new(cfb_bytes);
     let mut comp = CompoundFile::open(cursor).ok()?;
 
@@ -96,7 +113,10 @@ pub fn parse_ole_container(cfb_bytes: &[u8]) -> Option<OleContainer> {
                     container.ooxml_chart = Some(buf);
                 }
             }
-        } else if name == "Contents" {
+        } else if name.eq_ignore_ascii_case("contents") {
+            // [#5582] 한컴 산출 변형은 대문자 `CONTENTS` 도 쓴다(00128 실측). 차트가
+            // 아닌 일반 내장 개체의 CONTENTS 는 차트 파싱이 실패하고, 렌더 경로가
+            // 그 실패를 폴백 사유로 강등해 EMF/WMF 미리보기로 내려간다.
             if let Ok(mut s) = comp.open_stream(&path) {
                 let mut buf = Vec::new();
                 if s.read_to_end(&mut buf).is_ok() && !buf.is_empty() {
@@ -353,6 +373,35 @@ fn strip_ole_presentation_header_wmf(data: &[u8]) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [#5582] 길이 프리픽스가 붙은 CFB 도 컨테이너로 열린다 — HWPX 적재 경로는
+    /// `normalize_ole_bytes` 가 이미 벗기지만, 다른 유입 경로 대비 방어 정규화.
+    #[test]
+    fn length_prefixed_cfb_is_parsed() {
+        let cfb = crate::serializer::mini_cfb::build_cfb(&[("Contents", b"junk-not-a-chart")])
+            .expect("cfb");
+        assert!(parse_ole_container(&cfb).is_some(), "무프리픽스 기준선");
+        let mut prefixed = (cfb.len() as u32).to_le_bytes().to_vec();
+        prefixed.extend_from_slice(&cfb);
+        let container = parse_ole_container(&prefixed).expect("프리픽스 CFB 파싱");
+        assert!(container.raw_contents.is_some());
+        // 길이가 안 맞으면 벗기지 않는다(오인 방지) — CFB 매직이 없으니 None.
+        let mut wrong = 7u32.to_le_bytes().to_vec();
+        wrong.extend_from_slice(&cfb);
+        assert!(parse_ole_container(&wrong).is_none());
+    }
+
+    /// [#5582] 한컴 변형은 대문자 `CONTENTS` 를 쓴다(00128 실측) — 대소문자 무시 수집.
+    #[test]
+    fn uppercase_contents_stream_is_collected() {
+        let cfb = crate::serializer::mini_cfb::build_cfb(&[("CONTENTS", b"embedded-object")])
+            .expect("cfb");
+        let container = parse_ole_container(&cfb).expect("파싱");
+        assert_eq!(
+            container.raw_contents.as_deref(),
+            Some(b"embedded-object".as_slice())
+        );
+    }
 
     #[test]
     fn test_strip_no_emf_magic() {

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -1972,6 +1972,10 @@ impl LayoutEngine {
                     p
                 };
                 let mut rendered = false;
+                // [#5582] legacy 차트 `Contents` 파싱 실패는 최종 판정이 아니라 폴백
+                // 사유다 — 라벨만 기억하고 EMF/WMF/네이티브 이미지/hmapsi 폴백을
+                // 계속 시도한다. 전부 실패했을 때만 이 라벨로 자리표시를 그린다.
+                let mut chart_error_label: Option<String> = None;
                 // [#2550] 상한 로드 1회 — 이하 분기가 같은 바이트를 공유한다 (기존 3중
                 // 해제 제거 겸). 상한 초과는 아래 placeholder 폴백으로 접힌다.
                 if let Some((content, ole_bytes)) =
@@ -2053,24 +2057,16 @@ impl LayoutEngine {
                                             rendered = true;
                                         }
                                         Err(error) => {
-                                            push_ole_placeholder_render_node(
-                                                tree,
-                                                parent,
-                                                BoundingBox::new(
-                                                    render_x, render_y, render_w, render_h,
-                                                ),
-                                                0xFFFFF4E5,
-                                                0xFFB45F06,
-                                                ole_chart_fallback_label(
-                                                    error.stable_message(),
-                                                    ole.bin_data_id,
-                                                ),
-                                                section_index,
-                                                para_index,
-                                                control_index,
-                                                &ole_container_path,
-                                            );
-                                            rendered = true;
+                                            // [#5582] 종전에는 여기서 자리표시를 그리고
+                                            // 끝냈다 — `Contents` 를 가진 차트 아닌
+                                            // 일반 OLE 가 갖고 있는 EMF/WMF 미리보기에
+                                            // 도달하지 못해 개체가 화면에서 사라졌다
+                                            // (36494613 실측: 개체 2개 자리표시 →
+                                            // EMF 렌더 복원). 폴백 사유로 강등한다.
+                                            chart_error_label = Some(ole_chart_fallback_label(
+                                                error.stable_message(),
+                                                ole.bin_data_id,
+                                            ));
                                         }
                                     }
                                 }
@@ -2198,14 +2194,22 @@ impl LayoutEngine {
                 }
 
                 if !rendered {
-                    // 폴백: placeholder
-                    let label = format!("OLE 개체 (BinData #{})", ole.bin_data_id);
+                    // 폴백: placeholder. [#5582] 차트 `Contents` 파싱이 실패했고 다른
+                    // 미리보기 폴백도 전부 실패한 경우에만 그 사유 라벨(종전 색)을 쓴다.
+                    let (bg, fg, label) = match chart_error_label {
+                        Some(label) => (0xFFFFF4E5, 0xFFB45F06, label),
+                        None => (
+                            0xFFF0F0F0,
+                            0xFF707070,
+                            format!("OLE 개체 (BinData #{})", ole.bin_data_id),
+                        ),
+                    };
                     push_ole_placeholder_render_node(
                         tree,
                         parent,
                         BoundingBox::new(render_x, render_y, render_w, render_h),
-                        0xFFF0F0F0,
-                        0xFF707070,
+                        bg,
+                        fg,
                         label,
                         section_index,
                         para_index,


### PR DESCRIPTION
# fix(renderer): OLE 차트 Contents 파싱 실패를 폴백 사유로 강등해 EMF 미리보기에 도달하게 한다 (#5582)

## 근인 (이슈 원진단 그대로 + 지형 정정)

OLE 렌더 폴백 사슬에서 legacy 차트 `Contents` 파싱이 `Err` 면 **그 자리에서 자리표시를 그리고 `rendered=true` 로 종료** — `Contents` 를 가진 차트 아닌 일반 내장 개체가 보유한 EMF/WMF 미리보기(3·4단계)에 도달하지 못했다. 이슈의 제안(실패를 최종 판정이 아니라 폴백 사유로) 그대로 수정했다.

조사 중 지형을 정정했다:
- `.ole` 의 u32 길이 프리픽스는 HWPX 적재(`normalize_ole_bytes`, #2263)가 이미 벗긴다 — `parse_ole_container` 에는 다른 유입 경로 대비 **방어 정규화**로만 추가(선언 길이 일치 시에만).
- 이슈가 지목한 00128 등 일부 문서의 미리보기는 **EMF+ 전용**(GDI+ 레코드가 EMF 코멘트에 내장, 헤더 nRecords=16 전부 코멘트)이라 현 GDI 변환기(`emf::convert_to_svg`)의 범위 밖이다 — 폴백 순서를 고쳐도 변환 단계에서 실패한다. 별도 이슈로 분리한다.
- 한컴 변형은 대문자 `CONTENTS` 스트림도 쓴다(00128) — 대소문자 무시 수집으로 보강(폴백 강등과 결합돼 안전).

## 수정

1. `shape_layout.rs`: 차트 파싱 실패 시 라벨만 기억하고 EMF → WMF → 네이티브 이미지 → hmapsi 폴백을 계속. 전부 실패 시에만 그 라벨(종전 색)로 자리표시.
2. `ole_container.rs`: 길이 프리픽스 방어 정규화 + `CONTENTS` 대소문자 무시.

## 실측

- **36494613(서울시 도시생태현황도 운영지침)**: 자리표시였던 OLE 개체 2개(32·35쪽)가 EMF 미리보기로 렌더 복원 — render tree `RawSvg` 0→2, export-png 시각 확인. **음성 대조: 폴백 강등 제거 시 0 재현.**
- 코퍼스 `.ole` 보유 HWPX 11건 전수 A/B: **개선 1건(+개체 2) · 악화 0**. 잔여 자리표시는 EMF+ 전용(후속 이슈)·미리보기 부재·암호 문서로 전부 정당.

## 게이트

- 단위 테스트 2건(신규, `ole_container`): 길이 프리픽스 CFB 파싱(+오인 방지 음성) · 대문자 CONTENTS 수집. 기존 14건 전부 통과
- rustfmt(변경 파일)·clippy `-D warnings`·wasm check·manifest 체크·nextest 전체·Native Skia 3종: 결과는 아래 코멘트로 갱신
- `cargo fmt --all -- --check` 는 이 머신에서 실행 불능(변경 파일 rustfmt 직접 검사로 대체)

이슈 #5582 (신규 렌더 배치, 총괄 #5585; EMF+ 미지원은 후속 이슈로 분리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
