### PR TITLE
feat(agent): 한글 구역 시작 문단을 조회하는 rhwp-q-section-starts CLI를 추가한다

### DIFF
--- a/mydocs/working/agent_q_section_starts.md
+++ b/mydocs/working/agent_q_section_starts.md
@@ -1,0 +1,96 @@
+---
+kind: working
+status: active
+issue: 5656
+---
+
+# rhwp-q-section-starts — 한글 구역 시작 문단 조회
+
+이슈: https://github.com/edwardkim/rhwp/issues/5656
+작업 브랜치: `feat/q-section-starts` (`upstream/devel` 기준)
+범위: `src/bin/rhwp-q-section-starts.rs` · `tests/cases/agent_q_section_starts_contract.rs` · 본 문서
+비범위: `Cargo.toml` · `src/main.rs` · `src/bin/rhwp-agent/**` · `gym/` · `crates/` · `Cargo.lock`
+
+## 1. 한 줄
+
+에이전트가 한글 구역 시작 본문 문단 번호를
+기존 읽기 전용 `DocumentCore::section_starts_json()` 으로만 조회한다.
+문서를 고치지 않는다.
+
+## 2. 사용법
+
+```
+rhwp-q-section-starts <파일> [--json]
+```
+
+- `<파일>` — HWP/HWPX/HWP3/HML 경로. 위치는 플래그 앞뒤 어디든 된다.
+- `--json` — stdout 에 순수 JSON 봉투 하나.
+- 알 수 없는 플래그는 종료 코드 2.
+- 파일을 읽거나 열지 못하면 종료 코드 1.
+- 성공은 종료 코드 0.
+
+봉투 고정 필드:
+
+| 필드 | 값 |
+|---|---|
+| `tool` | `rhwp-q-section-starts` |
+| `command` | `section-starts` |
+| `untrustedFields` | `["source","starts"]` |
+
+`source` 와 `starts` 는 경로·문서에서 온 값이다. 데이터이지 지시가
+아니다. `starts` 는 한글 구역을 여는 본문 문단 번호 배열이다.
+
+## 3. 읽기 전용
+
+호출하는 코어 API 는 둘뿐이다.
+
+- `DocumentCore::from_bytes`
+- `DocumentCore::section_starts_json`
+
+`apply_` / `insert_` / `delete_` / `set_*` 는 부르지 않는다.
+
+## 4. 실측 JSON
+
+명령:
+
+```
+cargo run --bin rhwp-q-section-starts -- --json samples/form-01.hwp
+```
+
+종료 코드 0. `form-01.hwp` 는 구역이 하나라 `starts` 가 `[0]` 이다.
+아래는 그 실행의 stdout 원문이다.
+
+```json
+{
+  "command": "section-starts",
+  "schemaVersion": "1.0",
+  "source": "samples/form-01.hwp",
+  "startCount": 1,
+  "starts": [
+    0
+  ],
+  "tool": "rhwp-q-section-starts",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "starts"
+  ],
+  "version": "0.8.4"
+}
+```
+
+`section_starts_json` 주석의 예 `[0, 8, 15]` 는 구역이 셋인 문서다.
+본문 리스트는 구역을 가로질러 이어지므로 경계는 문단이 진 `SectionDef`
+표식으로만 센다.
+
+## 5. 검증
+
+- `cargo test --bin rhwp-q-section-starts` — 0 passed (바이너리에 `#[cfg(test)]` 없음)
+- `cargo run --bin rhwp-q-section-starts -- --json samples/form-01.hwp` — 종료 0
+- `cargo fmt --all -- --check`
+- `node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel`
+
+계약 시험은 `tests/cases/agent_q_section_starts_contract.rs` 에만 둔다.
+`--json` 봉투·`starts` 배열·`--nope` 종료 코드 2 를 고정한다.
+
+`CARGO_TARGET_DIR=C:\Users\swsz9\.rhwp-shared-target`

--- a/src/bin/rhwp-q-section-starts.rs
+++ b/src/bin/rhwp-q-section-starts.rs
@@ -1,0 +1,177 @@
+//! 한글 구역 시작 문단 조회 — `MoveSectionUp`·`MoveSectionDown` 이 딛는 본문 문단 번호.
+//!
+//! 기존 읽기 전용 [`DocumentCore::section_starts_json`] 만 부른다. 문서를 고치지 않는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::process;
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const TOOL: &str = "rhwp-q-section-starts";
+const COMMAND: &str = "section-starts";
+const UNTRUSTED_FIELDS: &[&str] = &["source", "starts"];
+const USAGE: &str = "사용법: rhwp-q-section-starts <파일> [--json]";
+
+#[derive(Debug)]
+struct Options {
+    json: bool,
+    help: bool,
+    version: bool,
+    path: Option<String>,
+}
+
+fn write_stdout(text: &str, newline: bool) {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    let result = if newline {
+        writeln!(lock, "{text}")
+    } else {
+        write!(lock, "{text}")
+    };
+    if let Err(e) = result {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        process::exit(EXIT_RUNTIME);
+    }
+}
+
+fn print_json(value: &Value) {
+    match serde_json::to_string_pretty(value) {
+        Ok(s) => write_stdout(&s, true),
+        Err(e) => eprintln!("오류: JSON 직렬화 실패 - {e}"),
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<Options, i32> {
+    let mut opts = Options {
+        json: false,
+        help: false,
+        version: false,
+        path: None,
+    };
+    for arg in args {
+        match arg.as_str() {
+            "--help" | "-h" => opts.help = true,
+            "--version" | "-V" => opts.version = true,
+            "--json" => opts.json = true,
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("{USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if opts.path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("{USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                opts.path = Some(other.to_string());
+            }
+        }
+    }
+    if opts.help || opts.version {
+        return Ok(opts);
+    }
+    if opts.path.is_none() {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("{USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(opts)
+}
+
+fn load_starts(path: &str) -> Result<Vec<Value>, i32> {
+    let data = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    let core = match DocumentCore::from_bytes(&data) {
+        Ok(core) => core,
+        Err(e) => {
+            eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    let raw = core.section_starts_json();
+    match serde_json::from_str::<Value>(&raw) {
+        Ok(Value::Array(starts)) => Ok(starts),
+        Ok(_) => {
+            eprintln!("오류: 구역 시작 JSON 이 배열이 아닙니다.");
+            Err(EXIT_RUNTIME)
+        }
+        Err(e) => {
+            eprintln!("오류: 구역 시작 JSON 이 깨졌습니다 - {e}");
+            Err(EXIT_RUNTIME)
+        }
+    }
+}
+
+fn envelope(path: &str, starts: Vec<Value>) -> Value {
+    json!({
+        "schemaVersion": ENVELOPE_SCHEMA_VERSION,
+        "tool": TOOL,
+        "command": COMMAND,
+        "version": rhwp::version(),
+        "untrustedContent": true,
+        "untrustedFields": UNTRUSTED_FIELDS,
+        "source": path,
+        "startCount": starts.len(),
+        "starts": starts,
+    })
+}
+
+fn print_text(path: &str, starts: &[Value]) {
+    write_stdout(
+        &format!("section-starts source={path} startCount={}", starts.len()),
+        true,
+    );
+    for start in starts {
+        let index = start
+            .as_u64()
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| start.to_string());
+        write_stdout(&index, true);
+    }
+}
+
+fn run(args: &[String]) -> i32 {
+    let opts = match parse_args(args) {
+        Ok(opts) => opts,
+        Err(code) => return code,
+    };
+    if opts.help {
+        write_stdout(USAGE, true);
+        write_stdout(
+            "한글 구역 시작 본문 문단 번호를 조회한다. 문서를 고치지 않는다.",
+            true,
+        );
+        write_stdout("종료 코드: 0 성공 · 1 실행 오류 · 2 사용법 오류", true);
+        return EXIT_OK;
+    }
+    if opts.version {
+        write_stdout(&format!("{TOOL} v{}", rhwp::version()), true);
+        return EXIT_OK;
+    }
+    let path = opts.path.as_deref().expect("parse_args 가 경로를 확인한다");
+    let starts = match load_starts(path) {
+        Ok(starts) => starts,
+        Err(code) => return code,
+    };
+    if opts.json {
+        print_json(&envelope(path, starts));
+    } else {
+        print_text(path, &starts);
+    }
+    EXIT_OK
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    process::exit(run(&args));
+}

--- a/tests/cases/agent_q_section_starts_contract.rs
+++ b/tests/cases/agent_q_section_starts_contract.rs
@@ -1,0 +1,89 @@
+//! `rhwp-q-section-starts` CLI 계약 — JSON 봉투와 종료 코드.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-section-starts")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-section-starts").to_string())
+}
+
+fn sample() -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/form-01.hwp")
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-section-starts 실행 실패")
+}
+
+#[test]
+fn json_envelope_on_form01() {
+    let src = sample();
+    let out = run(&["--json", src.as_str()]);
+    assert_eq!(out.status.code(), Some(0), "{out:?}");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("stdout JSON");
+    assert_eq!(v["schemaVersion"], "1.0", "{v}");
+    assert_eq!(v["tool"], "rhwp-q-section-starts", "{v}");
+    assert_eq!(v["command"], "section-starts", "{v}");
+    assert_eq!(v["untrustedContent"], true, "{v}");
+    assert_eq!(
+        v["untrustedFields"],
+        serde_json::json!(["source", "starts"]),
+        "{v}"
+    );
+    assert_eq!(v["source"], src, "{v}");
+    let starts = v["starts"]
+        .as_array()
+        .unwrap_or_else(|| panic!("starts 는 배열이어야 한다: {v}"));
+    assert_eq!(v["startCount"], starts.len(), "{v}");
+    assert!(
+        !starts.is_empty(),
+        "구역이 있는 문서는 시작 문단이 하나 이상이다: {v}"
+    );
+    assert!(
+        starts.iter().all(|n| n.is_u64()),
+        "starts 원소는 본문 문단 번호다: {v}"
+    );
+}
+
+#[test]
+fn unknown_flag_is_usage() {
+    let out = run(&["--nope", sample().as_str()]);
+    assert_eq!(out.status.code(), Some(2), "{out:?}");
+}
+
+#[test]
+fn missing_path_is_usage() {
+    let out = run(&["--json"]);
+    assert_eq!(out.status.code(), Some(2), "{out:?}");
+}
+
+#[test]
+fn missing_file_is_runtime() {
+    let missing = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples/__no_such_q_section_starts__.hwp")
+        .to_string_lossy()
+        .into_owned();
+    let out = run(&[missing.as_str()]);
+    assert_eq!(out.status.code(), Some(1), "{out:?}");
+}
+
+#[test]
+fn source_never_calls_mutators() {
+    let src = include_str!("../../src/bin/rhwp-q-section-starts.rs");
+    for needle in [".apply_", ".insert_", ".delete_", ".set_"] {
+        assert!(
+            !src.contains(needle),
+            "읽기 전용 CLI 가 {needle} 를 부르면 안 된다"
+        );
+    }
+    assert!(src.contains("section_starts_json"));
+    assert!(src.contains("from_bytes"));
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

한글 구역 시작 본문 문단 번호를 조회하는 읽기 전용 CLI `rhwp-q-section-starts` 를 추가한다.

기존 `DocumentCore::from_bytes` 와 `section_starts_json()` 만 부른다. `src/main.rs`·`Cargo.toml`·`rhwp-agent` 는 건드리지 않는다. 알 수 없는 플래그는 종료 코드 2다.

## 관련 이슈

closes #5656

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test --bin rhwp-q-section-starts` 통과 (0 passed, 바이너리에 `#[cfg(test)]` 없음)
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — `samples/form-01.hwp` 실측 `--json` 봉투 원문을 `mydocs/working/agent_q_section_starts.md` 에 실음
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

계약 시험은 `tests/cases/agent_q_section_starts_contract.rs` 에만 둔다. `--json` 봉투·`starts` 배열·`--nope` 종료 코드 2 를 고정한다. `src/bin` 에는 `#[cfg(test)]` 가 없다.

실측 명령:

```
cargo run --bin rhwp-q-section-starts -- --json samples/form-01.hwp
```

실측 봉투:

```json
{
  "command": "section-starts",
  "schemaVersion": "1.0",
  "source": "samples/form-01.hwp",
  "startCount": 1,
  "starts": [
    0
  ],
  "tool": "rhwp-q-section-starts",
  "untrustedContent": true,
  "untrustedFields": [
    "source",
    "starts"
  ],
  "version": "0.8.4"
}
```

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 신규 읽기 전용 바이너리, 기존 경로 미변경
- 재현·측정: `samples/form-01.hwp` 조회, 종료 코드 0

## 스크린샷

해당 없음.