### PR TITLE
fix: #3351 메뉴 개체 조작의 undo/redo 캐럿을 개체 인접에 착지시킨다 — 한컴 실측 반영

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -642,7 +642,15 @@ function recordObjectMutation(
   mutate: (wasm: WasmBridge) => boolean | void,
   opts?: { refresh?: RefreshPolicy },
 ): void {
-  const pos = ih.getCursorPosition();
+  // [Task #3351] 개체 선택은 `cursor.position` 을 옮기지 않는다. 그래서 여기서 그냥
+  // `getCursorPosition()` 을 잡으면 **개체를 선택하기 직전 캐럿**이 기록되고, undo/redo 가
+  // 조작과 무관한 자리(문서 상단일 수도 있다)로 착지한다.
+  //
+  // 한컴 2024 실측: 개체 선택은 캐럿을 앵커로 끌고 가고, 캐럿을 다른 문단으로 옮기면 선택이
+  // 풀린다 — "캐럿은 딴 곳, 개체는 선택" 이라는 상태 자체가 없다. 삭제·undo·redo 내내 캐럿은
+  // 개체 인접 문단에 머문다. Delete 키 경로(`performDelete`)가 이미 그렇게 하고 있으므로
+  // 메뉴 경로도 같은 자리를 기록한다.
+  const pos = ih.getPositionOutsideSelectedPicture() ?? ih.getCursorPosition();
   ih.executeOperation({
     kind: 'snapshot',
     operationType,

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1680,17 +1680,44 @@ export class CursorState {
     return this.selectedPictureRefs.length > 1;
   }
 
+  /**
+   * 선택된 개체 **밖**(인접 문단)의 위치. 커서를 옮기지도, 선택을 풀지도 않는다 (Task #3351).
+   *
+   * `moveOutOfSelectedPicture` 가 쓰던 규칙을 그대로 꺼낸 것이다. 개체 조작을 히스토리에
+   * 기록하는 쪽은 **위치만** 필요한데, 그러자고 선택을 푸는 메서드를 부를 수는 없기 때문이다.
+   * 규칙이 갈라지면 Delete 키 경로와 메뉴 경로의 착지가 또 어긋난다.
+   *
+   * 인접 문단을 잡을 수 없으면(개체가 든 문단이 유일) `null` 이다.
+   */
+  positionOutsideSelectedPicture(): DocumentPosition | null {
+    if (!this.selectedPictureRef) return null;
+    const { sec, ppi } = this.selectedPictureRef;
+    return this.positionOutsideObject(sec, ppi);
+  }
+
+  /**
+   * `sec` 구역 `ppi` 문단에 놓인 개체 **밖**의 위치 (Task #3351).
+   *
+   * 선택 상태를 읽지 않고 ref 만 받는다 — 클릭으로 z순서를 바꾸는 경로처럼 **선택 진입 전에**
+   * 기록해야 하는 자리가 있기 때문이다. 인접 문단을 잡을 수 없으면 `null`.
+   */
+  positionOutsideObject(sec: number, ppi: number): DocumentPosition | null {
+    const paraCount = this.wasm.getParagraphCount(sec);
+    if (ppi + 1 < paraCount) {
+      return { sectionIndex: sec, paragraphIndex: ppi + 1, charOffset: 0 };
+    }
+    if (ppi > 0) {
+      const prevLen = this.wasm.getParagraphLength(sec, ppi - 1);
+      return { sectionIndex: sec, paragraphIndex: ppi - 1, charOffset: prevLen };
+    }
+    return null;
+  }
+
   /** 개체 객체 선택 상태에서 개체 밖으로 커서를 이동한다. */
   moveOutOfSelectedPicture(): void {
     if (!this.selectedPictureRef) return;
-    const { sec, ppi } = this.selectedPictureRef;
-    const paraCount = this.wasm.getParagraphCount(sec);
-    if (ppi + 1 < paraCount) {
-      this.position = { sectionIndex: sec, paragraphIndex: ppi + 1, charOffset: 0 };
-    } else if (ppi > 0) {
-      const prevLen = this.wasm.getParagraphLength(sec, ppi - 1);
-      this.position = { sectionIndex: sec, paragraphIndex: ppi - 1, charOffset: prevLen };
-    }
+    const outside = this.positionOutsideSelectedPicture();
+    if (outside) this.position = outside;
     this.exitPictureObjectSelection();
     this.updateRect();
   }

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -1977,7 +1977,12 @@ function bringShapeToFront(this: any, picHit: any): void {
       // [Task #2759] 선택 시 z순서 변경도 문서 뮤테이션 — 메뉴 정렬(insert.ts:427 등)의
       // recordObjectMutation 과 동형으로 snapshot 기록해 undo 가능·redo 무효화·스냅샷 undo
       // 동반 파괴를 막는다. UI 후처리(선택 진입·재렌더)는 호출부가 기존대로 수행한다.
-      const pos = this.getCursorPosition();
+      // [Task #3351] 메뉴 경로와 같은 이유로 캐럿은 **개체 인접**을 기록한다. 여기서
+      // `getCursorPosition()` 을 잡으면 클릭 직전 캐럿(문서 상단일 수도 있다)이 남아 undo 가
+      // 조작과 무관한 자리로 착지한다. 이 지점은 선택 진입 **전**이라 선택 상태를 읽을 수 없어
+      // 클릭된 개체의 ref 로 위치를 구한다.
+      const pos = this.cursor.positionOutsideObject(picHit.sec, picHit.ppi)
+        ?? this.getCursorPosition();
       this.executeOperation({
         kind: 'snapshot',
         operationType: 'changeZOrder',

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -4007,6 +4007,15 @@ export class InputHandler {
   /** 선택된 그림/글상자 참조 반환 ([Task #825] headerFooter 동반 시 머리말/꼬리말 picture marker) */
   getSelectedPictureRef(): { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' | 'line' | 'ole'; cellIdx?: number; cellParaIdx?: number; outerTableControlIdx?: number; cellPath?: Array<{ controlIndex: number; cellIndex: number; cellParaIndex: number }>; noteRef?: any; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } } | null { return this.cursor.getSelectedPictureRef(); }
 
+  /**
+   * 선택된 개체 밖(인접 문단)의 위치 — 커서를 옮기지 않는다 (Task #3351).
+   *
+   * 개체 조작을 기록하는 쪽이 "그 조작이 일어난 자리" 를 캐럿으로 남기기 위해 쓴다.
+   */
+  getPositionOutsideSelectedPicture(): DocumentPosition | null {
+    return this.cursor.positionOutsideSelectedPicture();
+  }
+
   /** 다중 선택된 개체 목록 */
   getSelectedPictureRefs(): { sec: number; ppi: number; ci: number; type: string }[] { return this.cursor.getSelectedPictureRefs(); }
 

--- a/rhwp-studio/tests/issue-3351-object-caret-landing.test.ts
+++ b/rhwp-studio/tests/issue-3351-object-caret-landing.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { balancedFrom, functionBodyFrom } from './support/source-guard.ts';
+
+// [#3351] 메뉴 개체 조작의 undo/redo 캐럿이 조작과 무관한 자리로 착지하던 결함.
+//
+// 개체 선택(`enterPictureObjectSelectionDirect`)은 `cursor.position` 을 옮기지 않는다. 그래서
+// 기록 시점에 `getCursorPosition()` 을 잡으면 **개체를 선택하기 직전 캐럿**이 남고, 문단 0 에서
+// 스크롤해 문단 10 의 개체를 지우면 undo/redo 가 문서 상단으로 점프한다.
+//
+// 한컴 오피스 2024 실측(COM):
+//  - `FindCtrl` 로 개체를 선택하면 캐럿이 앵커로 이동한다((0,0,16) → (0,10,5)).
+//  - 그 뒤 캐럿을 다른 문단으로 옮기면 **개체 선택이 풀린다**(이후 Delete 가 개체를 못 지움).
+//    즉 "캐럿은 딴 곳, 개체는 선택" 이라는 상태가 한컴에는 없다.
+//  - 삭제 → Undo → Redo 내내 캐럿은 개체 인접 문단((0,10,0))에 머문다.
+//
+// 따라서 정답은 "개체 인접" 이고, Delete 키 경로(`performDelete`)가 이미 그렇게 한다.
+// 여기서 고정하는 것은 메뉴 경로와 클릭 z순서 경로도 같은 자리를 기록한다는 것이다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const studioRoot = rootDir;
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#3351] 인접 위치 규칙은 한 곳에만 있다', () => {
+  const cursor = src('src/engine/cursor.ts');
+
+  // 규칙 본체는 ref 를 받는 쪽이다.
+  const rule = functionBodyFrom(cursor, 'positionOutsideObject(sec: number, ppi: number)');
+  assert.match(rule, /ppi \+ 1 < paraCount/, '다음 문단 우선');
+  assert.match(rule, /getParagraphLength\(sec, ppi - 1\)/, '마지막 문단이면 이전 문단 끝');
+
+  // 선택 기반 조회는 그 규칙에 위임한다 — 복제하면 Delete 키 경로와 착지가 어긋난다.
+  const bySelection = functionBodyFrom(cursor, 'positionOutsideSelectedPicture()');
+  assert.match(bySelection, /this\.positionOutsideObject\(sec, ppi\)/, '규칙을 위임해야 한다');
+  assert.doesNotMatch(bySelection, /getParagraphCount/, '규칙을 복제하면 안 된다');
+
+  // 커서를 실제로 옮기는 쪽도 같은 규칙을 쓴다.
+  const move = functionBodyFrom(cursor, 'moveOutOfSelectedPicture()');
+  assert.match(move, /this\.positionOutsideSelectedPicture\(\)/, '이동도 같은 규칙');
+  assert.match(move, /this\.exitPictureObjectSelection\(\)/, '이동은 선택도 푼다(종전 동작)');
+});
+
+test('[#3351] 조회는 커서를 옮기지도 선택을 풀지도 않는다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const rule = functionBodyFrom(cursor, 'positionOutsideObject(sec: number, ppi: number)');
+  const bySelection = functionBodyFrom(cursor, 'positionOutsideSelectedPicture()');
+  for (const [name, body] of [['positionOutsideObject', rule], ['positionOutsideSelectedPicture', bySelection]] as const) {
+    assert.doesNotMatch(body, /this\.position\s*=/, `${name} 는 커서를 옮기면 안 된다`);
+    assert.doesNotMatch(body, /exitPictureObjectSelection/, `${name} 는 선택을 풀면 안 된다`);
+  }
+});
+
+test('[#3351] 메뉴 개체 조작은 개체 인접을 기록한다', () => {
+  const insert = src('src/command/commands/insert.ts');
+  const body = functionBodyFrom(insert, 'function recordObjectMutation');
+  assert.match(
+    body,
+    /getPositionOutsideSelectedPicture\(\)/,
+    '개체 선택은 cursor.position 을 옮기지 않는다 — 그냥 읽으면 선택 직전 캐럿이 기록된다',
+  );
+});
+
+test('[#3351] 클릭 z순서도 개체 인접을 기록한다', () => {
+  const mouse = src('src/engine/input-handler-mouse.ts');
+  const body = balancedFrom(mouse, 'function bringShapeToFront', '{');
+  assert.match(
+    body,
+    /positionOutsideObject\(picHit\.sec, picHit\.ppi\)/,
+    '선택 진입 전이라 ref 로 위치를 구해야 한다',
+  );
+});
+
+test('[#3351] 인접 문단 계산 — 실제 규칙 동작', async () => {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const make = (paraCount: number, lengths: Record<number, number>) => {
+      const wasm: any = {
+        getParagraphCount: () => paraCount,
+        getParagraphLength: (_s: number, p: number) => lengths[p] ?? 0,
+      };
+      return new CursorState(wasm) as any;
+    };
+
+    // 개체가 문단 10, 뒤에 문단이 더 있으면 다음 문단 시작.
+    assert.deepEqual(
+      make(13, {}).positionOutsideObject(0, 10),
+      { sectionIndex: 0, paragraphIndex: 11, charOffset: 0 },
+    );
+    // 개체가 마지막 문단이면 이전 문단 끝.
+    assert.deepEqual(
+      make(11, { 9: 7 }).positionOutsideObject(0, 10),
+      { sectionIndex: 0, paragraphIndex: 9, charOffset: 7 },
+    );
+    // 문단이 하나뿐이면 인접이 없다.
+    assert.equal(make(1, {}).positionOutsideObject(0, 0), null);
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
관련 이슈: #3351

## 문제

메뉴/도구상자 개체 조작(삭제·정렬 z순서·묶기/풀기)의 실행·undo·redo 가 캐럿을 **개체 선택 이전
위치**로 되돌립니다. 문단 0 에서 스크롤해 문단 10 의 도형을 메뉴로 지우면 캐럿이 문서 상단으로
점프합니다. 같은 삭제라도 Delete 키 경로는 개체 인접 문단에 착지하므로, 진입점에 따라 착지가
갈립니다.

## 원인

개체 선택(`enterPictureObjectSelectionDirect`)은 `cursor.position` 을 옮기지 않습니다. 그래서
`recordObjectMutation`(`insert.ts:645`)이 기록 시점에 잡는 값은 "개체를 선택하기 직전 캐럿"이고,
그 조작이 실제로 일어난 자리가 아닙니다.

```ts
const pos = ih.getCursorPosition();   // ← 개체 선택 중이라 선택 직전 캐럿
ih.executeOperation({ kind: 'snapshot', operationType, operation: (wasm) => (... ? null : pos) });
```

Delete 키 경로(`performDelete`, `input-handler.ts:4816`)는 반대로 `moveOutOfSelectedPicture()` 로
캐럿을 개체 인접으로 옮긴 **뒤** 기록합니다. 클릭 z순서(`bringShapeToFront`,
`input-handler-mouse.ts:1980`)도 메뉴 경로와 같은 모양이라 같은 결함을 갖습니다.

## 한컴 오라클 — 실측

이 이슈는 "실측 전까지 현행 유지" 로 열려 있었습니다. 한컴 오피스 2024(Hwp 13.0) COM 자동화로
쟀습니다.

| 단계 | 캐럿 | gso |
|---|---|---|
| 그림 삽입 후 | (0,10,8) | 1 |
| 캐럿을 문단 0 으로 | (0,0,16) | 1 |
| 개체 선택(`FindCtrl`) | **(0,10,5)** ← 앵커로 끌려감 | 1 |
| 메뉴 삭제 | (0,10,0) | 0 |
| Undo | **(0,10,0)** | 1 |
| Redo | **(0,10,0)** | 0 |

그리고 전제 자체를 확인했습니다 — 개체를 선택한 뒤 캐럿만 문단 0 으로 옮기면 **개체 선택이
풀립니다**(그 상태에서 Delete 가 개체를 지우지 못하고 `gso` 가 1 → 1). 즉 **"캐럿은 딴 곳, 개체는
선택" 이라는 상태가 한컴에는 없습니다.**

따라서 "선택 이전 캐럿으로 복귀" 는 한컴 정합이 아니며, 이슈 본문의 판정 기준
("(0,10,*) 또는 (0,11,*) 이면 개체 인접")대로 **개체 인접이 정답**입니다. Delete 키 경로가 이미
그렇게 하고 있으므로 메뉴 경로를 거기에 맞춥니다.

## 변경

**인접 위치 규칙을 한 곳으로 모았습니다.** 규칙은 `moveOutOfSelectedPicture` 안에 있었는데, 그
메서드는 위치 계산과 **선택 해제**를 함께 합니다. 기록하는 쪽은 위치만 필요한데 그러자고 선택을
푸는 메서드를 부를 수는 없습니다(회전·z순서는 조작 뒤에도 선택이 이어져야 합니다).

```
positionOutsideObject(sec, ppi)        ← 규칙 본체 (ref 기반, 상태를 읽지 않음)
  ├─ positionOutsideSelectedPicture()  ← 선택 기반 조회
  │    └─ moveOutOfSelectedPicture()   ← 조회 + 커서 이동 + 선택 해제 (종전 동작 그대로)
  └─ bringShapeToFront                 ← 선택 진입 *전* 이라 ref 로 직접
```

규칙을 복제하지 않은 것이 핵심입니다 — 갈라지면 Delete 키 경로와 메뉴 경로의 착지가 또
어긋납니다. 이 이슈가 정확히 그 어긋남입니다.

호출부는 둘입니다.

- `recordObjectMutation` — `ih.getPositionOutsideSelectedPicture() ?? ih.getCursorPosition()`
- `bringShapeToFront` — `cursor.positionOutsideObject(picHit.sec, picHit.ppi) ?? getCursorPosition()`
  (선택 진입 전이라 선택 상태를 읽을 수 없습니다)

폴백은 인접 문단이 없는 경우(개체가 든 문단이 유일)를 위한 것입니다.

회전/대칭은 해당 없습니다 — `SetObjectPropsCommand` 가 이미 개체 자신의 문단을 돌려줍니다.

### 테스트

`rhwp-studio/tests/issue-3351-object-caret-landing.test.ts` (5개)

- 인접 위치 규칙이 한 곳에만 있고 나머지가 위임한다(복제 금지)
- 조회는 커서를 옮기지도 선택을 풀지도 않는다
- 메뉴 경로·클릭 z순서가 개체 인접을 기록한다
- 규칙 자체의 동작 — 다음 문단 시작 / 마지막 문단이면 이전 문단 끝 / 문단 하나뿐이면 `null`
  (vite SSR 로 실제 `CursorState` 를 띄워 확인)

## 검증

devel `61baa6783` 기준.

- **수정 전 실패 증명**: 이 PR 의 테스트를 devel 소스에 그대로 걸면 **5개 전부 실패**.
  이 브랜치에서 5개 전부 통과.
- `npm --prefix rhwp-studio run test` — **1011 tests, 0 fail** (skipped 1 은 기존 테스트).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

한컴 측정 스크립트는 임시라 커밋하지 않았습니다. 재현은 `HWPFrame.HwpObject` COM 으로
`FileNew` → 문단 12개 + `InsertPicture` → `SetPosBySet(GetAnchorPos(0))` → `FindCtrl()` →
`Run("Delete"/"Undo"/"Redo")` 이고, 캐럿은 `GetPosBySet()`(out-parameter 라 `GetPos` 는
스크립트에서 호출 불가), 개체 수는 `HeadCtrl` 순회의 `CtrlID === 'gso'` 로 셉니다.

## 범위 외

- **Delete 키 경로** — 현행이 정답입니다(한컴과 일치). 건드리지 않았습니다.
- **undo 뒤 개체 재선택** — 한컴은 undo 후 개체가 돌아오지만 선택 상태까지 복원하지는
  않았습니다(`gso` 는 1 로 돌아오고 캐럿은 인접 유지). 이 PR 은 캐럿 착지만 맞춥니다.
- **선택 영역(텍스트) 복원** — #3416 의 축입니다. 같은 실측에서 "삭제 undo 는 선택을 복원하고
  타이핑 대체 undo 는 복원하지 않는다" 를 확인했고, 그쪽에서 다룹니다.
