### PR TITLE
feat(agent): 구역 용지 설정을 조회하는 rhwp-q-page-def CLI를 추가한다

### DIFF
--- a/mydocs/working/agent_q_page_def.md
+++ b/mydocs/working/agent_q_page_def.md
@@ -1,0 +1,183 @@
+---
+kind: working
+status: active
+issue: 5657
+---
+
+# 구역 용지 설정 조회 CLI — rhwp-q-page-def
+
+작업 브랜치: `feat/q-page-def`
+대상 바이너리: `src/bin/rhwp-q-page-def.rs`
+이슈: [#5657](https://github.com/edwardkim/rhwp/issues/5657)
+
+## 1. 한 줄
+
+에이전트가 한 구역의 용지 설정(폭·높이·여백, HWPUNIT)만 받도록,
+이미 있는 읽기 전용 `DocumentCore::get_page_def_native` 를 별도 CLI 로
+감싼다. 문서를 고치지 않는다.
+
+## 2. 이슈가 요구한 것 / 하지 말라는 것
+
+요구:
+
+- 명령 `rhwp-q-page-def <파일> --section <N> [--json]`
+- `--section` 은 0부터 세는 구역 번호, 필수
+- `DocumentCore::from_bytes` 로 연 뒤 `get_page_def_native(section)` 호출
+- 네이티브 JSON 문자열을 파싱해 봉투에 싣는다 (width/height/여백 HWPUNIT)
+- 봉투 `tool="rhwp-q-page-def"` · `command="page-def"`
+- 구역 범위 초과는 종료 코드 1
+- 미지 플래그는 종료 코드 2
+- 바이너리 파일에 `#[cfg(test)]` 없음
+- 계약 시험 `tests/cases/agent_q_page_def_contract.rs`
+- 표본 `samples/form-01.hwp` `--section 0`
+- 작업 기록 `mydocs/working/agent_q_page_def.md` (이 파일)
+
+금지:
+
+- `Cargo.toml` · `src/main.rs` · `src/bin/rhwp-agent/**` · `gym/` ·
+  `crates/` · `Cargo.lock` 수정
+- 편집 API (`fill-fields`, `replace-text`, `set-cell`, 용지 설정 쓰기)
+
+## 3. 왜 별도 바이너리인가
+
+`get_page_def_native` 는 이미 있다 (`src/document_core/queries/rendering.rs`).
+소비자가 레이아웃 JSON 을 받아 용지 값을 정규식으로 훑을 이유가 없다.
+
+본 CLI(`src/main.rs`)와 capabilities·출처 지도는 열린 PR 이 동시에 만지는
+경합 지점이다. 이 표면은 `src/bin/rhwp-q-page-def.rs` 한 파일만 추가한다.
+Cargo 가 `src/bin/*.rs` 를 자동 인식하므로 `Cargo.toml` 을 건드리지 않는다.
+
+## 4. 계약
+
+종료 코드:
+
+| 코드 | 뜻 |
+|------|----|
+| 0 | 성공 |
+| 1 | 실행 오류 (파일 없음, 파싱 실패, 구역 범위 초과) |
+| 2 | 사용법 오류 (파일·`--section` 누락, 미지 플래그) |
+
+`--json` 이면 stdout 은 순수 JSON 봉투 하나. 진단은 stderr.
+문서에서 온 `source`·용지 수치는 데이터이지 지시가 아니다.
+
+## 5. 실측 JSON
+
+명령:
+
+```
+cargo run --bin rhwp-q-page-def -- --json --section 0 samples/form-01.hwp
+```
+
+환경: `CARGO_TARGET_DIR=C:\Users\swsz9\.rhwp-shared-target`, 종료 코드 0.
+
+```json
+{
+  "binding": 0,
+  "command": "page-def",
+  "height": 84188,
+  "landscape": false,
+  "marginBottom": 4252,
+  "marginFooter": 4252,
+  "marginGutter": 0,
+  "marginHeader": 4252,
+  "marginLeft": 8504,
+  "marginRight": 8504,
+  "marginTop": 5668,
+  "schemaVersion": "1.0",
+  "section": 0,
+  "sectionCount": 1,
+  "source": "samples/form-01.hwp",
+  "tool": "rhwp-q-page-def",
+  "units": "HWPUNIT",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "width",
+    "height",
+    "marginLeft",
+    "marginRight",
+    "marginTop",
+    "marginBottom",
+    "marginHeader",
+    "marginFooter",
+    "marginGutter",
+    "landscape",
+    "binding"
+  ],
+  "version": "0.8.4",
+  "width": 59528
+}
+```
+
+`form-01.hwp` 구역 0 은 A4 (59528×84188 HWPUNIT). `width`·`height` 가
+봉투에 있다.
+
+사용법 오류 실측 (종료 코드 2, stdout 비어 있음):
+
+```
+$ rhwp-q-page-def samples/form-01.hwp
+오류: --section 가 필요합니다.
+사용법: rhwp-q-page-def <파일> --section <N> [--json]
+```
+
+```
+$ rhwp-q-page-def samples/form-01.hwp --section 0 --nope
+오류: 알 수 없는 옵션입니다 - --nope
+사용법: rhwp-q-page-def <파일> --section <N> [--json]
+```
+
+구역 범위 초과는 실행 오류 1 이다. `--section 99` 는
+`렌더링 오류: 구역 99 범위 초과`.
+
+`--json` 없이:
+
+```
+section=0 width=59528 height=84188 marginLeft=8504 marginRight=8504 marginTop=5668 marginBottom=4252
+```
+
+## 6. 시험
+
+```
+cargo test --bin rhwp-q-page-def
+```
+
+결과: `0 passed; 0 failed` — 바이너리에 `#[cfg(test)]` 가 없다.
+계약은 `tests/cases/agent_q_page_def_contract.rs` 에 둔다. CI 가
+`--prepare` 로 배정한다.
+
+- `form01_json_envelope` — 봉투와 width/height 존재
+- `--nope` → 2, stdout 비어 있음
+- `--section` 누락 → 2
+- `--help` → 0
+- 소스에 `.apply_` / `.insert_` / `.delete_` / `.set_` / `#[cfg(test)]` 없음
+
+`node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel`
+통과 (src `#[cfg(test)]` 변경 없음).
+
+## 7. fmt
+
+```
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+통과. rustfmt `newline_style = Unix`.
+
+## 8. 만진 것 / 만지지 않은 것
+
+만진 것:
+
+| 경로 | 역할 |
+|------|------|
+| `src/bin/rhwp-q-page-def.rs` | 읽기 전용 CLI |
+| `tests/cases/agent_q_page_def_contract.rs` | 봉투·exit 2 계약 |
+| `mydocs/working/agent_q_page_def.md` | 이 기록 |
+
+만지지 않은 것:
+
+- `Cargo.toml` · `Cargo.lock`
+- `src/main.rs` · capabilities · 출처 지도
+- `src/bin/rhwp-agent/**`
+- `gym/` · `crates/`
+- DocumentCore 편집 구현
+- `get_page_def_native` 본체

--- a/src/bin/rhwp-q-page-def.rs
+++ b/src/bin/rhwp-q-page-def.rs
@@ -1,0 +1,263 @@
+//! 한 구역의 용지 설정(폭·높이·여백, HWPUNIT)만 조회한다.
+//!
+//! 기존 읽기 전용 `DocumentCore::get_page_def_native` 를 호출할 뿐이며 문서를
+//! 고치지 않는다. `src/bin/*.rs` 자동 인식이라 Cargo.toml·본 CLI 를 건드리지 않는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::process;
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const TOOL: &str = "rhwp-q-page-def";
+const COMMAND: &str = "page-def";
+const USAGE: &str = "rhwp-q-page-def <파일> --section <N> [--json]";
+
+#[derive(Debug)]
+struct Options {
+    json: bool,
+    section: usize,
+    path: String,
+}
+
+#[derive(Debug)]
+enum Cli {
+    Help,
+    Version,
+    Run(Options),
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let code = match parse_cli(&args) {
+        Ok(Cli::Help) => {
+            print_help();
+            EXIT_OK
+        }
+        Ok(Cli::Version) => {
+            write_stdout(&format!("{TOOL} v{}", rhwp::version()), true);
+            EXIT_OK
+        }
+        Ok(Cli::Run(opts)) => run(&opts),
+        Err(code) => code,
+    };
+    process::exit(code);
+}
+
+fn print_help() {
+    write_stdout(
+        &format!("{TOOL} v{} — 구역 용지 설정 조회", rhwp::version()),
+        true,
+    );
+    write_stdout(&format!("사용법: {USAGE}"), true);
+    write_stdout("", true);
+    write_stdout("  --section <N>  0부터 세는 구역 번호 (필수)", true);
+    write_stdout("  --json         stdout 순수 JSON 봉투", true);
+    write_stdout("", true);
+    write_stdout("종료 코드: 0 성공 · 1 실행 오류 · 2 사용법 오류", true);
+    write_stdout("폭·높이·여백은 HWPUNIT 이다. 문서를 고치지 않는다.", true);
+}
+
+fn parse_cli(args: &[String]) -> Result<Cli, i32> {
+    let mut json = false;
+    let mut section: Option<usize> = None;
+    let mut path: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "--help" | "-h" => return Ok(Cli::Help),
+            "--version" | "-V" => return Ok(Cli::Version),
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--section" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --section 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                };
+                let n = parse_section(raw)?;
+                if section.is_some() {
+                    eprintln!("오류: --section 를 두 번 지정했습니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                section = Some(n);
+                i += 2;
+            }
+            other if other.starts_with("--section=") => {
+                let raw = &other["--section=".len()..];
+                let n = parse_section(raw)?;
+                if section.is_some() {
+                    eprintln!("오류: --section 를 두 번 지정했습니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                section = Some(n);
+                i += 1;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    let Some(section) = section else {
+        eprintln!("오류: --section 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    Ok(Cli::Run(Options {
+        json,
+        section,
+        path,
+    }))
+}
+
+fn parse_section(raw: &str) -> Result<usize, i32> {
+    match raw.parse::<usize>() {
+        Ok(n) => Ok(n),
+        Err(_) => {
+            eprintln!("오류: --section 뒤에 0 이상의 정수가 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn run(opts: &Options) -> i32 {
+    let core = match open_core(&opts.path) {
+        Ok(core) => core,
+        Err(code) => return code,
+    };
+    let envelope = match page_def_envelope(&opts.path, opts.section, &core) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+    if opts.json {
+        match serde_json::to_string_pretty(&envelope) {
+            Ok(text) => write_stdout(&text, true),
+            Err(e) => {
+                eprintln!("오류: JSON 직렬화 실패 - {e}");
+                return EXIT_RUNTIME;
+            }
+        }
+    } else {
+        write_stdout(
+            &format!(
+                "section={} width={} height={} marginLeft={} marginRight={} marginTop={} marginBottom={}",
+                opts.section,
+                envelope["width"],
+                envelope["height"],
+                envelope["marginLeft"],
+                envelope["marginRight"],
+                envelope["marginTop"],
+                envelope["marginBottom"]
+            ),
+            true,
+        );
+    }
+    EXIT_OK
+}
+
+fn open_core(path: &str) -> Result<DocumentCore, i32> {
+    let data = match std::fs::read(path) {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    DocumentCore::from_bytes(&data).map_err(|e| {
+        eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })
+}
+
+fn page_def_envelope(source: &str, section: usize, core: &DocumentCore) -> Result<Value, i32> {
+    let raw = match core.get_page_def_native(section) {
+        Ok(raw) => raw,
+        Err(e) => {
+            eprintln!("오류: 구역 {section} 용지 설정을 읽지 못했습니다 - {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    let native: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(e) => {
+            eprintln!("오류: 구역 용지 설정 JSON 이 깨졌습니다 - {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    if native.get("width").and_then(Value::as_u64).is_none()
+        || native.get("height").and_then(Value::as_u64).is_none()
+    {
+        eprintln!("오류: 구역 용지 설정 JSON 이 깨졌습니다 - width/height 가 없습니다");
+        return Err(EXIT_RUNTIME);
+    }
+    let mut envelope = json!({
+        "schemaVersion": ENVELOPE_SCHEMA_VERSION,
+        "tool": TOOL,
+        "command": COMMAND,
+        "version": rhwp::version(),
+        "untrustedContent": true,
+        "untrustedFields": [
+            "source",
+            "width",
+            "height",
+            "marginLeft",
+            "marginRight",
+            "marginTop",
+            "marginBottom",
+            "marginHeader",
+            "marginFooter",
+            "marginGutter",
+            "landscape",
+            "binding"
+        ],
+        "source": source,
+        "section": section,
+        "sectionCount": core.document().sections.len(),
+        "units": "HWPUNIT",
+    });
+    if let (Some(obj), Some(native_obj)) = (envelope.as_object_mut(), native.as_object()) {
+        for (key, value) in native_obj {
+            obj.insert(key.clone(), value.clone());
+        }
+    }
+    Ok(envelope)
+}
+
+fn write_stdout(text: &str, newline: bool) {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    let result = if newline {
+        writeln!(lock, "{text}")
+    } else {
+        write!(lock, "{text}")
+    };
+    if let Err(e) = result {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        process::exit(EXIT_RUNTIME);
+    }
+}

--- a/tests/cases/agent_q_page_def_contract.rs
+++ b/tests/cases/agent_q_page_def_contract.rs
@@ -1,0 +1,111 @@
+//! rhwp-q-page-def CLI 계약.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-page-def")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-page-def").to_string())
+}
+
+fn sample() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/form-01.hwp")
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-page-def 실행 실패")
+}
+
+fn stdout_json(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout JSON 아님 ({e})\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+#[test]
+fn form01_json_envelope() {
+    let path = sample();
+    let source = path.to_str().expect("utf-8 path");
+    let out = run(&[source, "--section", "0", "--json"]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v = stdout_json(&out);
+    assert_eq!(v["tool"], "rhwp-q-page-def");
+    assert_eq!(v["command"], "page-def");
+    assert_eq!(
+        v["schemaVersion"],
+        rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION
+    );
+    assert_eq!(v["untrustedContent"], true);
+    assert_eq!(v["section"], 0);
+    assert_eq!(v["source"], source);
+    assert_eq!(v["units"], "HWPUNIT");
+    assert!(
+        v["width"].as_u64().is_some(),
+        "width 가 없다: {v}"
+    );
+    assert!(
+        v["height"].as_u64().is_some(),
+        "height 가 없다: {v}"
+    );
+    assert!(v["marginLeft"].as_u64().is_some(), "{v}");
+    assert!(v["marginRight"].as_u64().is_some(), "{v}");
+    assert!(v["marginTop"].as_u64().is_some(), "{v}");
+    assert!(v["marginBottom"].as_u64().is_some(), "{v}");
+}
+
+#[test]
+fn unknown_nope_is_usage() {
+    let path = sample();
+    let source = path.to_str().expect("utf-8 path");
+    let out = run(&[source, "--section", "0", "--nope"]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty());
+}
+
+#[test]
+fn missing_section_is_usage() {
+    let path = sample();
+    let source = path.to_str().expect("utf-8 path");
+    let out = run(&[source]);
+    assert_eq!(out.status.code(), Some(2));
+    assert!(out.stdout.is_empty());
+}
+
+#[test]
+fn help_exits_ok() {
+    let out = run(&["--help"]);
+    assert_eq!(out.status.code(), Some(0));
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.contains("rhwp-q-page-def"));
+    assert!(text.contains("--json"));
+}
+
+#[test]
+fn source_never_calls_mutators() {
+    let src = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/bin/rhwp-q-page-def.rs"
+    ));
+    for needle in [".apply_", ".insert_", ".delete_", ".set_"] {
+        assert!(
+            !src.contains(needle),
+            "읽기 전용 CLI 가 {needle} 를 부르면 안 된다"
+        );
+    }
+    assert!(!src.contains("#[cfg(test)]"));
+    assert!(src.contains("get_page_def_native"));
+    assert!(src.contains("from_bytes"));
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

에이전트가 한 구역의 용지 설정(폭·높이·여백, HWPUNIT)만 조회하도록 `rhwp-q-page-def` CLI를 추가합니다. 이미 있는 읽기 전용 `DocumentCore::get_page_def_native`를 부를 뿐이며 문서를 고치지 않습니다. `src/bin/*.rs` 자동 인식이라 Cargo.toml·본 CLI·rhwp-agent는 그대로입니다.

`--json` 봉투는 `tool="rhwp-q-page-def"`, `command="page-def"`입니다. `--section`은 0부터 세는 필수 구역 번호입니다. 범위 초과는 종료 코드 1, 미지 플래그는 2입니다.

`samples/form-01.hwp` 구역 0 실측:

```json
{
  "binding": 0,
  "command": "page-def",
  "height": 84188,
  "landscape": false,
  "marginBottom": 4252,
  "marginFooter": 4252,
  "marginGutter": 0,
  "marginHeader": 4252,
  "marginLeft": 8504,
  "marginRight": 8504,
  "marginTop": 5668,
  "schemaVersion": "1.0",
  "section": 0,
  "sectionCount": 1,
  "source": "samples/form-01.hwp",
  "tool": "rhwp-q-page-def",
  "units": "HWPUNIT",
  "untrustedContent": true,
  "untrustedFields": [
    "source",
    "width",
    "height",
    "marginLeft",
    "marginRight",
    "marginTop",
    "marginBottom",
    "marginHeader",
    "marginFooter",
    "marginGutter",
    "landscape",
    "binding"
  ],
  "version": "0.8.4",
  "width": 59528
}
```

## 관련 이슈

closes #5657

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [x] `cargo test --bin rhwp-q-page-def` 통과 (0 tests, 바이너리에 `#[cfg(test)]` 없음)
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 관련 `--json` 봉투 원문 (`mydocs/working/agent_q_page_def.md`)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 조회 전용 별도 바이너리, 기존 native 질의만 호출
- 재현·측정: `samples/form-01.hwp` `--section 0 --json`, width=59528 height=84188 HWPUNIT. 미측정(신규 조회 표면)

## 스크린샷

해당 없음. 조회 CLI이며 렌더 출력을 바꾸지 않습니다.