### PR TITLE
feat(agent): 쪽 안 개체 순환 순서를 조회하는 rhwp-q-object-cycle CLI를 추가한다

### DIFF
--- a/mydocs/working/agent_q_object_cycle.md
+++ b/mydocs/working/agent_q_object_cycle.md
@@ -1,0 +1,244 @@
+---
+kind: working
+status: active
+---
+
+# rhwp-q-object-cycle — 쪽 안 개체 순환 순서 조회 CLI
+
+작업 브랜치: `feat/q-object-cycle` (`upstream/devel` @ `61baa6783`)
+이슈: https://github.com/edwardkim/rhwp/issues/5661
+
+## 1. 한 줄
+
+에이전트가 쪽 안에 놓인 표·도형·그림의 순환 차례(z 순서)를 `--json` 봉투로
+꺼낸다. 이미 있는 읽기 전용 `DocumentCore::object_cycle_json()` 만 부르고
+문서를 고치지 않는다.
+
+## 2. 왜 별도 바이너리인가
+
+본 CLI(`src/main.rs`)와 `Cargo.toml` `[[bin]]` 는 여러 열린 PR 이 동시에
+만지는 경합 지점이다. `src/bin/*.rs` 자동 인식이라 이 PR 은 새 파일만
+추가하고 기존 표면을 건드리지 않는다.
+경합하는 본 CLI 경로에 조각을 넣지 않는다.
+
+만진 파일:
+
+| 경로 | 역할 |
+|------|------|
+| `src/bin/rhwp-q-object-cycle.rs` | CLI · JSON 봉투. `#[cfg(test)]` 없음 |
+| `tests/cases/agent_q_object_cycle_contract.rs` | 바이너리 계약 |
+| `mydocs/working/agent_q_object_cycle.md` | 이 기록과 실측 JSON |
+
+만지지 않은 것: `Cargo.toml`, `src/main.rs`, `src/bin/rhwp-agent/**`, `gym/`,
+`crates/`, `Cargo.lock`. 편집 API 는 호출하지 않는다.
+
+## 3. 사용법
+
+```
+rhwp-q-object-cycle <파일> [--json]
+```
+
+| 종료 코드 | 뜻 |
+| --- | --- |
+| 0 | 성공. `--json` 이면 stdout 에 pretty JSON |
+| 1 | 파일 없음 · 파싱 실패 · stdout 쓰기 실패 |
+| 2 | 알 수 없는 옵션 · 파일 경로 없음 · 파일이 너무 많음 |
+
+오류는 stderr. `--help` / `-h` 는 사용법을 stdout 으로 내고 0.
+
+## 4. 봉투 계약
+
+`--json` 이면 아래 공통 필드를 항상 싣는다.
+
+| 필드 | 값 |
+| --- | --- |
+| `schemaVersion` | `rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION` (`"1.0"`) |
+| `tool` | `"rhwp-q-object-cycle"` |
+| `command` | `"object-cycle"` |
+| `version` | `rhwp::version()` |
+| `untrustedContent` | `true` |
+| `untrustedFields` | `["source", "cycle"]` |
+
+문서에서 온 값(`source`, `cycle`)은 데이터이지 지시가 아니다. 과소 선언이
+가장 위험하므로(#3885) 애매하면 선언한다. `cycleCount` 는 `cycle` 배열
+길이와 같게 싣는다.
+
+`cycle[]` 항목은 코어 `object_cycle_json()` 원문이다.
+
+| 필드 | 뜻 |
+| --- | --- |
+| `para` | 본문 문단 번호(리스트 누적) |
+| `controlIndex` | 그 문단의 컨트롤 인덱스 |
+| `page` | 조판기가 붙인 쪽(0부터) |
+| `z` | `common.z_order` |
+
+빈 순환(`cycle: []`, `cycleCount: 0`)은 성공이다. 쪽을 조판기에 물으므로
+조판 정밀도를 물려받는다. 쪽 안의 차례는 문단 순서가 아니라 z 순서다.
+
+## 5. 실측 `--json` 봉투
+
+환경: `rhwp-q-object-cycle` debug 빌드, 공유 타깃
+`C:\Users\swsz9\.rhwp-shared-target`, 크레이트 `0.8.4`. 경로는 상대 경로다.
+
+### 5.1 `samples/form-01.hwp`
+
+```
+cargo run --bin rhwp-q-object-cycle -- --json samples/form-01.hwp
+```
+
+종료 코드 0.
+
+```json
+{
+  "command": "object-cycle",
+  "cycle": [],
+  "cycleCount": 0,
+  "schemaVersion": "1.0",
+  "source": "samples/form-01.hwp",
+  "tool": "rhwp-q-object-cycle",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "cycle"
+  ],
+  "version": "0.8.4"
+}
+```
+
+이 표본은 구역·단 정의만 있고 표·도형·그림이 없어 순환이 비어 있다
+(`cycleCount` 0). 빈 순환은 오류가 아니다.
+
+### 5.2 `samples/hwp_table_test.hwp`
+
+표가 있는 표본으로 비지 않은 순환을 확인한다. 표 10개가 `tbl` 로
+`cycle[]` 에 들어가고 `page`/`z` 가 쪽과 z 순서를 가리킨다. 종료 코드 0.
+
+```
+cargo run --bin rhwp-q-object-cycle -- --json samples/hwp_table_test.hwp
+```
+
+```json
+{
+  "command": "object-cycle",
+  "cycle": [
+    {
+      "controlIndex": 0,
+      "page": 0,
+      "para": 3,
+      "z": 0
+    },
+    {
+      "controlIndex": 0,
+      "page": 0,
+      "para": 5,
+      "z": 1
+    },
+    {
+      "controlIndex": 0,
+      "page": 0,
+      "para": 8,
+      "z": 2
+    },
+    {
+      "controlIndex": 0,
+      "page": 0,
+      "para": 10,
+      "z": 3
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 12,
+      "z": 4
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 14,
+      "z": 8
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 15,
+      "z": 5
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 17,
+      "z": 7
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 19,
+      "z": 6
+    },
+    {
+      "controlIndex": 0,
+      "page": 1,
+      "para": 20,
+      "z": 9
+    }
+  ],
+  "cycleCount": 10,
+  "schemaVersion": "1.0",
+  "source": "samples/hwp_table_test.hwp",
+  "tool": "rhwp-q-object-cycle",
+  "untrustedContent": true,
+  "untrustedFields": [
+    "source",
+    "cycle"
+  ],
+  "version": "0.8.4"
+}
+```
+
+표 10개가 쪽 0(z 0..3)과 쪽 1(z 4..9)로 나뉜다. 쪽 1 안 z 순서는
+문단 순서와 다르다(para 14 가 z 8, para 15 가 z 5).
+
+## 6. 실패 경로 실측
+
+같은 debug 빌드.
+
+| 명령 | stderr | 종료 |
+| --- | --- | --- |
+| `--nope` | `오류: 알 수 없는 옵션입니다 - --nope` | 2 |
+| `--json` (파일 없음) | `오류: 파일 경로가 필요합니다.` | 2 |
+| `samples/__no_such_q_object_cycle__.hwp` | `오류: 파일을 읽을 수 없습니다` | 1 |
+| `README.md` | `오류: 문서를 열 수 없습니다` · `UNSUPPORTED_FILE_FORMAT` | 1 |
+
+## 7. 검증 명령
+
+같은 debug 빌드.
+
+```
+git config core.autocrlf false
+$env:CARGO_TARGET_DIR='C:\Users\swsz9\.rhwp-shared-target'
+rustfmt --edition 2021 --config newline_style=Unix src/bin/rhwp-q-object-cycle.rs
+cargo test --bin rhwp-q-object-cycle
+cargo run --bin rhwp-q-object-cycle -- --json samples/form-01.hwp
+rustfmt --edition 2021 --config newline_style=Unix --check src/bin/rhwp-q-object-cycle.rs
+cargo fmt --all -- --check
+node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel
+```
+
+결과:
+
+- `cargo test --bin rhwp-q-object-cycle` — **0 passed** (src unit test 없음. 계약은 `tests/cases/agent_q_object_cycle_contract.rs`)
+- `cargo run --bin rhwp-q-object-cycle -- --json samples/form-01.hwp` — 종료 0, §5.1 봉투
+- `rustfmt --check` — 통과
+- `cargo fmt --all -- --check` — 통과
+- `rust-unit-test-tiers --check --base-ref upstream/devel` — 통과 (src `#[cfg(test)]` 추가 없음)
+
+## 8. 커밋 후보 / 만지지 않은 것
+
+| 경로 | 역할 |
+| --- | --- |
+| `src/bin/rhwp-q-object-cycle.rs` | CLI · 봉투 · `#[cfg(test)]` 없음 |
+| `tests/cases/agent_q_object_cycle_contract.rs` | 바이너리 계약 (`CARGO_BIN_EXE_rhwp-q-object-cycle`) |
+| `mydocs/working/agent_q_object_cycle.md` | 이 기록 · 실측 JSON |
+
+만지지 않은 것: `Cargo.toml`, `src/main.rs`, `src/bin/rhwp-agent/**`,
+`gym/`, `crates/`, `Cargo.lock`.

--- a/src/bin/rhwp-q-object-cycle.rs
+++ b/src/bin/rhwp-q-object-cycle.rs
@@ -1,0 +1,144 @@
+//! 쪽 안 개체 순환 순서를 조회하는 읽기 전용 CLI.
+//!
+//! `src/bin/*.rs` 자동 인식이라 Cargo.toml 을 건드리지 않는다. 본 CLI(`src/main.rs`)와
+//! 경합하지 않도록 공개 조회 API 만 부른다 — `apply_`/`insert_`/`delete_`/`set_*` 금지.
+
+use rhwp::document_core::DocumentCore;
+use serde_json::{json, Value};
+use std::io::Write;
+
+const EXIT_OK: i32 = 0;
+const EXIT_RUNTIME: i32 = 1;
+const EXIT_USAGE: i32 = 2;
+const USAGE: &str = "rhwp-q-object-cycle <파일> [--json]";
+const UNTRUSTED: &[&str] = &["source", "cycle"];
+
+fn envelope(command: &str, payload: Value, untrusted: &[&str]) -> Value {
+    let mut out = json!({
+        "schemaVersion": rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION,
+        "tool": "rhwp-q-object-cycle",
+        "command": command,
+        "version": rhwp::version(),
+        "untrustedContent": !untrusted.is_empty(),
+        "untrustedFields": untrusted,
+    });
+    if let (Some(dst), Some(src)) = (out.as_object_mut(), payload.as_object()) {
+        for (key, value) in src {
+            dst.insert(key.clone(), value.clone());
+        }
+    }
+    out
+}
+
+fn write_stdout(text: &str) -> i32 {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if let Err(e) = writeln!(lock, "{text}") {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        return EXIT_RUNTIME;
+    }
+    EXIT_OK
+}
+
+fn parse_args(args: &[String]) -> Result<(bool, String), i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                path = Some(other.to_string());
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    Ok((json, path))
+}
+
+fn inspect(path: &str) -> Result<Value, i32> {
+    let data = std::fs::read(path).map_err(|e| {
+        eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })?;
+    let core = DocumentCore::from_bytes(&data).map_err(|e| {
+        eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })?;
+    let cycle: Value = serde_json::from_str(&core.object_cycle_json().map_err(|e| {
+        eprintln!("오류: 개체 순환을 만들지 못했습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })?)
+    .map_err(|e| {
+        eprintln!("오류: 개체 순환 JSON 이 깨졌습니다 - {e}");
+        EXIT_RUNTIME
+    })?;
+    Ok(envelope(
+        "object-cycle",
+        json!({
+            "source": path,
+            "cycleCount": cycle.as_array().map(Vec::len).unwrap_or(0),
+            "cycle": cycle,
+        }),
+        UNTRUSTED,
+    ))
+}
+
+fn print_text(report: &Value) -> i32 {
+    let source = report["source"].as_str().unwrap_or("");
+    let cycle = report["cycle"].as_array();
+    let mut lines = Vec::new();
+    lines.push(source.to_string());
+    lines.push(format!("cycle\t{}", cycle.map(Vec::len).unwrap_or(0)));
+    if let Some(items) = cycle {
+        for (i, item) in items.iter().enumerate() {
+            lines.push(format!(
+                "{i}\tpara={}\tctrl={}\tpage={}\tz={}",
+                item["para"], item["controlIndex"], item["page"], item["z"]
+            ));
+        }
+    }
+    write_stdout(&lines.join("\n"))
+}
+
+fn run(args: Vec<String>) -> i32 {
+    if args.iter().any(|arg| arg == "--help" || arg == "-h") {
+        return write_stdout(USAGE);
+    }
+    let (json, path) = match parse_args(&args) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    let report = match inspect(&path) {
+        Ok(v) => v,
+        Err(code) => return code,
+    };
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(text) => write_stdout(&text),
+            Err(e) => {
+                eprintln!("오류: JSON 직렬화 실패 - {e}");
+                EXIT_RUNTIME
+            }
+        }
+    } else {
+        print_text(&report)
+    }
+}
+
+fn main() {
+    std::process::exit(run(std::env::args().skip(1).collect()));
+}

--- a/tests/cases/agent_q_object_cycle_contract.rs
+++ b/tests/cases/agent_q_object_cycle_contract.rs
@@ -1,0 +1,156 @@
+//! `rhwp-q-object-cycle` CLI 계약. 실제 바이너리를 실행한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/form-01.hwp";
+const TOOL: &str = "rhwp-q-object-cycle";
+
+fn tool_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-object-cycle")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-object-cycle").to_string())
+}
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(tool_bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-object-cycle 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: {TOOL} {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+#[test]
+fn json_envelope_on_form01() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = ["--json", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    assert!(v["schemaVersion"].is_string(), "{v}");
+    assert_eq!(v["tool"], TOOL, "{v}");
+    assert_eq!(v["command"], "object-cycle", "{v}");
+    assert_eq!(v["untrustedContent"], true, "{v}");
+    assert!(v["untrustedFields"].is_array(), "{v}");
+    assert_eq!(v["source"], source, "{v}");
+    let cycle = v["cycle"].as_array().expect("cycle 배열");
+    assert_eq!(v["cycleCount"], cycle.len(), "{v}");
+    assert!(cycle.iter().all(|item| {
+        item.get("para")
+            .and_then(serde_json::Value::as_u64)
+            .is_some()
+            && item
+                .get("controlIndex")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+            && item
+                .get("page")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+            && item.get("z").and_then(serde_json::Value::as_i64).is_some()
+    }));
+}
+
+#[test]
+fn unknown_flag_nope_is_usage() {
+    let output = run(&["--nope"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&["--nope"], &output)
+    );
+}
+
+#[test]
+fn missing_path_is_usage() {
+    let output = run(&["--json"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&["--json"], &output)
+    );
+}
+
+#[test]
+fn extra_file_is_usage() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source, source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn missing_file_is_runtime() {
+    let path = sample("samples/__no_such_q_object_cycle__.hwp");
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn unparseable_file_is_runtime() {
+    let path = sample("README.md");
+    let source = path.to_str().expect("utf-8 path");
+    let args = [source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}",
+        describe(&args, &output)
+    );
+}
+
+#[test]
+fn source_never_calls_mutators() {
+    let src = include_str!("../../src/bin/rhwp-q-object-cycle.rs");
+    for needle in [".apply_", ".insert_", ".delete_", ".set_"] {
+        assert!(
+            !src.contains(needle),
+            "읽기 전용 CLI 가 {needle} 를 부르면 안 된다"
+        );
+    }
+    assert!(src.contains("object_cycle_json"));
+    assert!(src.contains("from_bytes"));
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다. 상세: [CONTRIBUTING.md](../CONTRIBUTING.md)

## 변경 요약

에이전트가 쪽 안 표·도형·그림의 순환 차례(z 순서)를 조회하도록 `rhwp-q-object-cycle` CLI를 추가합니다. 이미 있는 읽기 전용 `DocumentCore::object_cycle_json()`을 부를 뿐이며 문서를 고치지 않습니다. `src/bin/*.rs` 자동 인식이라 Cargo.toml·본 CLI·rhwp-agent는 그대로입니다.

`--json` 봉투는 `tool="rhwp-q-object-cycle"`, `command="object-cycle"`, `untrustedFields=["source","cycle"]`입니다. 종료 코드는 0/1/2입니다. 알 수 없는 플래그는 종료 코드 2입니다. 빈 순환은 종료 코드 0입니다.

`samples/form-01.hwp --json` 실측:

```json
{
  "command": "object-cycle",
  "cycle": [],
  "cycleCount": 0,
  "schemaVersion": "1.0",
  "source": "samples/form-01.hwp",
  "tool": "rhwp-q-object-cycle",
  "untrustedContent": true,
  "untrustedFields": [
    "source",
    "cycle"
  ],
  "version": "0.8.4"
}
```

표 표본 `samples/hwp_table_test.hwp`는 `cycleCount` 10입니다. 원문은 `mydocs/working/agent_q_object_cycle.md`에 있습니다.

## 관련 이슈

closes #5661

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (PR 생성·push 직전 필수. CI Lint Format check 와 동일. `cargo fmt --check` 만으로는 안 됨. 테스트만 고친 커밋도 다시 돌릴 것. 실패 시 `cargo fmt --all` 후 다시 `--check`)
- [x] 새 integration test는 원본을 `tests/cases/*.rs`에만 추가했고 `tests/generated/`, `tests/suites/manifest.json`, Cargo generated test target을 PR에 포함하지 않음
- [x] `src/**`의 `#[cfg(test)]`를 변경한 경우 `node scripts/rust-unit-test-tiers.mjs --check` 통과 (파생 inventory 생성·stage 불필요)
- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [ ] rhwp-studio 편집·UI 변경 시: e2e 시나리오(`rhwp-studio/e2e/…`) 또는 편집 커맨드 리뷰 체크리스트(`mydocs/manual/edit_command_review_checklist.md`) 통과 · 링크:
- [x] (에이전트 보조 작업 권장) 작업 증빙 첨부 — 관련 `--json` 봉투 원문 (`mydocs/working/agent_q_object_cycle.md`)
- [ ] `.claude/agents/`, `.claude/skills/`, `.agents/skills/` 변경 시: [capability 카탈로그](https://github.com/edwardkim/rhwp/blob/devel/mydocs/manual/agent_capability_registry.md)의 등록·검증 규칙을 반영

> `node scripts/rust-test-suite-manifest.mjs --prepare`와 이어지는 `--check`는 파생 suite를
> 준비한 PR review worktree와 CI의 절차입니다. 일반 기여자의 source PR checkout에서는
> 실행하거나 결과를 커밋하지 마세요. 새 `tests/cases/*.rs` 원본은 검토·CI에서 weight 기준으로
> 자동 배정됩니다. 상세 절차는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 따릅니다.

로컬 검증 (공유 타깃 `C:\Users\swsz9\.rhwp-shared-target`):

- `rustfmt --edition 2021 --config newline_style=Unix --check src/bin/rhwp-q-object-cycle.rs tests/cases/agent_q_object_cycle_contract.rs` 통과
- `cargo test --bin rhwp-q-object-cycle` — 0 passed (src unit test 없음)
- `cargo run --bin rhwp-q-object-cycle -- --json samples/form-01.hwp` — 종료 0
- `cargo fmt --all -- --check` 통과
- `node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel` 통과

계약 시험은 `tests/cases/agent_q_object_cycle_contract.rs`에 둔다. `--json samples/form-01.hwp` 봉투, `--nope` 종료 2, 뮤테이터 호출 금지를 고정한다.

실측 명령:

```
cargo run --bin rhwp-q-object-cycle -- --json samples/form-01.hwp
```

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 — 조회 전용 별도 바이너리, 기존 읽기 전용 질의만 호출
- 재현·측정: `samples/form-01.hwp --json`, 종료 코드 0. 빈 순환. 표 표본 `samples/hwp_table_test.hwp`는 cycleCount 10.

> 특정 장비의 절대 성능 수치나 메인테이너 전용·비공개 벤치마크 통과는 PR 제출 조건이 아닙니다.
> 공개된 결정적 성능 회귀 테스트와 GitHub required checks는 기존과 같이 적용됩니다.

## 스크린샷

해당 없음. 조회 CLI이며 렌더 출력을 바꾸지 않습니다.