### PR TITLE
fix(renderer): 본문 수식-only 줄도 문단 정렬을 따른다 — 가운데 정렬 문단의 수식이 왼쪽에 붙던 증상 (#5583)

### DIFF
--- a/mydocs/working/task_5583_body_equation_alignment.md
+++ b/mydocs/working/task_5583_body_equation_alignment.md
@@ -1,0 +1,55 @@
+# #5583 본문 수식-only 줄이 문단 정렬을 따르지 않는다
+
+## 목표
+
+가운데 정렬 문단에 놓인 수식이 단 왼쪽 끝에 붙는 증상을 없앤다.
+
+## 원인 — 계측으로 확정
+
+재현: 코퍼스 00192(`국가유산수리 감리대가 기준`) 2·3쪽 수식(폭 254.6px). 본문 좌측 75.6px 에
+그려지고, 가운데라면 269.6px 여야 한다.
+
+계측으로 세 가지를 차례로 배제·확정했다.
+
+1. `layout_shape` 의 수식 배치는 정렬을 본다(`Center → 가운데`). 그러나 이 문서는
+   `inline=true` 로 조기 반환한다 — 수식이 **글자처럼 취급(treatAsChar=1)** 이라 인라인 경로가
+   좌표를 먼저 등록한다.
+
+   ```
+   DBG_EQ pi=7  inline=true align=Center colx=75.6 colw=642.5 w=254.6
+   DBG_EQ pi=12 inline=true align=Center colx=75.6 colw=642.5 w=254.6
+   ```
+
+2. 문단 정렬 해석은 정상이다(`align=Center`).
+
+3. 실제 x 를 정하는 곳은 `place_empty_line_inline_equations` 의 정렬 오프셋이었다.
+
+   ```rust
+   let align_offset = if cell_ctx.is_some() {
+       match alignment { Center|Distribute => (avail - line_tac_width)/2.0, Right => …, _ => 0.0 }
+   } else {
+       0.0            // ← 본문이면 정렬을 아예 무시
+   };
+   ```
+
+   **표 셀 안에서만 정렬을 계산하고 본문에서는 0.0 으로 굳어 있었다.**
+
+## 변경
+
+본문에서도 같은 정렬을 적용하되, 저장 `LINE_SEG.column_start > 0` 인 줄은 한컴이 흐름 x 를 적어 둔
+경우이므로 #1256/#1308 계약대로 저장값을 존중한다. 00192 의 해당 줄은 `cs=0 sw=48188`(단 전체)로
+위치 정보가 없다.
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| 재현 문서 00192 3쪽 수식 | x 75.6 → **269.6** (기대 가운데 269.6) |
+| 표본에서 위치가 바뀐 수식 | 3개 — **전부 가운데로 이동**, 그 외 0 |
+| 쪽수 회귀 (표본 1,000문서) | **변화 0건** |
+
+## 검증 기준
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --all-targets -- -D warnings`
+- `cargo test --test regression_suite_027 -- issue_5583` (계약 테스트 2건)

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -2444,7 +2444,14 @@ impl LayoutEngine {
             }
         }
         let line_tac_width: f64 = row_tac_widths.iter().sum();
-        let align_offset = if cell_ctx.is_some() {
+        // [#5583] 본문 흐름의 수식-only 줄도 문단 정렬을 따른다 — 단 저장 LINE_SEG 가 줄 시작
+        // 위치를 담고 있으면(그 값이 권위다) 종전대로 저장 흐름을 쓴다.
+        //
+        // 종전에는 비-셀이면 무조건 0.0 이라 가운데 정렬 문단의 수식이 단 왼쪽 끝에 붙었다
+        // (3252633 국가유산수리 감리대가 기준 2·3쪽: 저장 cs=0 sw=48188 인데 수식 x=75.6 =
+        // 본문 좌측, 가운데라면 269.6). `column_start > 0` 인 줄은 한컴이 흐름 x 를 적어 둔
+        // 경우이므로 #1256/#1308 계약대로 그 값을 존중한다.
+        let align_offset = if cell_ctx.is_some() || comp_line.column_start == 0 {
             match alignment {
                 Alignment::Center | Alignment::Distribute => {
                     (available_width - line_tac_width).max(0.0) / 2.0

--- a/tests/cases/issue_5583_body_equation_alignment.rs
+++ b/tests/cases/issue_5583_body_equation_alignment.rs
@@ -1,0 +1,124 @@
+//! Issue #5583: 본문 흐름의 수식-only 줄이 문단 정렬을 따르지 않고 항상 왼쪽에 붙는다.
+//!
+//! `place_empty_line_inline_equations` 의 정렬 오프셋은 표 셀 안에서만 계산되고 본문에서는
+//! `0.0` 으로 굳어 있었다. 그래서 가운데 정렬 문단에 놓인 글자처럼 취급(treatAsChar=1) 수식이
+//! 단 왼쪽 끝에 그려졌다(코퍼스 00192 `국가유산수리 감리대가 기준` 2·3쪽: 본문 좌측 75.6px,
+//! 가운데였다면 269.6px).
+//!
+//! 저장 `LINE_SEG.column_start` 가 0 이면 그 줄은 흐름 x 를 담고 있지 않으므로 문단 정렬을
+//! 적용한다. `column_start > 0` 인 줄은 한컴이 흐름 x 를 적어 둔 경우라 #1256/#1308 계약대로
+//! 저장값을 존중한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::{Control, Equation};
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::{Alignment, ParaShape};
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 단 폭(HWPUNIT) — 96dpi 에서 642.5px.
+const COLUMN_WIDTH: i32 = 48188;
+/// 수식 폭(HWPUNIT) — 96dpi 에서 254.6px.
+const EQ_WIDTH: u32 = 19094;
+
+fn document_with_centered_equation(column_start: i32) -> Document {
+    let shape = ParaShape {
+        alignment: Alignment::Center,
+        ..Default::default()
+    };
+
+    let mut doc = Document::default();
+    doc.doc_info.para_shapes = vec![shape];
+
+    let mut eq = Equation::default();
+    eq.common.width = EQ_WIDTH;
+    eq.common.height = 4333;
+    eq.common.treat_as_char = true;
+    eq.script = "1 over 2".to_string();
+    eq.font_size = 1000;
+
+    let mut para = Paragraph::default();
+    para.para_shape_id = 0;
+    para.controls.push(Control::Equation(Box::new(eq)));
+    para.line_segs = vec![LineSeg {
+        text_start: 0,
+        vertical_pos: 0,
+        line_height: 4333,
+        text_height: 4333,
+        baseline_distance: 2773,
+        line_spacing: 1820,
+        column_start,
+        segment_width: COLUMN_WIDTH,
+        ..Default::default()
+    }];
+
+    let mut section = Section::default();
+    section.paragraphs.push(para);
+    doc.sections.push(section);
+    doc
+}
+
+/// 첫 수식 노드의 (x, w) 와 그 본문 영역 (x, w).
+fn equation_and_body(doc: &Document) -> ((f64, f64), (f64, f64)) {
+    let bytes = serialize_hwpx(doc).expect("HWPX 직렬화 실패");
+    let core = DocumentCore::from_bytes(&bytes).expect("재로드 실패");
+    let tree = core
+        .build_page_render_tree(0)
+        .expect("render tree 생성 실패");
+    let json: serde_json::Value =
+        serde_json::from_str(&tree.root.to_json()).expect("render tree JSON 파싱");
+
+    let mut eq: Option<(f64, f64)> = None;
+    let mut body: Option<(f64, f64)> = None;
+
+    fn walk(node: &serde_json::Value, eq: &mut Option<(f64, f64)>, body: &mut Option<(f64, f64)>) {
+        if let Some(obj) = node.as_object() {
+            let ty = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let bbox = obj
+                .get("bbox")
+                .and_then(|b| Some((b.get("x")?.as_f64()?, b.get("w")?.as_f64()?)));
+            if ty == "Body" && body.is_none() {
+                *body = bbox;
+            }
+            if ty == "Equation" && eq.is_none() {
+                *eq = bbox;
+            }
+            for (_, v) in obj {
+                walk(v, eq, body);
+            }
+        } else if let Some(arr) = node.as_array() {
+            for v in arr {
+                walk(v, eq, body);
+            }
+        }
+    }
+
+    walk(&json, &mut eq, &mut body);
+    (
+        eq.expect("수식 노드를 찾지 못했다"),
+        body.expect("본문 영역을 찾지 못했다"),
+    )
+}
+
+#[test]
+fn issue_5583_body_equation_follows_paragraph_center() {
+    let ((eq_x, eq_w), (body_x, body_w)) = equation_and_body(&document_with_centered_equation(0));
+    let want = body_x + (body_w - eq_w) / 2.0;
+    assert!(
+        (eq_x - want).abs() <= 2.0,
+        "가운데 정렬 문단의 본문 수식이 x={eq_x:.1} 에 놓였다 (가운데는 {want:.1}) (#5583)"
+    );
+}
+
+#[test]
+fn issue_5583_stored_line_start_still_wins() {
+    // 저장 LINE_SEG 가 흐름 x 를 담고 있으면(#1256/#1308) 그 값을 존중한다 —
+    // 정렬 오프셋으로 덮어쓰지 않는다.
+    let ((eq_x, eq_w), (body_x, body_w)) =
+        equation_and_body(&document_with_centered_equation(6000));
+    let centered = body_x + (body_w - eq_w) / 2.0;
+    assert!(
+        (eq_x - centered).abs() > 2.0,
+        "저장 column_start 가 있는 줄까지 가운데로 옮기면 #1256/#1308 계약이 깨진다 (x={eq_x:.1})"
+    );
+}


### PR DESCRIPTION
## 변경 요약

본문 흐름의 **수식-only 줄**도 문단 정렬을 따르게 한다. 종전에는 정렬 오프셋이 표 셀 안에서만
계산되고 본문에서는 `0.0` 으로 굳어 있어, 가운데 정렬 문단의 수식이 단 왼쪽 끝에 그려졌다.

```rust
let align_offset = if cell_ctx.is_some() {
    match alignment { Center | Distribute => (avail - line_tac_width) / 2.0, Right => …, _ => 0.0 }
} else {
    0.0            // ← 본문이면 정렬을 아예 무시
};
```

저장 `LINE_SEG.column_start > 0` 인 줄은 한컴이 흐름 x 를 적어 둔 경우이므로 #1256/#1308 계약대로
저장값을 존중하고, `== 0`(위치 정보 없음)인 줄에만 문단 정렬을 적용한다.

## 관련 이슈

#5583

**이슈 전제 정정**: 이슈 본문에는 "자리차지(treatAsChar=0) 개체"라고 적었으나 실제로는
**글자처럼 취급(treatAsChar=1)** 수식이다. 원문 작성 때 문서의 다른 개체 `hp:pos` 를 잘못 읽었다.
따라서 축도 "자리차지 개체의 가로 기준"이 아니라 **본문 인라인 수식 줄의 정렬 누락**이다.

## 원인 규명 — 임시 계측으로 확정

재현: `admrul_downloads/국가유산청/3252633_[별표 1] 책임 및 상주감리원 배치기준…`(코퍼스 00192)
2·3쪽 수식(폭 254.6px), 본문 좌측 75.6px.

1. `layout_shape` 의 정렬 기반 배치는 **조기 반환**한다(인라인 좌표가 이미 등록됨).

   ```
   DBG_EQ pi=7  inline=true align=Center colx=75.6 colw=642.5 w=254.6
   DBG_EQ pi=12 inline=true align=Center colx=75.6 colw=642.5 w=254.6
   ```

2. 문단 정렬 해석은 정상이다 — `align=Center`.
3. 실제 x 는 `place_empty_line_inline_equations` 의 `align_offset` 이 정하고, 그 값이 본문에서 0.0 이었다.

저장 LINE_SEG 도 확인했다 — 해당 줄은 `cs=0 sw=48188`(단 전체)라 흐름 x 정보가 없다.

## 검증

| 항목 | 결과 |
|---|---|
| 00192 3쪽 수식 | x **75.6 → 269.6** (기대 가운데 269.6) |
| 표본 1,000문서에서 위치가 바뀐 수식 | **3개 — 전부 가운데로 이동**, 그 외 **0** |
| 쪽수 회귀 (표본 1,000문서, rhwp 자체 조판) | **변화 0건** |

처리 결과 문서: `mydocs/working/task_5583_body_equation_alignment.md`

## 테스트

- [x] **`cargo fmt --all -- --check` 통과**
- [x] `node scripts/rust-test-suite-manifest.mjs --check` 통과
- [x] `cargo test` — 범위 대상만 (아래 명시)
- [x] `cargo clippy --all-targets -- -D warnings` 통과
- [x] 렌더 결과 확인 — `export-render-tree` 좌표 대조(위 표), 표본 1,000문서 쪽수 무변화
- [ ] 웹(WASM)·rhwp-studio — 해당 없음

**돌린 테스트**

| 명령 | 이유 |
|---|---|
| `cargo test --test regression_suite_027 -- issue_5583` | 이 PR 이 추가한 계약 테스트 2건 (2 passed) |

추가한 계약 테스트 `tests/cases/issue_5583_body_equation_alignment.rs`:

1. 가운데 정렬 문단의 본문 수식이 본문 폭 기준 가운데에 놓인다
2. 저장 `column_start` 가 있는 줄은 정렬 오프셋으로 덮이지 않는다(#1256/#1308 보호)
