### PR TITLE
기능: 한컴 PUA 표시 대체표에 검증된 15항목 추가 (#5599 부분)

### DIFF
--- a/mydocs/working/task_5599_hancom_pua_verified.md
+++ b/mydocs/working/task_5599_hancom_pua_verified.md
@@ -1,0 +1,115 @@
+---
+kind: working
+status: active
+issue: 5599
+---
+
+# 한컴 PUA 표시 대체표 15항목 확정 (#5599 부분)
+
+작업 브랜치: `feat/5599-hancom-pua-verified`
+대상: `src/renderer/hancom_pua.rs` · `tests/cases/issue_5599_hancom_pua_display.rs`
+
+## 한 줄
+
+저장소에 이미 있는 **한컴 출력 PDF**로 미매핑 PUA 15종의 glyph 를 확정해
+`VERIFIED_HANCOM_PUA_DISPLAY` 에 넣었다(12 → 27항목). 한글 설치 없이 리눅스에서 규약
+("한컴 PDF 대조")을 그대로 만족한다.
+
+## 한글 없이 오라클을 쓴 방법
+
+`pdf/` 에는 한컴이 내보낸 PDF 가 섞여 있다. `pdffonts` 로 임베드 폰트를 보면 구별된다.
+
+| PDF | 임베드 폰트 | 판정 |
+|---|---|---|
+| `pdf/hwp3-sample11-2020.pdf` | HCRBatang · HCRDotum | 한컴 출력 ✅ |
+| `pdf/복학원서-2022.pdf` | Haansoft Batang | ✅ |
+| `pdf/issue2083_hide_fill_page-2020.pdf` | DejaVu 만 | ❌ (한컴 아님) |
+
+한컴 PDF 는 폰트를 임베드하므로 `pdftocairo -png -r 400` 이 원래 glyph 를 그대로 그린다.
+문서의 PUA 출현 위치와 PDF 텍스트 좌표를 맞춰 그 자리를 잘라 보면 glyph 를 눈으로 확정할 수
+있다(도구: `tools` 밖 임시 스크립트, 산출물은 커밋하지 않음).
+
+## 확정한 항목
+
+### 罫線 조각 6종 — `hwp3-sample11` + `pdf/hwp3-sample11-2020.pdf`
+
+| 코드포인트 | glyph | 근거 |
+|---|---|---|
+| U+F0806 | `┌` | p129 세 줄 연속 `F0806 / F0810 / F080C` → ┌ │ └ |
+| U+F0807 | `┬` | p22 `━━━F0807━━━` |
+| U+F0808 | `┐` | p6 `SUN OS 4.1.1 ━F0808` |
+| U+F080C | `└` | p22 `F080C━>`, p129 |
+| U+F080E | `┘` | p6 `SUN OS 4.1.4 ━F080E` |
+| U+F0810 | `│` | p6 중간 두 줄, p129 |
+
+p6 의 네 줄은 한컴 출력에서 `━┐ / │ / │ / ━┘` 세로 묶음으로 보인다. `SO-SUEOP.hwpx`
+(한컴 PDF `pdf/SO-SUEOP-2024.pdf`)도 같은 묶음을 쓴다.
+
+### 원숫자 9종 — 같은 문서 p23 NVRAM 바이트 라벨
+
+한컴 출력의 라벨 줄: `⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⓐ ⓑ`
+문서 본문의 같은 자리: `F0288 F0289 F028A ③(리터럴) F028C F028D F028E F028F F0290 F0291 ⓐ ⓑ`
+
+| 코드포인트 | glyph |
+|---|---|
+| U+F0288 | `⓪` |
+| U+F0289 | `①` |
+| U+F028A | `②` |
+| U+F028C | `④` |
+| U+F028D | `⑤` |
+| U+F028E | `⑥` |
+| U+F028F | `⑦` |
+| U+F0290 | `⑧` |
+| U+F0291 | `⑨` |
+
+같은 쪽 아래 `Host-ID = ①+ⓒ+ⓓ+ⓔ`(= 바이트 1·c·d·e) 줄이 `F0289 = ①` 을 한 번 더 확인해
+준다. **U+F028B(=③)는 이 문서가 리터럴 ③ 을 써서 근거가 없으므로 넣지 않았다** — 연속
+구간이라고 추정하지 않는다(모듈 규약).
+
+## 확정하지 못해 뺀 것
+
+| 코드포인트 | 문서 | 상태 |
+|---|---|---|
+| U+F0848 (17회) | 2025 행정업무운영 편람 | 한컴 출력에서 짧은 가로 막대 bullet 로 보이나 `─`/`—`/`-` 중 무엇인지 폭까지 확정 못 함 |
+| U+F0090 | img-start-001 | 여러 갈래 꽃무늬 bullet — 공개 글꼴 대체 문자 특정 실패 |
+| U+F03A7 · U+F03A8 | 편람 p43 | 네모 안 `+`/`−` 로 보이나 같은 줄 리터럴 `①` 이 네모로 그려져 정렬 신뢰도 부족 |
+| U+F02C5 | mel-001 | PDF 쪽 PUA 워드와 문서 위치 정렬 실패 |
+| U+F081C | 복학원서 | 점선 rule 로 보이나 대체 문자 미정 |
+| U+F03DA (150회/22문서) | issue2083 | 그 PDF 가 한컴 출력이 아님 → 판정 불가 |
+
+이슈의 최대 덩어리 `U+F02B1`–`U+F02B7`·`U+F0832`·`U+F03FF`·`U+F02EC` 는 admrul 코퍼스에만
+있어 이 환경에서 볼 수 없다. 그래서 이 작업은 이슈를 **부분 해소**한다.
+
+## 검증 실측
+
+```
+rhwp export-svg samples/hwp3-sample11-hwp5.hwp   (p6)
+  전: raw PUA 두부 3종(0F0808 · 0F0810 · 0F080E) 이 코드 숫자 상자로 그려짐
+  후: ┐ │ │ ┘  — 한컴 출력과 같은 세로 묶음
+  두 쪽(p6·p23) 모두 매핑된 코드포인트의 raw PUA 잔존 0
+```
+
+## 시험 명령
+
+```
+cargo test --profile release-test --test regression_suite_006 issue_5599   # 신규 가드 2건
+cargo test --profile release-test --tests --no-fail-fast                   # 전체
+```
+
+신규 가드는 수정 전 코드에서 둘 다 실패, 수정 후 통과.
+
+## fmt 게이트
+
+```
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+```
+
+## 환경
+
+Linux 6.17 · rhwp v0.8.4 · 한글 미설치. 오라클은 저장소에 커밋된 한컴 PDF 를 썼다.
+
+## PR 메모
+
+`gh pr create --base devel --body-file ...`. 이슈를 완전히 닫지 않으므로 `closes` 대신
+`#5599 부분 해소` 로 참조한다.

--- a/src/renderer/hancom_pua.rs
+++ b/src/renderer/hancom_pua.rs
@@ -15,6 +15,21 @@
 static VERIFIED_HANCOM_PUA_DISPLAY: &[(u32, &str)] = &[
     // `복학원서.hwp` 서명란. Hancom PDF: `(인)`.
     (0xF012B, "(인)"),
+    // `hwp3-sample11`(HWP3→HWP5 변환본) p23 NVRAM 바이트 라벨 ⓪..⑨.
+    // Hancom PDF `pdf/hwp3-sample11-2020.pdf` p23 실측: 라벨 줄이
+    // ⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⓐ ⓑ 로 이어지고, 문서 본문은 같은 자리에
+    // F0288 F0289 F028A ③(리터럴) F028C F028D F028E F028F F0290 F0291 ⓐ ⓑ 다.
+    // 같은 쪽 아래 "Host-ID = ①+ⓒ+ⓓ+ⓔ" 줄이 F0289=① 을 한 번 더 확인해 준다.
+    // F028B(=③)는 이 문서가 리터럴 ③ 을 써서 근거가 없으므로 넣지 않는다.
+    (0xF0288, "⓪"),
+    (0xF0289, "①"),
+    (0xF028A, "②"),
+    (0xF028C, "④"),
+    (0xF028D, "⑤"),
+    (0xF028E, "⑥"),
+    (0xF028F, "⑦"),
+    (0xF0290, "⑧"),
+    (0xF0291, "⑨"),
     // `pau-004.hwp`/한컴 문자표와 `issue2007_nested_cell_pagination_42065.hwp` 중첩 표 글머리표.
     // HCR Dotum/Hancom PDF: small right-pointing triangle. 공개 글꼴에서 raw PUA는 두부가 된다.
     (0xF02FB, "▸"),
@@ -34,6 +49,18 @@ static VERIFIED_HANCOM_PUA_DISPLAY: &[(u32, &str)] = &[
     (0xF03F2, "컴"),
     (0xF03F3, "퓨"),
     (0xF03F4, "터"),
+    // 罫線(괘선) 조각 — `hwp3-sample11` 이 텍스트 다이어그램의 세로 묶음에 쓴다.
+    // Hancom PDF `pdf/hwp3-sample11-2020.pdf` 실측:
+    //   p6  `SUN OS 4.1.1 ━F0808 / F0810 / F0810 / 4.1.4 ━F080E` → ┐ │ │ ┘
+    //   p22 `━━━F0807━━━` 와 그 아래 `F080C━>` → ┬ 와 └
+    //   p129 세 줄 연속 F0806 / F0810 / F080C → ┌ │ └
+    // `SO-SUEOP.hwpx`(Hancom PDF `pdf/SO-SUEOP-2024.pdf`)도 같은 묶음을 쓴다.
+    (0xF0806, "┌"),
+    (0xF0807, "┬"),
+    (0xF0808, "┐"),
+    (0xF080C, "└"),
+    (0xF080E, "┘"),
+    (0xF0810, "│"),
 ];
 
 /// 검증된 한컴 기호에 대한 공개 글꼴 표시 대체값.

--- a/tests/cases/issue_5599_hancom_pua_display.rs
+++ b/tests/cases/issue_5599_hancom_pua_display.rs
@@ -1,0 +1,63 @@
+//! Issue #5599: 한컴 전용 PUA 기호가 표시 대체표에 없어 공개 글꼴로 raw PUA(두부)가
+//! 그려지던 문제 — 한컴 PDF 로 확정한 항목의 회귀 가드.
+//!
+//! 이번에 확정한 두 묶음은 `samples/hwp3-sample11-hwp5.hwp` 와 그 한컴 출력
+//! `pdf/hwp3-sample11-2020.pdf` 대조로 얻었다.
+//!
+//! - 罫線 조각 `U+F0806·F0807·F0808·F080C·F080E·F0810` → `┌ ┬ ┐ └ ┘ │`
+//!   (p6 세로 묶음 `━┐ │ │ ━┘`, p22 `━━━┬━━━` 와 `└─>`, p129 `┌ │ └`)
+//! - 원숫자 `U+F0288·F0289·F028A·F028C..F0291` → `⓪ ① ② ④ ⑤ ⑥ ⑦ ⑧ ⑨`
+//!   (p23 NVRAM 바이트 라벨 줄이 한컴 출력에서 ⓪①②③④⑤⑥⑦⑧⑨ⓐⓑ 로 이어진다)
+//!
+//! 이 테스트는 그 두 쪽을 렌더해 (1) 대체 문자가 실제로 그려지고 (2) 매핑된
+//! 코드포인트의 raw PUA 가 남지 않는 것을 잠근다.
+
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/hwp3-sample11-hwp5.hwp";
+
+/// 이번에 확정해 표에 넣은 코드포인트.
+const MAPPED: &[u32] = &[
+    0xF0288, 0xF0289, 0xF028A, 0xF028C, 0xF028D, 0xF028E, 0xF028F, 0xF0290, 0xF0291, 0xF0806,
+    0xF0807, 0xF0808, 0xF080C, 0xF080E, 0xF0810,
+];
+
+fn render(page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", SAMPLE, e));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {}: {}", SAMPLE, e));
+    doc.render_page_svg_native(page)
+        .unwrap_or_else(|e| panic!("render page {page}: {e}"))
+}
+
+fn assert_no_mapped_raw_pua(svg: &str, page: u32) {
+    for &code_point in MAPPED {
+        let ch = char::from_u32(code_point).expect("valid code point");
+        assert!(
+            !svg.contains(ch),
+            "p{page}: 매핑된 U+{code_point:05X} 가 raw PUA 로 남았다 — 대체표 투영이 끊겼는지 확인"
+        );
+    }
+}
+
+/// p6(0-based 5): 세로 묶음 `━┐ │ │ ━┘`.
+#[test]
+fn issue_5599_box_drawing_pua_is_substituted() {
+    let svg = render(5);
+    for ch in ['┐', '│', '┘'] {
+        assert!(svg.contains(ch), "p6 에 {ch} 가 그려져야 한다");
+    }
+    assert_no_mapped_raw_pua(&svg, 6);
+}
+
+/// p23(0-based 22): NVRAM 바이트 라벨 ⓪..⑨.
+#[test]
+fn issue_5599_circled_digit_pua_is_substituted() {
+    let svg = render(22);
+    for ch in ['⓪', '①', '②', '④', '⑨'] {
+        assert!(svg.contains(ch), "p23 에 {ch} 가 그려져야 한다");
+    }
+    assert_no_mapped_raw_pua(&svg, 23);
+}


### PR DESCRIPTION
> PR base 브랜치: `devel`

## 변경 요약

저장소에 **이미 커밋된 한컴 출력 PDF**로 미매핑 PUA 15종의 glyph 를 확정해
`VERIFIED_HANCOM_PUA_DISPLAY` 에 넣습니다(12 → 27항목). 한글 설치 없이 모듈 규약
("실제 문서 + Hancom PDF + 회귀 테스트")을 그대로 만족합니다.

## 관련 이슈

#5599 **부분 해소** (44종 중 15종). 나머지는 아래 "확정하지 못한 것" 참조 — 이슈는 열어 둡니다.

## 한글 없이 오라클을 쓴 방법

`pdf/` 에는 한컴 출력 PDF 가 섞여 있고, `pdffonts` 의 임베드 폰트로 구별됩니다.

| PDF | 임베드 폰트 | 판정 |
|---|---|---|
| `pdf/hwp3-sample11-2020.pdf` | HCRBatang · HCRDotum | 한컴 출력 ✅ |
| `pdf/복학원서-2022.pdf` | Haansoft Batang | ✅ |
| `pdf/issue2083_hide_fill_page-2020.pdf` | DejaVu 만 | ❌ 한컴 아님 |

한컴 PDF 는 폰트를 임베드하므로 `pdftocairo -png -r 400` 이 원래 glyph 를 그대로 그립니다.
문서의 PUA 출현 순서와 PDF 텍스트 좌표를 맞춰 그 자리를 잘라 확인했습니다.

## 확정한 항목

### 罫線 조각 6종 — `samples/hwp3-sample11-hwp5.hwp` ↔ `pdf/hwp3-sample11-2020.pdf`

| 코드포인트 | glyph | 근거 |
|---|---|---|
| U+F0806 | `┌` | p129 세 줄 연속 `F0806 / F0810 / F080C` → ┌ │ └ |
| U+F0807 | `┬` | p22 `━━━F0807━━━` |
| U+F0808 | `┐` | p6 `SUN OS 4.1.1 ━F0808` |
| U+F080C | `└` | p22 `F080C━>`, p129 |
| U+F080E | `┘` | p6 `SUN OS 4.1.4 ━F080E` |
| U+F0810 | `│` | p6 중간 두 줄, p129 |

### 원숫자 9종 — 같은 문서 p23 NVRAM 바이트 라벨

```
한컴 출력 라벨 줄 : ⓪  ①  ②  ③  ④  ⑤  ⑥  ⑦  ⑧  ⑨  ⓐ  ⓑ
문서 본문 같은 자리: F0288 F0289 F028A ③ F028C F028D F028E F028F F0290 F0291 ⓐ ⓑ
```

`F0288 ⓪ · F0289 ① · F028A ② · F028C ④ · F028D ⑤ · F028E ⑥ · F028F ⑦ · F0290 ⑧ · F0291 ⑨`

같은 쪽 아래 `Host-ID = ①+ⓒ+ⓓ+ⓔ`(= 바이트 1·c·d·e) 줄이 `F0289 = ①` 을 한 번 더 확인해
줍니다. **U+F028B(=③)는 이 문서가 리터럴 `③` 을 써서 근거가 없으므로 넣지 않았습니다** —
연속 구간이라고 추정하지 않는다는 모듈 규약을 지킵니다.

## 확정하지 못해 뺀 것 (후속용 기록)

| 코드포인트 | 문서 | 상태 |
|---|---|---|
| U+F0848 (17회) | 2025 행정업무운영 편람 | 짧은 가로 막대 bullet 로 보이나 `─`/`—`/`-` 중 폭까지 확정 못 함 |
| U+F0090 | img-start-001 | 여러 갈래 꽃무늬 bullet — 대체 문자 특정 실패 |
| U+F03A7 · U+F03A8 | 편람 p43 | 네모 안 `+`/`−` 로 보이나 같은 줄 리터럴 `①` 이 네모로 그려져 정렬 신뢰도 부족 |
| U+F02C5 | mel-001 | PDF PUA 워드와 문서 위치 정렬 실패 |
| U+F081C | 복학원서 | 점선 rule 로 보이나 대체 문자 미정 |
| U+F03DA (150회/22문서) | issue2083 | 그 PDF 가 한컴 출력이 아님 → 판정 불가 |

이슈의 최대 덩어리 `U+F02B1`–`U+F02B7` · `U+F0832` · `U+F03FF` · `U+F02EC` 는 admrul
코퍼스에만 있어 이 환경에서 볼 수 없습니다. 해당 문서 + 한컴 PDF 가 있으면 같은 절차로
바로 확정할 수 있습니다.

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] 새 integration test는 원본을 `tests/cases/issue_5599_hancom_pua_display.rs` 에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [x] `src/**` 의 `#[cfg(test)]` 는 변경하지 않음 (기존 `hancom_pua` 단위 테스트 그대로 통과)
- [x] `cargo test --profile release-test --tests --no-fail-fast` 통과 — 49 타깃 / 7,850 통과 / 0 실패
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인 (아래)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음(표시 대체표는 paint·폭 측정 공통 경로)
- [ ] rhwp-studio 변경 없음

신규 가드 2건은 수정 전 코드에서 둘 다 실패, 수정 후 통과합니다.

## 시각 근거 (전/후)

`rhwp export-svg samples/hwp3-sample11-hwp5.hwp` p6 세로 묶음:

```
전: raw PUA 두부 3종(0F0808 · 0F0810 · 0F080E)이 코드 숫자 상자로 그려짐
후: ┐ │ │ ┘        ← 한컴 출력(pdf/hwp3-sample11-2020.pdf p6)과 같은 모양
p6·p23 모두 매핑된 코드포인트의 raw PUA 잔존 0
```

처리 결과 문서: `mydocs/working/task_5599_hancom_pua_verified.md`
