### PR TITLE
fix: #3416 선택 삭제 undo 뒤 지우기 전 선택을 되살린다 — 한컴 실측 반영

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -44,6 +44,17 @@ export interface EditCommand {
    * 시 이 값을 읽어 HF/FN 모드 재진입 + 커서 위치를 복원하고 본문 moveTo 를 건너뛴다.
    */
   editContext?(): EditContext | null;
+  /**
+   * [Task #3416] 이 명령이 실행되기 **직전의 선택 범위**. undo 후 그 선택을 되살리는 데 쓴다.
+   *
+   * 한컴 2024 실측: 선택을 지운 뒤 undo 하면 지우기 전 범위가 그대로 복원되고(캐럿은 선택 끝),
+   * redo 하면 해제된다. 반면 선택 위에 타이핑해서 대체한 경우의 undo 는 복원하지 않는다.
+   * 그래서 이것은 **선택 삭제 계열만 구현한다** — 미구현이면 종전대로 해제된다.
+   *
+   * 반환값은 "그때 그랬다" 는 기록일 뿐 지금 유효하다는 보장이 아니다. 복원하는 쪽이 현재
+   * 문서에서 유효한지 반드시 확인해야 한다(#2339).
+   */
+  selectionBefore?(): { start: DocumentPosition; end: DocumentPosition } | null;
 }
 
 /**
@@ -845,8 +856,10 @@ export class DeleteSelectionCommand implements EditCommand {
    * 양식 모드 선택 삭제가 게이트에서 드롭돼 무언 폐기가 된다.
    */
   private readonly snapshot: SnapshotCommand;
+  private readonly selection: { start: DocumentPosition; end: DocumentPosition };
 
   constructor(start: DocumentPosition, end: DocumentPosition) {
+    this.selection = { start: { ...start }, end: { ...end } };
     // 삭제 후 커서는 선택 시작으로 모이고, undo 후에는 선택 끝으로 되돌아간다.
     this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
       if (isCell(start)) {
@@ -876,6 +889,16 @@ export class DeleteSelectionCommand implements EditCommand {
   }
 
   mergeWith(): null { return null; }
+
+  /**
+   * [Task #3416] 지우기 전 선택 범위. undo 뒤 이 범위를 되살린다.
+   *
+   * undo 가 돌려주는 커서가 이미 `end`(선택 끝)라, 여기에 anchor(`start`)만 더하면 한컴과
+   * 같은 상태가 된다 — 실측에서 undo 후 선택은 `(0,0,18)~(0,0,22)`, 캐럿은 `(0,0,22)` 였다.
+   */
+  selectionBefore(): { start: DocumentPosition; end: DocumentPosition } {
+    return this.selection;
+  }
 
   snapshotResourceCount(): number {
     return this.snapshot.snapshotResourceCount();

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -183,13 +183,37 @@ export class CursorState {
    * `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 이미 anchor 가 있으면 아무것도 하지
    * 않는다. undo 뒤 복원처럼 **범위 전체를 지정해야 하는** 자리에는 쓸 수 없어 따로 둔다.
    *
-   * 호출부가 범위의 유효성을 먼저 확인해야 한다 — 문서에 없는 범위를 세우면 이후 Bold·
-   * Backspace 가 유령 범위를 만지게 된다(#2339 가 막아 둔 그 경로).
+   * **두 끝이 모두 현재 문서에서 확인될 때만 세운다.** anchor/focus 의 소유자가 여기이므로
+   * "선택은 실재하는 위치를 가리킨다"(#2339)를 지키는 것도 여기 몫이다 — 호출부의 선의에
+   * 맡기면 호출부가 하나 늘 때마다 유령 범위가 되살아난다. 세우지 못하면 아무것도 바꾸지
+   * 않고 `false` 를 돌려준다(종전 선택 상태 그대로).
    */
-  selectRange(start: DocumentPosition, end: DocumentPosition): void {
+  selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
+    if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
     this.anchor = { ...start };
     this.position = { ...end };
     this.updateRect();
+    return true;
+  }
+
+  /**
+   * 본문 좌표계에서 **실재가 확인된** 위치인가 (Task #3416).
+   *
+   * 셀 안 위치(`parentParaIndex`)는 `false` 다 — 확인이 중첩 셀 경로(`cellPath`)를 따라가는
+   * 별도 축이라 이 산술로는 실재를 말할 수 없다. "없다" 가 아니라 "이 판정으로는 확인할 수
+   * 없다" 는 뜻이고, 확인할 수 없는 위치를 세우지 않는 것이 #2339 의 판단과 같다.
+   */
+  private isVerifiedBodyPosition(pos: DocumentPosition): boolean {
+    if (pos.parentParaIndex !== undefined) return false;
+    try {
+      const paraCount = this.wasm.getParagraphCount(pos.sectionIndex);
+      if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
+      const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
+      return pos.charOffset >= 0 && pos.charOffset <= len;
+    } catch {
+      // 조회 자체가 실패하면 그 위치를 실재한다고 말할 수 없다.
+      return false;
+    }
   }
 
   /** 선택을 해제한다 */

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -177,6 +177,21 @@ export class CursorState {
     }
   }
 
+  /**
+   * 선택 범위를 명시적으로 세운다 — anchor 는 `start`, 커서는 `end` (Task #3416).
+   *
+   * `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 이미 anchor 가 있으면 아무것도 하지
+   * 않는다. undo 뒤 복원처럼 **범위 전체를 지정해야 하는** 자리에는 쓸 수 없어 따로 둔다.
+   *
+   * 호출부가 범위의 유효성을 먼저 확인해야 한다 — 문서에 없는 범위를 세우면 이후 Bold·
+   * Backspace 가 유령 범위를 만지게 된다(#2339 가 막아 둔 그 경로).
+   */
+  selectRange(start: DocumentPosition, end: DocumentPosition): void {
+    this.anchor = { ...start };
+    this.position = { ...end };
+    this.updateRect();
+  }
+
   /** 선택을 해제한다 */
   clearSelection(): void {
     this.anchor = null;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2661,32 +2661,12 @@ export class InputHandler {
   private restoreSelectionAfterUndo(cmd: EditCommand | null): void {
     const range = cmd?.selectionBefore?.();
     if (!range) return;
-    if (!this.isRestorableBodySelection(range.start, range.end)) return;
+    // 구역을 걸치는 범위는 되살리지 않는다 — 한컴 실측을 한 구역 안에서만 했다. 이건 실재
+    // 여부가 아니라 "어디까지 맞출지" 의 판단이라 여기 남는다.
+    if (range.start.sectionIndex !== range.end.sectionIndex) return;
+    // 범위가 현재 문서에 실재하는지는 `selectRange` 가 판정하고 거절한다(#2339 유령 범위
+    // 차단은 anchor/focus 소유자의 계약이다). 거절되면 해제된 상태 그대로 둔다.
     this.cursor.selectRange(range.start, range.end);
-  }
-
-  /**
-   * 되살려도 되는 본문 선택 범위인가 (Task #3416).
-   *
-   * 셀 안 범위(`parentParaIndex` 보유)는 되살리지 않는다 — 유효성 확인이 중첩 셀 경로
-   * (`cellPath`)를 따라가는 별도 축이고, 한컴 실측도 본문에서만 했다. 확인할 수 없는 범위를
-   * 세우느니 해제로 남기는 쪽이 #2339 의 판단과 같다.
-   */
-  private isRestorableBodySelection(start: DocumentPosition, end: DocumentPosition): boolean {
-    if (start.parentParaIndex !== undefined || end.parentParaIndex !== undefined) return false;
-    if (start.sectionIndex !== end.sectionIndex) return false;
-    try {
-      const paraCount = this.wasm.getParagraphCount(start.sectionIndex);
-      for (const pos of [start, end]) {
-        if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
-        const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
-        if (pos.charOffset < 0 || pos.charOffset > len) return false;
-      }
-    } catch {
-      // 조회 자체가 실패하면 그 범위를 유효하다고 말할 수 없다.
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2523,6 +2523,9 @@ export class InputHandler {
       this.resetDerivedStateAfterHistoryJump();
       // [Task #2337] 방금 되돌린 커맨드가 HF/FN 편집이면 그 커서 모드로 복원(본문 moveTo 대신).
       this.restoreEditContextAfterHistory(this.history.peekRedoTop(), newPos);
+      // [Task #3416] 그 위에 "지우기 전 선택" 을 되살린다 — 커서 위치가 정해진 뒤라야
+      // anchor 만 더해 범위가 완성된다. redo 쪽에는 두지 않는다(한컴도 redo 는 해제).
+      this.restoreSelectionAfterUndo(this.history.peekRedoTop());
       this.afterEdit();
     }
   }
@@ -2641,6 +2644,49 @@ export class InputHandler {
     this.cellSelectionRenderer?.clear();
     // [#2339] 외부 위치-기반 파생 상태(find currentHit 등)를 구독으로 정리하는 확장점.
     this.eventBus.emit('history-jumped');
+  }
+
+  /**
+   * [Task #3416] undo 뒤 "지우기 전 선택" 을 되살린다.
+   *
+   * 한컴 2024 실측 — 선택을 지우고 undo 하면 지우기 전 범위가 그대로 복원되고(캐럿은 선택 끝),
+   * redo 하면 해제된다. 선택 위에 타이핑해 대체한 경우의 undo 는 복원하지 않는다. 그래서 이
+   * 복원은 `selectionBefore()` 를 구현한 커맨드(선택 삭제)에만 걸리고, 나머지는
+   * `resetDerivedStateAfterHistoryJump` 의 해제가 그대로 최종 상태다.
+   *
+   * **복원 전에 현재 문서에서 유효한 범위인지 반드시 확인한다.** #2339 가 해제를 넣은 이유가
+   * 유령 범위이기 때문이다 — 문서에 없는 anchor/focus 를 세우면 이후 Bold·Backspace 가 본 적
+   * 없는 범위를 만진다. 유효하지 않으면 해제된 상태로 둔다(종전 동작).
+   */
+  private restoreSelectionAfterUndo(cmd: EditCommand | null): void {
+    const range = cmd?.selectionBefore?.();
+    if (!range) return;
+    if (!this.isRestorableBodySelection(range.start, range.end)) return;
+    this.cursor.selectRange(range.start, range.end);
+  }
+
+  /**
+   * 되살려도 되는 본문 선택 범위인가 (Task #3416).
+   *
+   * 셀 안 범위(`parentParaIndex` 보유)는 되살리지 않는다 — 유효성 확인이 중첩 셀 경로
+   * (`cellPath`)를 따라가는 별도 축이고, 한컴 실측도 본문에서만 했다. 확인할 수 없는 범위를
+   * 세우느니 해제로 남기는 쪽이 #2339 의 판단과 같다.
+   */
+  private isRestorableBodySelection(start: DocumentPosition, end: DocumentPosition): boolean {
+    if (start.parentParaIndex !== undefined || end.parentParaIndex !== undefined) return false;
+    if (start.sectionIndex !== end.sectionIndex) return false;
+    try {
+      const paraCount = this.wasm.getParagraphCount(start.sectionIndex);
+      for (const pos of [start, end]) {
+        if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
+        const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
+        if (pos.charOffset < 0 || pos.charOffset > len) return false;
+      }
+    } catch {
+      // 조회 자체가 실패하면 그 범위를 유효하다고 말할 수 없다.
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -19,8 +19,9 @@ import { functionBodyFrom } from './support/source-guard.ts';
 //  Redo 는 선택을 해제한다(삭제 직후 상태).
 //
 // 그래서 복원은 **선택 삭제 계열만** 이고, 나머지는 #2339 의 해제가 그대로 최종 상태다.
-// 그리고 복원 전에 현재 문서에서 유효한 범위인지 확인해야 한다 — #2339 가 해제를 넣은 이유가
-// 유령 범위이기 때문이다.
+// 그리고 실재하지 않는 범위는 서지 않아야 한다 — #2339 가 해제를 넣은 이유가 유령 범위이기
+// 때문이다. 그 판정은 anchor/focus 소유자인 `CursorState.selectRange` 가 하고, 호출부는
+// "어디까지 맞출지"(구역·커맨드 종류)만 정한다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
@@ -60,15 +61,22 @@ test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다
     '해제 뒤에 복원해야 한다');
 });
 
-test('[#3416] 복원 전에 유효성을 확인한다 (#2339 유령 범위 방지)', () => {
+test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정된다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const select = functionBodyFrom(cursor, 'selectRange(start: DocumentPosition, end: DocumentPosition)');
+
+  // 확인이 대입보다 먼저여야 한다 — 뒤면 유령 범위가 이미 선 뒤다.
+  const idxCheck = select.indexOf('isVerifiedBodyPosition');
+  const idxAssign = select.indexOf('this.anchor =');
+  assert.ok(idxCheck !== -1 && idxAssign !== -1 && idxCheck < idxAssign,
+    '두 끝을 확인한 뒤에 anchor/position 을 세워야 한다');
+  assert.match(select, /return false/, '세우지 못하면 그 사실을 돌려줘야 한다');
+
+  // 호출부에 같은 판정을 두면 계약이 두 곳으로 갈라진다 — 그때부터 한쪽만 고쳐진다.
   const handler = src('src/engine/input-handler.ts');
   const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
-  assert.match(restore, /isRestorableBodySelection\(/, '유효성 확인을 거쳐야 한다');
-  // 확인보다 먼저 selectRange 를 부르면 유령 범위가 그대로 선다.
-  const idxCheck = restore.indexOf('isRestorableBodySelection');
-  const idxSelect = restore.indexOf('selectRange');
-  assert.ok(idxCheck !== -1 && idxSelect !== -1 && idxCheck < idxSelect,
-    '확인이 selectRange 보다 먼저여야 한다');
+  assert.doesNotMatch(restore, /getParagraphCount|getParagraphLength|parentParaIndex/,
+    '실재 판정을 호출부가 되풀이하면 안 된다');
 });
 
 test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
@@ -79,43 +87,61 @@ test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향�
   assert.match(reset, /exitPictureObjectSelection\(\)/);
 });
 
-test('[#3416] 범위 유효성 판정 — 실제 동작', async () => {
+test('[#3416] selectRange 는 실재하지 않는 범위를 거절한다 — 실제 동작', async () => {
   const vite = await createServer({
     root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
   });
   try {
-    const mod = await vite.ssrLoadModule('/src/engine/input-handler.ts');
-    const InputHandler: any = mod.InputHandler;
-    // 판정은 wasm 조회에만 의존하므로 프로토타입 메서드를 최소 컨텍스트로 부른다.
-    const check = InputHandler.prototype['isRestorableBodySelection'];
-    assert.equal(typeof check, 'function', 'isRestorableBodySelection 이 있어야 함');
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const selectRange = CursorState.prototype.selectRange;
 
-    const ctx = (paraCount: number, len: number) => ({
-      wasm: {
-        getParagraphCount: () => paraCount,
-        getParagraphLength: () => len,
+    // 판정은 wasm 조회에만 의존한다. 생성자는 렌더러까지 요구하므로 프로토타입 위에
+    // 최소 상태만 얹어 부른다(내부 helper 도 프로토타입에서 찾아야 하므로 Object.create).
+    const ctx = (paraCount: number, len: number) => Object.assign(
+      Object.create(CursorState.prototype),
+      {
+        anchor: null, position: null,
+        wasm: { getParagraphCount: () => paraCount, getParagraphLength: () => len },
+        updateRect() { /* 기하 갱신은 이 판정과 무관 */ },
       },
-    });
+    );
     const p = (para: number, off: number) => ({ sectionIndex: 0, paragraphIndex: para, charOffset: off });
 
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 6)), true, '문서 안 범위는 복원 가능');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(5, 6)), false, '문단이 사라졌으면 불가');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 99)), false, '오프셋이 길이를 넘으면 불가');
-    assert.equal(
-      check.call(ctx(3, 10), p(0, 2), { sectionIndex: 1, paragraphIndex: 0, charOffset: 1 }),
-      false,
-      '구역이 다르면 불가',
-    );
-    // 셀 안 범위는 확인 축이 달라 복원하지 않는다.
-    assert.equal(
-      check.call(ctx(3, 10), { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)),
-      false,
-      '셀 범위는 복원 대상이 아니다',
-    );
-    // 조회가 던지면 유효하다고 말할 수 없다.
-    const throwing = { wasm: { getParagraphCount: () => { throw new Error('gone'); } } };
-    assert.equal(check.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 불가로 판정');
+    const ok = ctx(3, 10);
+    assert.equal(selectRange.call(ok, p(0, 2), p(0, 6)), true, '문서 안 범위는 세운다');
+    assert.deepEqual(ok.anchor, p(0, 2), 'anchor 는 start');
+    assert.deepEqual(ok.position, p(0, 6), '커서는 end');
+
+    // 거절할 때는 **아무것도 바꾸지 않아야** 한다 — 반쯤 세우면 그게 유령 범위다.
+    for (const [why, start, end] of [
+      ['문단이 사라졌으면', p(0, 2), p(5, 6)],
+      ['오프셋이 길이를 넘으면', p(0, 2), p(0, 99)],
+      ['셀 안 위치는', { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)],
+    ] as Array<[string, any, any]>) {
+      const c = ctx(3, 10);
+      assert.equal(selectRange.call(c, start, end), false, `${why} 거절한다`);
+      assert.equal(c.anchor, null, `${why} anchor 를 건드리지 않는다`);
+      assert.equal(c.position, null, `${why} 커서를 건드리지 않는다`);
+    }
+
+    // 조회가 던지면 실재한다고 말할 수 없다.
+    const throwing = Object.assign(Object.create(CursorState.prototype), {
+      anchor: null, position: null,
+      wasm: { getParagraphCount: () => { throw new Error('gone'); } },
+      updateRect() {},
+    });
+    assert.equal(selectRange.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 거절');
+    assert.equal(throwing.anchor, null, '조회 실패에도 상태를 건드리지 않는다');
   } finally {
     await vite.close();
   }
+});
+
+test('[#3416] 구역을 걸치는 범위는 복원 대상이 아니다 (실측 범위 밖)', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /sectionIndex !== range\.end\.sectionIndex/, '구역 정책은 호출부가 갖는다');
+  const idxPolicy = restore.indexOf('sectionIndex !==');
+  const idxSelect = restore.indexOf('selectRange');
+  assert.ok(idxPolicy !== -1 && idxPolicy < idxSelect, '정책 판정이 먼저다');
 });

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { functionBodyFrom } from './support/source-guard.ts';
+
+// [#3416] undo 뒤 "지우기 전 선택" 복원.
+//
+// 한컴 오피스 2024 실측(COM, `GetSelectedPosBySet`):
+//
+//  | 연산                | Undo 후 선택                          |
+//  |---------------------|---------------------------------------|
+//  | 선택 삭제(Delete)   | (0,0,18)~(0,0,22) — 지우기 전 범위 복원 |
+//  | 선택 위 타이핑 대체 | 없음 — 캐럿만 선택 끝(0,0,19)          |
+//  | 선택 서식(Bold)     | 애초에 유지(잃지 않음)                 |
+//
+//  Redo 는 선택을 해제한다(삭제 직후 상태).
+//
+// 그래서 복원은 **선택 삭제 계열만** 이고, 나머지는 #2339 의 해제가 그대로 최종 상태다.
+// 그리고 복원 전에 현재 문서에서 유효한 범위인지 확인해야 한다 — #2339 가 해제를 넣은 이유가
+// 유령 범위이기 때문이다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#3416] 선택 삭제 커맨드가 지우기 전 범위를 들고 있다', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const { DeleteSelectionCommand } = await vite.ssrLoadModule('/src/engine/command.ts');
+    const start = { sectionIndex: 0, paragraphIndex: 0, charOffset: 18 };
+    const end = { sectionIndex: 0, paragraphIndex: 0, charOffset: 22 };
+    const cmd: any = new DeleteSelectionCommand(start, end);
+
+    assert.deepEqual(cmd.selectionBefore(), { start, end });
+
+    // 호출부가 넘긴 객체를 그대로 들고 있으면 이후 변형이 기록을 오염시킨다.
+    start.charOffset = 999;
+    assert.equal(cmd.selectionBefore().start.charOffset, 18, '복사해서 보관해야 한다');
+  } finally {
+    await vite.close();
+  }
+});
+
+test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const undo = functionBodyFrom(handler, 'private handleUndo()');
+  const redo = functionBodyFrom(handler, 'private handleRedo()');
+
+  assert.match(undo, /this\.restoreSelectionAfterUndo\(/, 'undo 는 복원을 시도해야 한다');
+  assert.doesNotMatch(redo, /restoreSelectionAfterUndo/, '한컴은 redo 에서 선택을 해제한다');
+
+  // 해제가 먼저, 복원이 나중이어야 한다 — 순서가 뒤집히면 복원한 선택을 곧바로 지운다.
+  const idxReset = undo.indexOf('resetDerivedStateAfterHistoryJump');
+  const idxRestore = undo.indexOf('restoreSelectionAfterUndo');
+  assert.ok(idxReset !== -1 && idxRestore !== -1 && idxReset < idxRestore,
+    '해제 뒤에 복원해야 한다');
+});
+
+test('[#3416] 복원 전에 유효성을 확인한다 (#2339 유령 범위 방지)', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /isRestorableBodySelection\(/, '유효성 확인을 거쳐야 한다');
+  // 확인보다 먼저 selectRange 를 부르면 유령 범위가 그대로 선다.
+  const idxCheck = restore.indexOf('isRestorableBodySelection');
+  const idxSelect = restore.indexOf('selectRange');
+  assert.ok(idxCheck !== -1 && idxSelect !== -1 && idxCheck < idxSelect,
+    '확인이 selectRange 보다 먼저여야 한다');
+});
+
+test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const reset = functionBodyFrom(handler, 'private resetDerivedStateAfterHistoryJump');
+  assert.match(reset, /exitBlockSelectionMode\(\)/, '#2339 의 해제가 유지돼야 한다');
+  assert.match(reset, /exitCellSelectionMode\(\)/);
+  assert.match(reset, /exitPictureObjectSelection\(\)/);
+});
+
+test('[#3416] 범위 유효성 판정 — 실제 동작', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const mod = await vite.ssrLoadModule('/src/engine/input-handler.ts');
+    const InputHandler: any = mod.InputHandler;
+    // 판정은 wasm 조회에만 의존하므로 프로토타입 메서드를 최소 컨텍스트로 부른다.
+    const check = InputHandler.prototype['isRestorableBodySelection'];
+    assert.equal(typeof check, 'function', 'isRestorableBodySelection 이 있어야 함');
+
+    const ctx = (paraCount: number, len: number) => ({
+      wasm: {
+        getParagraphCount: () => paraCount,
+        getParagraphLength: () => len,
+      },
+    });
+    const p = (para: number, off: number) => ({ sectionIndex: 0, paragraphIndex: para, charOffset: off });
+
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 6)), true, '문서 안 범위는 복원 가능');
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(5, 6)), false, '문단이 사라졌으면 불가');
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 99)), false, '오프셋이 길이를 넘으면 불가');
+    assert.equal(
+      check.call(ctx(3, 10), p(0, 2), { sectionIndex: 1, paragraphIndex: 0, charOffset: 1 }),
+      false,
+      '구역이 다르면 불가',
+    );
+    // 셀 안 범위는 확인 축이 달라 복원하지 않는다.
+    assert.equal(
+      check.call(ctx(3, 10), { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)),
+      false,
+      '셀 범위는 복원 대상이 아니다',
+    );
+    // 조회가 던지면 유효하다고 말할 수 없다.
+    const throwing = { wasm: { getParagraphCount: () => { throw new Error('gone'); } } };
+    assert.equal(check.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 불가로 판정');
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
관련 이슈: #3416

## 문제

undo 뒤 선택 영역이 복원되지 않습니다. 글자를 선택해 지운 뒤 Ctrl+Z 를 누르면 글자는 돌아오지만
선택은 풀린 채입니다. 한컴은 이 경우 선택 상태까지 되돌립니다.

## 원인

#2339 가 히스토리 점프 때 선택을 **해제**합니다(`input-handler.ts` 의
`resetDerivedStateAfterHistoryJump`). 이유가 있었습니다 — 되돌리기로 문서가 줄면 anchor/focus 가
유령 범위가 되어 이후 Bold·Backspace 가 WASM 예외나 본 적 없는 범위의 무언 삭제를 일으켰습니다.

**해제는 안전을 위한 올바른 최소 조치였고, 이 PR 은 그 위에 얹는 향상입니다.** 결함 수정이
아니라 한컴 정합 enhancement 라는 이슈 본문의 규정을 그대로 따릅니다.

## 한컴 오라클 — 실측

이슈 본문이 "한컴 실제 동작을 먼저 확인한다 — 되돌린 뒤 선택이 '삭제 전 범위' 인지 '삽입된 내용
범위' 인지, redo 시에는 어떤지" 를 선결 조건으로 두었습니다. 한컴 오피스 2024(Hwp 13.0) COM
자동화(`GetSelectedPosBySet`)로 쟀습니다.

| 단계 | 캐럿 | 선택 |
|---|---|---|
| 선택 직후(C~F) | (0,0,22) | (0,0,18)~(0,0,22) |
| 삭제 후 | (0,0,18) | 없음 |
| **Undo 후** | **(0,0,22)** | **(0,0,18)~(0,0,22)** |
| **Redo 후** | (0,0,18) | **없음** |

**"삭제 전 범위" 가 답이고, 캐럿은 선택 끝입니다. redo 는 해제합니다.**

다만 모든 undo 가 복원하는 것은 아닙니다.

| 연산 | Undo 후 선택 |
|---|---|
| 선택 삭제 | **삭제 전 범위 복원** |
| 선택 위에 타이핑(대체) | **복원 안 함** — 캐럿만 선택 끝(0,0,19) |
| 선택 서식(Bold) | 애초에 선택이 유지됨(잃지 않으므로 복원 개념 없음) |

## 변경

복원을 **선택 삭제 계열에만** 겁니다.

`EditCommand` 에 `selectionBefore?(): { start, end } | null` 을 두고 `DeleteSelectionCommand` 만
구현합니다. 미구현 커맨드는 종전대로 해제되므로, 타이핑 대체 undo 는 한컴과 같이 복원되지
않습니다. 이미 있는 `editContext?()` + `restoreEditContextAfterHistory` 와 같은 모양입니다.

`DeleteSelectionCommand` 는 **이미 undo 시 커서를 선택 끝으로 돌려줍니다**("삭제 후 커서는 선택
시작으로 모이고, undo 후에는 선택 끝으로 되돌아간다" — 기존 주석). 그래서 anchor 만 더하면 한컴과
같은 상태가 됩니다. 새로 잡을 상태가 없습니다.

```ts
// handleUndo
this.resetDerivedStateAfterHistoryJump();                     // #2339 해제 — 그대로 유지
this.restoreEditContextAfterHistory(this.history.peekRedoTop(), newPos);
this.restoreSelectionAfterUndo(this.history.peekRedoTop());   // 그 위에 얹는다
```

`handleRedo` 에는 넣지 않습니다 — 한컴도 redo 는 해제합니다.

### 실재하지 않는 범위는 `selectRange` 가 거절합니다

확인 없이 세우면 유령 범위가 그대로 돌아옵니다 — #2339 가 해제를 넣은 이유입니다. 그 확인을
**anchor/focus 의 소유자인 `CursorState.selectRange` 안**에 둡니다.

```ts
selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
  if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
  this.anchor = { ...start };
  this.position = { ...end };
  this.updateRect();
  return true;
}
```

- 두 끝이 확인될 때만 세우고, 못 세우면 **아무것도 바꾸지 않고** `false` 를 돌려줍니다.
  반쯤 세우는 상태가 곧 유령 범위이므로 거절 경로는 anchor·position 을 건드리지 않습니다.
- 문단이 아직 있는지, 오프셋이 문단 길이 안인지 보고, 조회 자체가 던지면 실재한다고 말할 수
  없으므로 거절합니다.
- 셀 안 위치(`parentParaIndex`)는 확인이 중첩 셀 경로(`cellPath`)를 따라가는 별도 축이라 이
  산술로는 실재를 말할 수 없어 거절합니다. **"없다" 가 아니라 "이 판정으로는 확인할 수 없다"**
  이고, 확인 못 한 위치를 세우지 않는 것이 #2339 의 판단과 같습니다.

처음에는 이 확인을 호출부(`restoreSelectionAfterUndo`)에 두고 `selectRange` 주석에 "호출부가
먼저 확인해야 한다" 를 적었습니다. 계약을 소비자가 지키는 형태여서 되돌렸습니다 — 호출부가
하나인 동안에는 옳게 동작하지만 두 번째 호출부에서 조용히 무너지고, 소스 가드도 불변식이 아니라
그 한 호출부의 순서만 잠급니다. #3438 에서 정리된 **"생산자가 판정하고 결과로 알린다"** 규약
(`update_style` 의 `false`, `SnapshotCommand` 의 `null` 과 동형)에 맞춥니다.

호출부에 남는 것은 실재 여부가 아니라 **어디까지 맞출지의 판단**뿐입니다 — 구역을 걸치는 범위는
한컴 실측을 한 구역 안에서만 했으므로 복원하지 않습니다.

### `cursor.selectRange(start, end)` 를 따로 둔 이유

기존 `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 **이미 anchor 가 있으면 아무것도 하지
않습니다.** 범위 전체를 지정해야 하는 이 자리에는 쓸 수 없습니다.

### 테스트

`rhwp-studio/tests/issue-3416-selection-restore.test.ts` (6개)

- 커맨드가 지우기 전 범위를 들고 있고, **호출부 객체를 복사해 보관**한다(이후 변형이 기록을
  오염시키지 않는다)
- undo 경로가 복원하고 redo 경로에는 없다 + **해제 뒤에 복원**하는 순서(뒤집히면 복원한 선택을
  곧바로 지운다)
- 유효성 판정이 호출부가 아니라 `selectRange` **안**에 있다 — 확인이 대입보다 먼저이고,
  호출부가 같은 판정을 되풀이하지 않는다(계약이 두 곳으로 갈라지면 한쪽만 고쳐진다)
- #2339 의 해제가 그대로 남아 있다
- `selectRange` 의 실제 동작 — 문서 안 범위는 세우고, 문단 사라짐 / 오프셋 초과 / 셀 안 위치 /
  조회 실패는 거절하며 **거절할 때 anchor·position 을 건드리지 않는다**
- 구역을 걸치는 범위는 호출부 정책으로 복원 대상이 아니다

## 검증

devel `61baa6783` 기준.

- **수정 전 실패 증명**: 이 PR 의 테스트를 devel 소스에 그대로 걸면 **6개 중 5개 실패**
  (통과하는 1개는 "#2339 의 해제가 유지되는가" — 이 PR 이 그것을 건드리지 않는다는 확인이라
  양쪽에서 통과하는 것이 맞습니다). 이 브랜치에서 6개 전부 통과.
- `npm --prefix rhwp-studio run test` — **1012 tests, 0 fail** (skipped 1 은 기존 테스트).
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

계약을 소유자로 옮긴 두 번째 커밋은 **복원되는 범위를 바꾸지 않습니다** — 판정이 사는 층만
옮겼고, 위 6개 테스트가 그 전후 모두에서 최종 동작을 잠급니다.

한컴 측정 스크립트는 임시라 커밋하지 않았습니다. 재현은 `HWPFrame.HwpObject` COM 으로
`FileNew` → `InsertText("ABCDEFGHIJ")` → `MoveDocBegin`/`MoveRight`×2/`MoveSelRight`×4 →
`Run("Delete"/"Undo"/"Redo")` 이고, 선택은 `GetSelectedPosBySet(a, b)`(둘 다
`CreateSet("ListParaPos")`), 캐럿은 `GetPosBySet()` 로 읽습니다 — `GetPos`/`GetSelectedPos` 는
out-parameter 라 스크립트에서 직접 호출할 수 없습니다.

## 범위 외

- **셀 안 선택 범위** — 위 이유로 해제로 남깁니다. 오라클도 없습니다.
- **선택 위 타이핑 대체의 복원** — 한컴이 복원하지 않으므로 맞추지 않습니다.
- **개체 선택 복원** — 위치 기반 ref 라 축이 다릅니다(#2303 계열). #3351 실측에서 한컴은
  undo 후 개체가 돌아와도 **선택 상태까지 복원하지는 않았습니다**(`gso` 는 1 로 돌아오고 캐럿은
  개체 인접 유지).
- **F3 확장 단계·F5 셀 블록** — 이슈 본문이 같은 규약을 요구하지만, 이 PR 이 답을 가진 것은
  선택 삭제뿐입니다. 두 모드의 한컴 동작은 재지 않았습니다.
