### PR TITLE
커서 자리 ParaShape를 조회하는 rhwp-q-para-shape CLI를 추가한다

### DIFF
--- a/mydocs/working/agent_q_para_shape.md
+++ b/mydocs/working/agent_q_para_shape.md
@@ -1,0 +1,224 @@
+---
+kind: working
+status: active
+issue: 5658
+---
+
+# 커서 자리 ParaShape 조회 CLI — rhwp-q-para-shape
+
+작업 브랜치: `feat/q-para-shape`
+범위 파일: `src/bin/rhwp-q-para-shape.rs`
+이슈: [#5658](https://github.com/edwardkim/rhwp/issues/5658)
+
+## 1. 한 줄
+
+에이전트가 한 자리(리스트·문단)의 ParaShape 파라미터셋만 조회하도록
+`rhwp-q-para-shape` CLI를 둔다. 이미 있는 읽기 전용
+`DocumentCore::para_shape_set_json(list_id, para_in_list)`를 부를 뿐이며
+문서를 고치지 않는다. 없는 자리의 셋은 빈 객체다.
+
+## 2. 계약과 만진 것 / 만지지 않은 것
+
+계약:
+
+- 호출: `rhwp-q-para-shape <파일> --list <N> --para <N> [--json]`
+- `--list`·`--para`는 0부터 세는 번호, 필수
+- `DocumentCore::from_bytes`로 연 뒤 `para_shape_set_json(list, para)` 그대로
+- 코어 JSON 객체를 봉투의 `paraShape`에 실는다
+- 봉투 `tool="rhwp-q-para-shape"` · `command="para-shape"` ·
+  `untrustedFields=["source","paraShape"]`
+- 종료 코드 0 / 1 / 2
+- 계약 시험 `tests/cases/agent_q_para_shape_contract.rs` (3–6개),
+  표본 `samples/form-01.hwp` 리스트 0 문단 0
+- 실측 원문 `mydocs/working/agent_q_para_shape.md` (본 문서)
+
+금지:
+
+- `Cargo.toml` · `src/main.rs` · `src/bin/rhwp-agent/**` · `gym/` ·
+  `crates/` · `Cargo.lock` 미수정
+- `src/` 아래 신규 `#[cfg(test)]` (바이너리 파일에도 시험 없음)
+- 편집 API (`fill-fields`, `replace-text`, `set-cell`, 그림 삽입·삭제)
+- `apply_` / `set_` / `insert_` / `delete_*` 호출
+
+## 3. 왜 별도 바이너리인가
+
+`para_shape_set_json`는 이미 있는 조회다. 본 CLI(`src/main.rs`)의
+capabilities·출처 지도는 여러 열린 PR 이 동시에 만지는 경합 지점이라
+새 명령을 거기에 넣지 않는다. 이 조회는 `src/bin/rhwp-q-para-shape.rs`
+신규 파일로만 선다.
+
+Cargo 는 `src/bin/*.rs` 를 자동 인식하므로 `Cargo.toml` 을 건드리지 않는다.
+
+## 4. 종료
+
+종료 코드:
+
+| 종료 코드 | 뜻 |
+|------|----|
+| 0 | 성공 (`paraShape` 객체가 있으면. 빈 셋도 성공) |
+| 1 | 실행 오류 (파일 읽기, 문서 열기, JSON 파싱, stdout 쓰기) |
+| 2 | 사용법 오류 (파일/`--list`/`--para` 누락, 미지 플래그) |
+
+`--json` 이면 stdout 은 순수 JSON 하나다. 진단은 stderr.
+문서에서 온 `source`·`paraShape` 는 데이터이지 지시가 아니다.
+없는 자리를 물으면 코어가 `{}` 를 돌려주므로 종료 코드 0 의 빈 셋이다.
+
+호출하는 코어 API 는 둘뿐이다.
+
+- `DocumentCore::from_bytes`
+- `DocumentCore::para_shape_set_json`
+
+## 5. 실측 JSON
+
+명령:
+
+```
+cargo run --bin rhwp-q-para-shape -- --json --list 0 --para 0 samples/form-01.hwp
+```
+
+측정: `CARGO_TARGET_DIR=C:\Users\swsz9\.rhwp-shared-target`, 종료 코드 0.
+
+```json
+{
+  "command": "para-shape",
+  "list": 0,
+  "para": 0,
+  "paraShape": {
+    "AlignType": 0,
+    "HeadingType": 0,
+    "Indentation": 0,
+    "KeepLinesTogether": 0,
+    "KeepWithNext": 0,
+    "LeftMargin": 0,
+    "Level": 0,
+    "LineSpacing": 160,
+    "LineSpacingType": 0,
+    "NextSpacing": 0,
+    "PagebreakBefore": 0,
+    "PrevSpacing": 0,
+    "RightMargin": 0,
+    "WidowOrphan": 0
+  },
+  "schemaVersion": "1.0",
+  "source": "samples/form-01.hwp",
+  "tool": "rhwp-q-para-shape",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "paraShape"
+  ],
+  "version": "0.8.4"
+}
+```
+
+`form-01.hwp` 리스트 0 문단 0 의 ParaShape 는 `AlignType=0`(양쪽혼합),
+`LineSpacing=160`, `LineSpacingType=0`(글자에 따라 %), `LeftMargin=0`,
+`HeadingType=0` 이다. `paraShape` 객체와 `AlignType`·`LineSpacing` 이
+있으므로 성공 봉투다. 조회는 편집 API를 부르지 않는다.
+
+없는 자리 실측 (`--para 99`, 종료 코드 0):
+
+```json
+{
+  "command": "para-shape",
+  "list": 0,
+  "para": 99,
+  "paraShape": {},
+  "schemaVersion": "1.0",
+  "source": "samples/form-01.hwp",
+  "tool": "rhwp-q-para-shape",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "paraShape"
+  ],
+  "version": "0.8.4"
+}
+```
+
+사용법 오류 실측 (종료 코드 2, stdout 비움):
+
+```
+$ rhwp-q-para-shape samples/form-01.hwp --list 0 --para 0 --nope
+오류: 알 수 없는 옵션입니다 - --nope
+사용법: rhwp-q-para-shape <파일> --list <N> --para <N> [--json]
+```
+
+```
+$ rhwp-q-para-shape --list 0 --para 0
+오류: 파일 경로가 필요합니다.
+사용법: rhwp-q-para-shape <파일> --list <N> --para <N> [--json]
+```
+
+```
+$ rhwp-q-para-shape samples/form-01.hwp --para 0
+오류: --list 가 필요합니다.
+사용법: rhwp-q-para-shape <파일> --list <N> --para <N> [--json]
+```
+
+없는 파일은 실행 오류 1 이다.
+
+```
+$ rhwp-q-para-shape --json --list 0 --para 0 samples/no-such-file.hwp
+오류: 파일을 읽을 수 없습니다 - samples/no-such-file.hwp: 지정된 파일을 찾을 수 없습니다. (os error 2)
+```
+
+텍스트 모드 실측 (종료 코드 0):
+
+```
+list=0 para=0 AlignType=0 LineSpacing=160 LeftMargin=0 HeadingType=0
+```
+
+없는 자리 텍스트:
+
+```
+list=0 para=99 (empty)
+```
+
+## 6. 시험
+
+바이너리 파일에는 단위 시험이 없다. `cargo test --bin rhwp-q-para-shape` 는
+컴파일만 확인하고 `0 passed; 0 failed` 다.
+
+계약 시험은 `tests/cases/agent_q_para_shape_contract.rs` 에 둔다. CI 가
+`--prepare` 로 suite 에 배정한다. 로컬 source PR 은 `--prepare` 를 돌리지
+않는다.
+
+- `json_envelope_on_form01_list0_para0` — 봉투 필드, 비지 않은 `paraShape`
+- `unknown_flag_nope_is_usage` — `--nope` → 종료 코드 2
+- `missing_list_is_usage` — `--list` 누락 → 2
+- `missing_cursor_is_empty_success` — 99문단은 빈 셋, 종료는 성공
+- `source_never_calls_mutators` — `para_shape_set_json`·`from_bytes` 만,
+  `apply_`/`set_`/`insert_`/`delete_*` 호출 없음
+
+`node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel` 는
+`src/` 신규 `#[cfg(test)]` 가 없으므로 통과해야 한다.
+
+## 7. fmt
+
+```
+cargo fmt --all
+cargo fmt --all -- --check
+```
+
+통과. rustfmt `newline_style = Unix`.
+
+## 8. 만진 것 / 만지지 않은 것
+
+만진 것:
+
+| 경로 | 역할 |
+|------|------|
+| `src/bin/rhwp-q-para-shape.rs` | 조회 CLI (시험 없음) |
+| `tests/cases/agent_q_para_shape_contract.rs` | 바이너리 계약 5개 |
+| `mydocs/working/agent_q_para_shape.md` | 본 기록 |
+
+만지지 않은 것:
+
+- `Cargo.toml` · `Cargo.lock`
+- `src/main.rs` · capabilities · 출처 지도
+- `src/bin/rhwp-agent/**`
+- `gym/` · `crates/`
+- DocumentCore 편집 뮤테이터
+- `para_shape_set_json` 본문
+- `tests/generated/` · `tests/suites/manifest.json`

--- a/src/bin/rhwp-q-para-shape.rs
+++ b/src/bin/rhwp-q-para-shape.rs
@@ -1,0 +1,306 @@
+//! 커서 자리 ParaShape를 조회하는 읽기 전용 CLI.
+//!
+//! 이미 있는 `DocumentCore::para_shape_set_json`를 부를 뿐이며 문서를
+//! 고치지 않는다. `src/bin/*.rs` 자동 인식이라 Cargo.toml·본 CLI 는 그대로다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::process;
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const TOOL: &str = "rhwp-q-para-shape";
+const COMMAND: &str = "para-shape";
+const UNTRUSTED_FIELDS: &[&str] = &["source", "paraShape"];
+const USAGE: &str = "rhwp-q-para-shape <파일> --list <N> --para <N> [--json]";
+
+#[derive(Debug)]
+struct Options {
+    json: bool,
+    list: u32,
+    para: usize,
+    path: String,
+}
+
+#[derive(Debug)]
+enum Cli {
+    Help,
+    Version,
+    Run(Options),
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let code = match parse_cli(&args) {
+        Ok(Cli::Help) => {
+            print_help();
+            EXIT_OK
+        }
+        Ok(Cli::Version) => {
+            write_stdout(&format!("{TOOL} v{}", rhwp::version()), true);
+            EXIT_OK
+        }
+        Ok(Cli::Run(opts)) => run(&opts),
+        Err(code) => code,
+    };
+    process::exit(code);
+}
+
+fn print_help() {
+    write_stdout(
+        &format!(
+            "{TOOL} v{} — 커서 자리 ParaShape를 조회하는 읽기 전용 CLI",
+            rhwp::version()
+        ),
+        true,
+    );
+    write_stdout(&format!("사용법: {USAGE}"), true);
+    write_stdout("", true);
+    write_stdout("  --list <N>  0부터 세는 리스트 번호 (필수)", true);
+    write_stdout("  --para <N>  0부터 세는 문단 번호 (필수)", true);
+    write_stdout("  --json      stdout 순수 JSON 봉투", true);
+    write_stdout("", true);
+    write_stdout("종료 코드: 0 성공 · 1 실행 오류 · 2 사용법 오류", true);
+    write_stdout("문서를 고치지 않는다. 편집 API 를 부르지 않는다.", true);
+    write_stdout("없는 자리의 셋은 빈 객체다.", true);
+}
+
+fn parse_cli(args: &[String]) -> Result<Cli, i32> {
+    let mut json = false;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut path: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        match arg {
+            "--help" | "-h" => return Ok(Cli::Help),
+            "--version" | "-V" => return Ok(Cli::Version),
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--list" => {
+                list = Some(parse_required_u32(args, i, "--list")?);
+                i += 2;
+            }
+            other if other.starts_with("--list=") => {
+                list = Some(parse_equals_u32(other, "--list")?);
+                i += 1;
+            }
+            "--para" => {
+                para = Some(parse_required_usize(args, i, "--para")?);
+                i += 2;
+            }
+            other if other.starts_with("--para=") => {
+                para = Some(parse_equals_usize(other, "--para")?);
+                i += 1;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    let Some(list) = list else {
+        eprintln!("오류: --list 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    let Some(para) = para else {
+        eprintln!("오류: --para 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    Ok(Cli::Run(Options {
+        json,
+        list,
+        para,
+        path,
+    }))
+}
+
+fn parse_required_usize(args: &[String], i: usize, flag: &str) -> Result<usize, i32> {
+    let Some(raw) = args.get(i + 1) else {
+        eprintln!("오류: {flag} 뒤에 0부터 세는 번호가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    parse_usize_value(raw, flag)
+}
+
+fn parse_equals_usize(arg: &str, flag: &str) -> Result<usize, i32> {
+    let raw = &arg[flag.len() + 1..];
+    parse_usize_value(raw, flag)
+}
+
+fn parse_usize_value(raw: &str, flag: &str) -> Result<usize, i32> {
+    match raw.parse::<usize>() {
+        Ok(n) => Ok(n),
+        Err(_) => {
+            eprintln!("오류: {flag} 뒤에 0부터 세는 번호가 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn parse_required_u32(args: &[String], i: usize, flag: &str) -> Result<u32, i32> {
+    let Some(raw) = args.get(i + 1) else {
+        eprintln!("오류: {flag} 뒤에 0부터 세는 번호가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    parse_u32_value(raw, flag)
+}
+
+fn parse_equals_u32(arg: &str, flag: &str) -> Result<u32, i32> {
+    let raw = &arg[flag.len() + 1..];
+    parse_u32_value(raw, flag)
+}
+
+fn parse_u32_value(raw: &str, flag: &str) -> Result<u32, i32> {
+    match raw.parse::<u32>() {
+        Ok(n) => Ok(n),
+        Err(_) => {
+            eprintln!("오류: {flag} 뒤에 0부터 세는 번호가 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn run(opts: &Options) -> i32 {
+    let core = match open_core(&opts.path) {
+        Ok(core) => core,
+        Err(code) => return code,
+    };
+    let envelope = match para_shape_envelope(&opts.path, opts.list, opts.para, &core) {
+        Ok(value) => value,
+        Err(code) => return code,
+    };
+    if opts.json {
+        match serde_json::to_string_pretty(&envelope) {
+            Ok(text) => write_stdout(&text, true),
+            Err(e) => {
+                eprintln!("오류: JSON 직렬화 실패 - {e}");
+                return EXIT_RUNTIME;
+            }
+        }
+    } else {
+        print_text(&envelope);
+    }
+    EXIT_OK
+}
+
+fn open_core(path: &str) -> Result<DocumentCore, i32> {
+    let data = match std::fs::read(path) {
+        Ok(data) => data,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    DocumentCore::from_bytes(&data).map_err(|e| {
+        eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })
+}
+
+fn para_shape_envelope(
+    source: &str,
+    list: u32,
+    para: usize,
+    core: &DocumentCore,
+) -> Result<Value, i32> {
+    let raw = core.para_shape_set_json(list, para);
+    let para_shape: Value = match serde_json::from_str(&raw) {
+        Ok(value) => value,
+        Err(e) => {
+            eprintln!("오류: ParaShape JSON 이 깨졌습니다 - {e}");
+            return Err(EXIT_RUNTIME);
+        }
+    };
+    if !para_shape.is_object() {
+        eprintln!("오류: ParaShape JSON 이 객체가 아닙니다.");
+        return Err(EXIT_RUNTIME);
+    }
+    Ok(json!({
+        "schemaVersion": ENVELOPE_SCHEMA_VERSION,
+        "tool": TOOL,
+        "command": COMMAND,
+        "version": rhwp::version(),
+        "untrustedContent": true,
+        "untrustedFields": UNTRUSTED_FIELDS,
+        "source": source,
+        "list": list,
+        "para": para,
+        "paraShape": para_shape,
+    }))
+}
+
+fn print_text(envelope: &Value) {
+    let shape = envelope["paraShape"].as_object();
+    let empty = shape.map(|m| m.is_empty()).unwrap_or(true);
+    if empty {
+        write_stdout(
+            &format!(
+                "list={} para={} (empty)",
+                envelope["list"], envelope["para"]
+            ),
+            true,
+        );
+        return;
+    }
+    let align = display_json(&envelope["paraShape"]["AlignType"]);
+    let spacing = display_json(&envelope["paraShape"]["LineSpacing"]);
+    let left = display_json(&envelope["paraShape"]["LeftMargin"]);
+    let heading = display_json(&envelope["paraShape"]["HeadingType"]);
+    write_stdout(
+        &format!(
+            "list={} para={} AlignType={} LineSpacing={} LeftMargin={} HeadingType={}",
+            envelope["list"], envelope["para"], align, spacing, left, heading
+        ),
+        true,
+    );
+}
+
+fn display_json(value: &Value) -> String {
+    match value {
+        Value::Null => "-".to_string(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn write_stdout(text: &str, newline: bool) {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    let result = if newline {
+        writeln!(lock, "{text}")
+    } else {
+        write!(lock, "{text}")
+    };
+    if let Err(e) = result {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        process::exit(EXIT_RUNTIME);
+    }
+}

--- a/tests/cases/agent_q_para_shape_contract.rs
+++ b/tests/cases/agent_q_para_shape_contract.rs
@@ -1,0 +1,134 @@
+//! `rhwp-q-para-shape` CLI 계약. 실제 바이너리를 실행한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/form-01.hwp";
+const TOOL: &str = "rhwp-q-para-shape";
+
+fn tool_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-para-shape")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-para-shape").to_string())
+}
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(tool_bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-para-shape 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: {TOOL} {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+#[test]
+fn json_envelope_on_form01_list0_para0() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = ["--json", "--list", "0", "--para", "0", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    assert!(v["schemaVersion"].is_string(), "{v}");
+    assert_eq!(v["tool"], TOOL, "{v}");
+    assert_eq!(v["command"], "para-shape", "{v}");
+    assert_eq!(v["untrustedContent"], true, "{v}");
+    assert!(v["untrustedFields"].is_array(), "{v}");
+    assert_eq!(v["list"], 0, "{v}");
+    assert_eq!(v["para"], 0, "{v}");
+    assert_eq!(v["source"], source, "{v}");
+    let shape = v["paraShape"].as_object().expect("paraShape object");
+    assert!(
+        !shape.is_empty(),
+        "form-01 0/0 ParaShape 가 비면 안 된다: {shape:?}"
+    );
+    assert!(shape
+        .get("AlignType")
+        .and_then(serde_json::Value::as_i64)
+        .is_some());
+    assert!(shape.contains_key("LineSpacing"));
+    assert!(shape.contains_key("LeftMargin"));
+}
+
+#[test]
+fn unknown_flag_nope_is_usage() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source, "--list", "0", "--para", "0", "--nope"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn missing_list_is_usage() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source, "--para", "0", "--json"];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn missing_cursor_is_empty_success() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = ["--json", "--list", "0", "--para", "99", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    let shape = v["paraShape"].as_object().expect("paraShape object");
+    assert!(shape.is_empty(), "없는 자리의 셋은 빈 객체다: {shape:?}");
+}
+
+#[test]
+fn source_never_calls_mutators() {
+    let src = include_str!("../../src/bin/rhwp-q-para-shape.rs");
+    for needle in [".apply_", ".insert_", ".delete_", ".set_"] {
+        assert!(
+            !src.contains(needle),
+            "읽기 전용 CLI 가 {needle} 를 부르면 안 된다"
+        );
+    }
+    assert!(src.contains("para_shape_set_json"));
+    assert!(src.contains("from_bytes"));
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

에이전트가 한 자리(리스트·문단)의 ParaShape 파라미터셋만 조회하도록 `rhwp-q-para-shape` CLI를 추가합니다. 이미 있는 읽기 전용 `DocumentCore::para_shape_set_json(list_id, para_in_list)`를 부를 뿐이며 문서를 고치지 않습니다. `src/bin/*.rs` 자동 인식이라 Cargo.toml·본 CLI·rhwp-agent는 그대로입니다. 바이너리 파일에는 `#[cfg(test)]`가 없고 계약 시험은 `tests/cases/agent_q_para_shape_contract.rs`에만 둡니다.

`--json` 봉투는 `tool="rhwp-q-para-shape"`, `command="para-shape"`, `untrustedFields=["source","paraShape"]`입니다. 종료 코드는 0/1/2입니다. 알 수 없는 플래그는 종료 코드 2입니다. 없는 자리의 셋은 빈 객체이며 종료 코드 0입니다.

`samples/form-01.hwp --list 0 --para 0` 실측:

```json
{
  "command": "para-shape",
  "list": 0,
  "para": 0,
  "paraShape": {
    "AlignType": 0,
    "HeadingType": 0,
    "Indentation": 0,
    "KeepLinesTogether": 0,
    "KeepWithNext": 0,
    "LeftMargin": 0,
    "Level": 0,
    "LineSpacing": 160,
    "LineSpacingType": 0,
    "NextSpacing": 0,
    "PagebreakBefore": 0,
    "PrevSpacing": 0,
    "RightMargin": 0,
    "WidowOrphan": 0
  },
  "schemaVersion": "1.0",
  "source": "samples/form-01.hwp",
  "tool": "rhwp-q-para-shape",
  "untrustedContent": true,
  "untrustedFields": [
    "source",
    "paraShape"
  ],
  "version": "0.8.4"
}
```

## 관련 이슈

closes #5658

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경하지 않음. `node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel` 통과 (4225 tests / 298 modules)
- [x] `cargo test --bin rhwp-q-para-shape` 통과 (0 passed; 0 failed — 바이너리에 단위 시험 없음)
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 관련 `--json` 봉투 원문 (`mydocs/working/agent_q_para_shape.md`)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

실측 명령:

```
cargo run --bin rhwp-q-para-shape -- --json --list 0 --para 0 samples/form-01.hwp
```

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 조회 전용 별도 바이너리, 기존 읽기 전용 질의만 호출
- 재현·측정: `samples/form-01.hwp --list 0 --para 0 --json`, 종료 코드 0. 미측정(신규 조회 표면)

## 스크린샷

해당 없음. 조회 CLI이며 렌더 출력을 바꾸지 않습니다.