### PR TITLE
fix(renderer): 부모 셀보다 넓게 저장된 중첩표를 부모 폭에서 자른다 (#5587)

### DIFF
--- a/mydocs/report/task_m100_5587_report.md
+++ b/mydocs/report/task_m100_5587_report.md
@@ -1,0 +1,144 @@
+# Task M100-5587 완료 보고서 — 부모보다 넓은 중첩표 클리핑
+
+- Issue: #5587 (`[renderer] 부모보다 넓은 중첩표를 클리핑하지 않아 점선 상자가 표 밖으로 삐져나온다 (00387)`)
+- 브랜치: `fix/issue-5587-nested-table-clip` (base `stream/devel` 61baa6783)
+- 변경: `src/renderer/layout/table_layout.rs`, `tests/cases/issue_5587_overwide_nested_table_clip.rs`
+- 작성일: 2026-08-19 KST
+
+## 1. 증상과 재현
+
+`admrul_downloads/기후에너지환경부/3227255_[별지 2] 직무윤리 서약서…hwpx` (코퍼스 docid 00387)
+1쪽의 점선 상자(중첩표)가 바깥 표 오른쪽 경계를 넘어 그려졌다.
+
+| 요소 | 저장 폭 | px(96dpi) | 렌더 오른쪽 끝 |
+| --- | --- | --- | --- |
+| 바깥 표 셀 | 45,359HU | 604.8 | 680.37 |
+| 중첩표(점선 상자) | 46,490HU | 619.9 | **704.88** |
+
+즉 원본이 이미 부모보다 15.1px 넓게 저장돼 있고, 렌더는 그 선언 폭을 그대로 그려
+부모 오른쪽으로 24.5px 삐져나왔다.
+
+## 2. 원인
+
+패인트 경로가 아니라 **셀 clip 확장**이 원인이다.
+
+`src/renderer/layout/table_layout.rs`의
+`extend_clipped_cell_horizontal_clip_to_nested_table_borders` 는 42065(#2007) 계약을 위해
+존재한다 — 저장 폭이 부모 셀 **이하**인 중첩표가 셀 왼쪽 패딩만큼 밀려 오른쪽 외곽
+테두리를 host clip 밖에 두면, 그 테두리가 통째로 사라지므로 clip 을 테두리까지 넓힌다.
+
+이 확장에 "부모보다 넓게 저장된 표" 예외가 없었다. 00387에서는 host 셀 clip 이
+604.79px → 629.54px 로 넓어져(SVG `cell-clip-26`) 점선 4변이 부모 밖까지 그대로 칠해졌다.
+셀 clip 은 SVG·Canvas·paint 공통 경로라서 렌더러 전체가 같은 증상을 보였다.
+
+두 형상은 저장 폭 하나로 갈린다 (repo 픽스처 실측):
+
+| 문서 | 부모 셀 | 중첩표 | 관계 |
+| --- | --- | --- | --- |
+| `issue2007_nested_cell_pagination_42065.hwp` | — | — | 부모보다 넓은 중첩표 **0건** (패딩 이동만) |
+| `issue1994_behindtext_table_20200830.hwp` | 34,161HU | 35,144HU | 넓게 저장 (+13.1px) |
+| 00387 | 45,359HU | 46,490HU | 넓게 저장 (+15.1px) |
+
+## 3. 수정
+
+직접 자식 표의 bbox 폭이 host clip 폭보다 크면(`NESTED_OVER_WIDE_EPSILON_PX = 0.5`)
+clip 확장 대상에서 제외한다. host viewport 를 그대로 두면 셀 clip 이 중첩표의 테두리와
+내용을 부모 경계에서 자른다. #2007 노출 경로와 중첩 셀 content 클램프는 그대로 둔다.
+
+레이아웃·줄바꿈·쪽수는 건드리지 않는다 — 페인트 범위만 좁힌다.
+
+## 4. 한컴 정답지
+
+00387 자체의 한컴 PDF 는 없다. 대신 **부모보다 넓게 저장된 중첩표**를 가진 문서 중 한컴
+PDF 가 함께 있는 두 건으로 방향을 확인했다.
+
+### 4.1 코퍼스 오라클 쌍 (문서 id 36301151) — 수정 후 clip 이 한컴 clip 과 일치
+
+부모 셀 48,194HU, 중첩표 48,440HU(+246HU). 같은 문서의 한컴 PDF(`hwpdocs_10k_share/_oracle_pdf_2022/…`, Hancom PDF 1.3.0.550) 1쪽에서 이 중첩표가 놓인 구간의 clip
+사각형은 `mutool draw -F trace` 기준 **x = 59.49 ~ 541.15pt** 다.
+
+| | rhwp host 셀 clip (px) | 오른쪽 끝(pt) | 한컴 clip 오른쪽(pt) | 차 |
+| --- | --- | --- | --- | --- |
+| 수정 전 | 79.36 + 650.61 | 547.48 | 541.15 | **+6.33pt** |
+| 수정 후 | 79.36 + 642.59 | 541.46 | 541.15 | +0.31pt |
+
+수정 전 페인트 viewport 는 한컴보다 6.3pt 넓었고, 수정 후 0.3pt(0.4px) 안으로 맞는다.
+이 문서는 그 구간에 칠할 것이 없어 잉크는 변하지 않는다(SVG clip 값만 변경).
+
+### 4.2 `issue1994_behindtext_table_20200830.hwp` — 부모 밖에는 아무것도 없다
+
+repo 픽스처(부모 셀 34,161HU, 중첩표 35,144HU)와 그 한컴 출력
+`samples/issue1994/issue_1994.pdf`(Creator: Hwp 2020 11.0.0.9083). host 셀 오른쪽은
+512.2px = 384.15pt, 중첩표 선언 폭 오른쪽은 529.1px = 396.8pt 다. 1쪽 전체 경로를 뽑으면
+x ∈ [391.5pt, 402pt] 구간에 stroke·clip·glyph 가 **하나도 없다** — 한컴은 중첩표 선언 폭의
+오른쪽 끝에 아무것도 그리지 않는다. 다만 이 문서는 그 구간에 그릴 테두리 자체가 없어서
+"한컴이 잘라낸다"까지 증명하지는 못한다. 새 회귀 테스트가 고정하는 값이 이 실측이다.
+
+## 5. 검증
+
+| 게이트 | 결과 |
+| --- | --- |
+| `issue_5587_overwide_nested_table_clip` (신규) | 통과 — 수정 원복 시 실패(가드 유효) |
+| `issue_2007_nested_cell_pagination` | 15건 통과 (테두리 노출 계약 유지) |
+| `cargo test --profile release-test --lib` | 3,893건 통과 |
+| `cargo test --profile release-test --tests --no-fail-fast` | 49 suite ok / 2 실패 — `issue_4179_…`·`issue_4128_…` 두 perf 카운터 테스트. **둘 다 수정 없는 baseline 에서 동일하게 실패**하고 단독 실행은 통과(아래 §7) |
+| `cargo fmt --all -- --check` | 통과 |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| Native Skia 3종 | **미실행** — 이 호스트에 `freetype`/`fontconfig` 개발 라이브러리가 없어 `--features native-skia` 링크 실패 (`rust-lld: unable to find library -lfreetype`) |
+| Docker WASM | **미실행** — 표준 환경 없음 |
+
+### 10k 코퍼스 전후 스윕
+
+`/home/planet/hwpdocs_10k_share` 10,000건 중 9,995건 검사(경로 인용 실패 4건, 파싱 패닉 1건 제외).
+
+| 항목 | 값 |
+| --- | --- |
+| 부모 셀보다 넓게 저장된 중첩표를 가진 문서 | **71건 (0.71%)** |
+| 수정 전후 SVG 가 달라진 문서 | 35건 |
+| 그중 픽셀(잉크)이 달라진 문서 | **20건 / 21쪽** |
+| 제거된 잉크 | **6,709px** |
+| 추가된 잉크 | **0px** |
+
+전부 부모 표 오른쪽 경계 **밖**에서만 사라졌다. 잉크가 늘어난 픽셀은 한 점도 없다.
+표본 육안 확인(overlay, 빨강=제거): 부모 세로 테두리 오른쪽으로 튀어나온 가로 테두리
+꼬리와 중첩표 오른쪽 세로선만 사라지고 본문·표 내용은 그대로다.
+
+## 6. 하지 않은 것
+
+- 중첩표 축소(폭 스케일)·재조판. 정답지에 근거가 없고 줄바꿈·쪽수를 흔든다.
+- 세로 방향 클리핑. RowBreak continuation 이 다음 쪽 내용을 clip 아래에 의도적으로
+  남기는 기존 계약과 충돌한다.
+- 이슈가 함께 지적한 **폭 583px 빈 TextRun**(x=377.3 → 오른쪽 끝 960.3, 쪽 폭 밖).
+  칠하는 내용이 없고, 이제 host 셀 clip(604.79px) 안에서 잘리므로 이 결함의 경로가
+  아니다. 렌더 트리 bbox 위생 문제로 별도 추적이 필요하다.
+
+## 7. 기존 실패 2건 (이 변경과 무관)
+
+- `issue_4179_cursor_rect_text_host_para_pages::text_host_para_cursor_rect_builds_few_page_trees`
+- `issue_4128_cell_cursor_page_narrowing::deep_cell_cursor_queries_build_few_page_trees`
+
+둘 다 `perf_counters` 의 page tree build 횟수 상한을 보는 테스트다. 이 호스트에
+`cargo-nextest` 가 없어 묶음 suite 를 `cargo test` 로 **한 프로세스에서 병렬** 실행하면
+다른 테스트의 빌드 횟수가 전역 카운터에 섞인다(측정값이 실행마다 13·18·27 로 흔들린다).
+테스트 주석의 "파일당 테스트 1개" 전제가 generated suite 묶음에서 깨진 것으로, CI 의
+nextest(프로세스 분리) 실행에서는 발생하지 않는다.
+
+- 단독 실행: 둘 다 통과
+- 수정을 원복한 baseline 에서 같은 명령: 둘 다 동일하게 실패 — 이 변경과 무관함을 확인
+
+## 8. 재현 명령
+
+```bash
+# 증상/수정 확인 (부모 표 오른쪽 = 680.37px)
+rhwp export-svg "<00387>.hwpx" -o out/
+grep -o '<clipPath id="cell-clip-26[^/]*/>' out/00387.svg   # width 604.79 (수정 후)
+
+# 회귀
+node scripts/run-rust-test.mjs --cargo-test issue_5587_overwide_nested_table_clip -- \
+  --profile release-test --target-dir target/pr-review
+node scripts/run-rust-test.mjs --cargo-test issue_2007_nested_cell_pagination -- \
+  --profile release-test --target-dir target/pr-review
+
+# 한컴 정답지 재계산
+mutool draw -F trace -o - samples/issue1994/issue_1994.pdf 1 | grep -E 'x="39[1-9]|x="40[0-2]'
+```

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -202,6 +202,14 @@ fn caption_has_topbottom_picture(caption: &Caption) -> bool {
 /// horizontal viewport so the border exception cannot reveal a text tail.
 /// The vertical correction is separately bounded to a terminal border that
 /// misses the clip by at most six pixels.
+///
+/// [#5587] The exposure is for a nested table whose *stored width* still fits
+/// the host cell and only leaves the clip because it starts after the cell's
+/// left padding (42065: nested width <= host cell width).  A nested table that
+/// declares a width wider than its host cell is a different source shape —
+/// 00387's dotted 46,490HU box inside a 45,359HU cell — and 한글 paints it cut
+/// at the parent's edge.  Widening the clip for that shape would drag the
+/// dotted frame past the outer table border, so it keeps the host viewport.
 fn extend_clipped_cell_horizontal_clip_to_nested_table_borders(cell_node: &mut RenderNode) {
     let RenderNodeType::TableCell(cell_meta) = &cell_node.node_type else {
         return;
@@ -212,6 +220,7 @@ fn extend_clipped_cell_horizontal_clip_to_nested_table_borders(cell_node: &mut R
 
     let host_clip_left = cell_node.bbox.x;
     let host_clip_right = cell_node.bbox.x + cell_node.bbox.width;
+    let host_clip_width = host_clip_right - host_clip_left;
     let mut clip_left = host_clip_left;
     let mut clip_right = host_clip_right;
 
@@ -221,40 +230,44 @@ fn extend_clipped_cell_horizontal_clip_to_nested_table_borders(cell_node: &mut R
         }
         let table_left = table_node.bbox.x;
         let table_right = table_node.bbox.x + table_node.bbox.width;
+        // [#5587] 부모 셀보다 넓게 저장된 중첩표는 clip 확장 대상이 아니다.
+        let over_wide = table_node.bbox.width > host_clip_width + NESTED_OVER_WIDE_EPSILON_PX;
         let mut found_outer_vertical_border = false;
 
-        for border_node in &table_node.children {
-            let RenderNodeType::Line(line) = &border_node.node_type else {
-                continue;
-            };
-            // Cell-content lines can be arbitrary.  Only a near-vertical
-            // table edge that sits on the nested table's left/right boundary
-            // is eligible to enlarge the clipping viewport.
-            if (line.x1 - line.x2).abs() > 0.01 || (line.y1 - line.y2).abs() < 1.0 {
-                continue;
+        if !over_wide {
+            for border_node in &table_node.children {
+                let RenderNodeType::Line(line) = &border_node.node_type else {
+                    continue;
+                };
+                // Cell-content lines can be arbitrary.  Only a near-vertical
+                // table edge that sits on the nested table's left/right boundary
+                // is eligible to enlarge the clipping viewport.
+                if (line.x1 - line.x2).abs() > 0.01 || (line.y1 - line.y2).abs() < 1.0 {
+                    continue;
+                }
+                let x = line.x1;
+                let outer_edge_tolerance = (line.style.width + 1.0).max(2.0);
+                if (x - table_left).abs() > outer_edge_tolerance
+                    && (x - table_right).abs() > outer_edge_tolerance
+                {
+                    continue;
+                }
+                let half_stroke = line.style.width / 2.0;
+                clip_left = clip_left.min(x - half_stroke);
+                clip_right = clip_right.max(x + half_stroke);
+                found_outer_vertical_border = true;
             }
-            let x = line.x1;
-            let outer_edge_tolerance = (line.style.width + 1.0).max(2.0);
-            if (x - table_left).abs() > outer_edge_tolerance
-                && (x - table_right).abs() > outer_edge_tolerance
-            {
-                continue;
-            }
-            let half_stroke = line.style.width / 2.0;
-            clip_left = clip_left.min(x - half_stroke);
-            clip_right = clip_right.max(x + half_stroke);
-            found_outer_vertical_border = true;
-        }
 
-        if !found_outer_vertical_border {
-            // 일부 normal/partial 표는 현재 부모 subtree가 최종 edge `Line`을
-            // 붙이기 전에도 직접 child Table bbox를 완성한다(42065 p2-p3). 이
-            // bbox는 table의 물리 stored-width 경계이므로 작은 stroke 여유만
-            // 포함해 가로 clip의 fallback으로 쓸 수 있다. 세로 bbox는 전혀
-            // 확장하지 않아 다음 쪽 continuation tail은 계속 가려진다.
-            const FALLBACK_BORDER_HALF_STROKE_PX: f64 = 1.0;
-            clip_left = clip_left.min(table_left - FALLBACK_BORDER_HALF_STROKE_PX);
-            clip_right = clip_right.max(table_right + FALLBACK_BORDER_HALF_STROKE_PX);
+            if !found_outer_vertical_border {
+                // 일부 normal/partial 표는 현재 부모 subtree가 최종 edge `Line`을
+                // 붙이기 전에도 직접 child Table bbox를 완성한다(42065 p2-p3). 이
+                // bbox는 table의 물리 stored-width 경계이므로 작은 stroke 여유만
+                // 포함해 가로 clip의 fallback으로 쓸 수 있다. 세로 bbox는 전혀
+                // 확장하지 않아 다음 쪽 continuation tail은 계속 가려진다.
+                const FALLBACK_BORDER_HALF_STROKE_PX: f64 = 1.0;
+                clip_left = clip_left.min(table_left - FALLBACK_BORDER_HALF_STROKE_PX);
+                clip_right = clip_right.max(table_right + FALLBACK_BORDER_HALF_STROKE_PX);
+            }
         }
 
         if table_left < host_clip_left - NESTED_FRAGMENT_EDGE_EPSILON_PX
@@ -395,6 +408,9 @@ fn extend_table_horizontal_bbox_to_direct_cell_paint(table_node: &mut RenderNode
 }
 
 const NESTED_FRAGMENT_EDGE_EPSILON_PX: f64 = 0.5;
+/// [#5587] 중첩표가 부모 셀보다 이만큼 넘게 넓으면 "부모보다 넓게 저장된 표"로
+/// 본다. 42065의 padding 이동 케이스는 저장 폭이 부모 셀 이하라 걸리지 않는다.
+const NESTED_OVER_WIDE_EPSILON_PX: f64 = 0.5;
 /// A table that leaks less than this distance into a clipped continuation cell
 /// is the terminal border of the previous fragment, not content for this page.
 /// Keeping it paints a stray horizontal line at the next page's top (42065

--- a/tests/cases/issue_5587_overwide_nested_table_clip.rs
+++ b/tests/cases/issue_5587_overwide_nested_table_clip.rs
@@ -1,0 +1,74 @@
+//! Issue #5587: 부모 셀보다 넓게 저장된 중첩표가 부모 밖으로 삐져나오지 않는다.
+//!
+//! `samples/basic/issue1994_behindtext_table_20200830.hwp` p1 의 셀(34,161HU)
+//! 안에는 35,144HU 로 저장된 TAC 중첩표가 있다. 정답지
+//! `samples/issue1994/issue_1994.pdf`(Hancom PDF 1.3.0.550) 1쪽에는 그 셀의
+//! 오른쪽 경계(384.15pt = 512.2px @96dpi) 너머로 그려진 stroke·clip·glyph 가
+//! 하나도 없다 — 중첩표 선언 폭의 오른쪽 끝(396.8pt)에는 아무것도 없다.
+//!
+//! `extend_clipped_cell_horizontal_clip_to_nested_table_borders` 는 42065
+//! (#2007) 처럼 **저장 폭이 부모 셀 이하**인 중첩표가 셀 왼쪽 패딩만큼 밀려
+//! 오른쪽 테두리를 clip 밖에 두는 경우를 위해 host clip 을 넓힌다. 부모보다
+//! 넓게 저장된 표는 그 예외가 아니므로 host viewport 를 그대로 둔다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/basic/issue1994_behindtext_table_20200830.hwp";
+
+/// 직접 자식 표가 자기보다 넓은 clipped host cell 을 모두 모은다.
+fn over_wide_nested_hosts<'a>(
+    node: &'a RenderNode,
+    found: &mut Vec<(&'a RenderNode, &'a RenderNode)>,
+) {
+    if let RenderNodeType::TableCell(meta) = &node.node_type {
+        if meta.clip {
+            for child in &node.children {
+                if matches!(child.node_type, RenderNodeType::Table(_))
+                    && child.bbox.width > node.bbox.width + 0.5
+                {
+                    found.push((node, child));
+                }
+            }
+        }
+    }
+    for child in &node.children {
+        over_wide_nested_hosts(child, found);
+    }
+}
+
+#[test]
+fn issue_5587_over_wide_nested_table_keeps_host_cell_clip() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(path).expect("read #5587 fixture");
+    let core = DocumentCore::from_bytes(&bytes).expect("parse #5587 fixture");
+
+    let page = core.build_page_render_tree(0).expect("render p1");
+    let mut hosts = Vec::new();
+    over_wide_nested_hosts(&page.root, &mut hosts);
+    assert_eq!(
+        hosts.len(),
+        1,
+        "p1 에는 부모 셀보다 넓게 저장된 중첩표 host cell 이 하나여야 한다"
+    );
+
+    let (host, nested) = hosts[0];
+    let host_right = host.bbox.x + host.bbox.width;
+    let nested_right = nested.bbox.x + nested.bbox.width;
+
+    // 전제: 중첩표는 실제로 부모 셀 오른쪽 너머까지 선언돼 있다.
+    assert!(
+        nested_right > host_right + 1.0,
+        "전제 붕괴 — 중첩표가 부모 셀을 넘지 않는다: host_right={host_right:.2}, \
+         nested_right={nested_right:.2}"
+    );
+
+    // 한컴 정답지의 오른쪽 paint 한계 512.2px(384.15pt). host clip 이 중첩표의
+    // 선언 폭(529.1px)까지 넓어지면 그 밖까지 그려진다.
+    assert!(
+        (host_right - 512.2).abs() <= 1.5,
+        "host cell clip 오른쪽이 한컴 정답지 경계(512.2px)를 벗어났다: {host_right:.2}"
+    );
+}


### PR DESCRIPTION
## 요약

부모 셀보다 **넓게 저장된** 중첩표가 부모 표 밖까지 그려지던 결함(#5587)을 고친다.
코퍼스 00387의 점선 상자(46,490HU)가 부모 셀(45,359HU) 오른쪽 밖 24.5px 까지 칠해졌다.

## 원인

패인트가 아니라 **셀 clip 확장**이다.
`extend_clipped_cell_horizontal_clip_to_nested_table_borders` 는 42065(#2007) 계약을 위해
있다 — 저장 폭이 부모 셀 **이하**인 중첩표가 셀 왼쪽 패딩만큼 밀려 오른쪽 외곽 테두리를
host clip 밖에 두면 그 테두리가 통째로 사라지므로, clip 을 테두리까지 넓힌다.

여기에 "부모보다 넓게 저장된 표" 예외가 없었다. 00387에서는 host 셀 clip 이
604.79px → 629.54px 로 넓어져(SVG `cell-clip-26`) 점선 4변이 부모 밖까지 칠해졌다.
셀 clip 은 SVG·Canvas·paint 공통 경로라 렌더러 전체가 같은 증상을 보였다.

두 형상은 저장 폭 하나로 갈린다 (repo 픽스처 실측).

| 문서 | 부모 셀 | 중첩표 | 관계 |
| --- | --- | --- | --- |
| `issue2007_nested_cell_pagination_42065.hwp` | — | — | 부모보다 넓은 중첩표 **0건** (패딩 이동만) |
| `issue1994_behindtext_table_20200830.hwp` | 34,161HU | 35,144HU | 넓게 저장 (+13.1px) |
| 00387 | 45,359HU | 46,490HU | 넓게 저장 (+15.1px) |

## 수정

직접 자식 표의 bbox 폭이 host clip 폭보다 크면(`NESTED_OVER_WIDE_EPSILON_PX = 0.5`)
clip 확장 대상에서 뺀다. host viewport 를 그대로 두면 셀 clip 이 중첩표의 테두리와 내용을
부모 경계에서 자른다. #2007 노출 경로와 중첩 셀 content 클램프는 그대로 둔다.
레이아웃·줄바꿈·쪽수는 건드리지 않는다 — 페인트 범위만 좁힌다.

## 한컴 정답지

00387 자체의 한컴 PDF 는 없다. 부모보다 넓은 중첩표를 가진 문서 중 한컴 PDF 가 함께 있는
두 건으로 방향을 확인했다.

1. 코퍼스 오라클 쌍(문서 id 36301151, 부모 48,194HU / 중첩 48,440HU). 한컴 PDF 1쪽에서
   해당 구간 clip 은 `mutool draw -F trace` 기준 x = 59.49~541.15pt.

   | | rhwp host 셀 clip 오른쪽 | 한컴 clip 오른쪽 | 차 |
   | --- | --- | --- | --- |
   | 수정 전 | 547.48pt | 541.15pt | **+6.33pt** |
   | 수정 후 | 541.46pt | 541.15pt | +0.31pt |

2. `samples/issue1994/issue_1994.pdf` (Hancom PDF 1.3.0.550) 1쪽: host 셀 오른쪽(384.15pt)
   너머 x ∈ [391.5pt, 402pt] 구간에 stroke·clip·glyph 가 하나도 없다. 중첩표 선언 폭의
   오른쪽 끝(396.8pt)에는 아무것도 그려지지 않는다.

## 검증

| 게이트 | 결과 |
| --- | --- |
| `issue_5587_overwide_nested_table_clip` (신규) | 통과 — 수정 원복 시 실패(가드 유효) |
| `issue_2007_nested_cell_pagination` | 15건 통과 (테두리 노출 계약 유지) |
| `cargo test --profile release-test --lib` | 3,893건 통과 |
| `cargo fmt --all -- --check` | 통과 |
| `cargo clippy --all-targets -- -D warnings` | 통과 |
| `cargo test --profile release-test --tests --no-fail-fast` | 49 suite ok / 2 실패 — `issue_4179_…`·`issue_4128_…` perf 카운터 테스트. 단독 실행은 통과하고, **수정 없는 baseline 에서도 동일하게 실패**한다(이 호스트에 `cargo-nextest` 가 없어 묶음 suite 를 한 프로세스에서 병렬 실행 → 전역 카운터 오염) |
| Native Skia 3종 / Docker WASM | **미실행** — 이 호스트에 `freetype`/`fontconfig` 개발 라이브러리와 Docker 표준 환경이 없다 (`rust-lld: unable to find library -lfreetype`) |

### 10k 한글문서 코퍼스 전후 스윕

10,000건 중 9,995건 검사(경로 인용 실패 4건, 파싱 패닉 1건 제외).

| 항목 | 값 |
| --- | --- |
| 부모 셀보다 넓게 저장된 중첩표를 가진 문서 | **71건 (0.71%)** |
| 수정 전후 SVG 가 달라진 문서 | 35건 |
| 그중 잉크가 달라진 문서 | **20건 / 21쪽** |
| 제거된 잉크 | **6,709px** |
| 추가된 잉크 | **0px** |

전부 부모 표 오른쪽 경계 **밖**에서만 사라졌다. 육안 확인(overlay) 결과 부모 세로 테두리
오른쪽으로 튀어나온 가로 테두리 꼬리와 중첩표 오른쪽 세로선만 사라지고 본문·표 내용은
그대로다.

## 하지 않은 것

- 중첩표 축소(폭 스케일)·재조판 — 정답지 근거가 없고 줄바꿈·쪽수를 흔든다.
- 세로 클리핑 — RowBreak continuation 이 다음 쪽 내용을 clip 아래에 의도적으로 남기는
  기존 계약과 충돌한다.
- 이슈가 함께 지적한 폭 583px 빈 TextRun(x=377.3 → 오른쪽 끝 960.3). 칠하는 내용이 없고
  이제 host 셀 clip(604.79px) 안에서 잘리므로 이 결함의 경로가 아니다. 렌더 트리 bbox
  위생 문제로 별도 추적이 필요하다.

보고서: `mydocs/report/task_m100_5587_report.md`

closes #5587
