### PR TITLE
조회 CLI 50개를 rhwp-q-kit에 모은다

### DIFF
--- a/mydocs/working/agent_q_kit.md
+++ b/mydocs/working/agent_q_kit.md
@@ -1,0 +1,6 @@
+# rhwp-q-kit — 조회 CLI 50개
+
+선점 목록: `C:/Users/swsz9/.rhwp-cli-registry.json` 의 `claimed_pack50`.
+이미 있는 `rhwp-agent` 80명령, `rhwp-q-*` 15명령, 진행 중 단건 PR 4개(para-shape, object-cycle, page-def, section-starts)와 이름이 겹치지 않는다.
+
+이 바이너리는 DocumentCore 공개 조회만 부른다. 편집 API·더미 JSON 코퍼스·src `#[cfg(test)]` 는 없다. 회귀는 `tests/cases/agent_q_kit_contract.rs`.

--- a/src/bin/rhwp-q-kit/auto_numbers.rs
+++ b/src/bin/rhwp-q-kit/auto_numbers.rs
@@ -1,0 +1,45 @@
+//! auto-numbers — `Control::AutoNumber` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit auto-numbers <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::AutoNumber(an) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["numberType"] = json!(an.number_type);
+        item["format"] = json!(an.format);
+        item["superscript"] = json!(an.superscript);
+        item["assignedNumber"] = json!(an.assigned_number);
+        item["number"] = json!(an.number);
+        item["userSymbol"] = json!(an.user_symbol.to_string());
+        item["prefixChar"] = json!(an.prefix_char.to_string());
+        item["suffixChar"] = json!(an.suffix_char.to_string());
+        items.push(item);
+    });
+    emit_items(
+        "auto-numbers",
+        &opts.path,
+        opts.json,
+        items,
+        &[
+            "items[].userSymbol",
+            "items[].prefixChar",
+            "items[].suffixChar",
+        ],
+    )
+}

--- a/src/bin/rhwp-q-kit/bin_data.rs
+++ b/src/bin/rhwp-q-kit/bin_data.rs
@@ -1,0 +1,101 @@
+//! 임베드 바이너리 길이·종류 — `DocumentCore::get_bin_data`.
+
+use crate::envelope::{envelope, load_core, parse_usize, print_json, write_stdout, EXIT_USAGE};
+use base64::Engine;
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit bin-data <파일> --index <N> [--include-bytes] [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut include_bytes = false;
+    let mut path: Option<String> = None;
+    let mut index: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--include-bytes" => {
+                include_bytes = true;
+                i += 1;
+            }
+            "--index" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --index 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                index = Some(match parse_usize("--index", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(index)) = (path, index) else {
+        eprintln!("오류: 파일과 --index 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let slot = core.document().bin_data_content.get(index);
+    let bytes = core.get_bin_data(index);
+    let present = bytes.is_some();
+    let len = bytes.as_ref().map(|b| b.len()).unwrap_or(0);
+    let id = slot.map(|s| s.id);
+    let extension = slot.map(|s| s.extension.as_str());
+    let mut payload = json!({
+        "source": path,
+        "index": index,
+        "present": present,
+        "len": len,
+        "id": id,
+        "extension": extension,
+    });
+    let mut untrusted: Vec<&str> = Vec::new();
+    if include_bytes {
+        if let Some(data) = bytes.as_ref() {
+            payload["bytesBase64"] = json!(base64::engine::general_purpose::STANDARD.encode(data));
+            untrusted.push("bytesBase64");
+        }
+    }
+    if json_mode {
+        print_json(&envelope("bin-data", payload, &untrusted))
+    } else {
+        let ext = extension.unwrap_or("");
+        let line = format!("present={present} len={len} extension={ext}");
+        if include_bytes {
+            if let Some(data) = bytes.as_ref() {
+                write_stdout(&format!(
+                    "{line} bytesBase64={}",
+                    base64::engine::general_purpose::STANDARD.encode(data)
+                ))
+            } else {
+                write_stdout(&line)
+            }
+        } else {
+            write_stdout(&line)
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/canvaskit_preflight.rs
+++ b/src/bin/rhwp-q-kit/canvaskit_preflight.rs
@@ -1,0 +1,100 @@
+//! canvaskit-preflight — `get_canvaskit_document_preflight_native`. 조회만 한다.
+
+use rhwp::paint::RenderProfile;
+use serde_json::json;
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, print_json, write_stdout, EXIT_RUNTIME, EXIT_USAGE,
+};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str =
+        "rhwp-q-kit canvaskit-preflight <파일> [--mode default|compat] [--profile screen|print|high-quality|fast-preview] [--json]";
+    let mut path = None;
+    let mut json_mode = false;
+    let mut mode = "default".to_string();
+    let mut profile = RenderProfile::Screen;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--mode" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("오류: --mode 뒤에 값이 필요합니다 (default|compat).");
+                    return EXIT_USAGE;
+                };
+                match v.trim().to_ascii_lowercase().as_str() {
+                    "" | "default" | "compat" | "compatibility" => mode = v.clone(),
+                    _ => {
+                        eprintln!(
+                            "오류: 지원하지 않는 CanvasKit replay mode입니다: {v}. allowed modes: default, compat"
+                        );
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            "--profile" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!(
+                        "오류: --profile 뒤에 값이 필요합니다 (screen|print|high-quality|fast-preview)."
+                    );
+                    return EXIT_USAGE;
+                };
+                match RenderProfile::parse(v) {
+                    Some(p) => profile = p,
+                    None => {
+                        eprintln!(
+                            "오류: --profile 값이 올바르지 않습니다 (screen|print|high-quality|fast-preview)."
+                        );
+                        return EXIT_USAGE;
+                    }
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.replace(other.to_string()).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_canvaskit_document_preflight_native(&mode, profile) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: CanvasKit 사전점검 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let preflight = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let payload = json!({
+        "source": path,
+        "mode": mode,
+        "preflight": preflight,
+    });
+    if json_mode {
+        print_json(&envelope("canvaskit-preflight", payload, &["preflight"]))
+    } else {
+        let status = payload["preflight"]["status"].as_str().unwrap_or("unknown");
+        write_stdout(&format!("status={status}"))
+    }
+}

--- a/src/bin/rhwp-q-kit/caret_stops.rs
+++ b/src/bin/rhwp-q-kit/caret_stops.rs
@@ -1,0 +1,90 @@
+//! 캐럿 정지 위치 — `DocumentCore::caret_stops_json`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit caret-stops <파일> --list <N> --para <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para)) = (path, list, para) else {
+        eprintln!("오류: 파일과 --list --para 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let stops = match parse_json_string(&core.caret_stops_json(list, para)) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    if json_mode {
+        print_json(&envelope(
+            "caret-stops",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "stops": stops,
+            }),
+            &["stops"],
+        ))
+    } else {
+        write_stdout(&stops.to_string())
+    }
+}

--- a/src/bin/rhwp-q-kit/cell_shape.rs
+++ b/src/bin/rhwp-q-kit/cell_shape.rs
@@ -1,0 +1,124 @@
+//! 셀 CellShape 파라미터셋 (`Width`·`Height`·`VertAlign`).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "cell-shape";
+const USAGE: &str = "rhwp-q-kit cell-shape <파일> --list <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = core.cell_shape_set_json(opts.list);
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({ "source": opts.path, "list": opts.list });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(
+            CMD,
+            payload,
+            &["source", "Width", "Height", "VertAlign"],
+        ))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    list: u32,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--list" => list = Some(take_u32(args, &mut i, "--list")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        list: require(list, "--list")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/char_index.rs
+++ b/src/bin/rhwp-q-kit/char_index.rs
@@ -1,0 +1,112 @@
+//! 스트림 자리의 글자 인덱스 — `DocumentCore::char_index_at`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit char-index <파일> --list <N> --para <N> --pos <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut pos: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                pos = Some(match parse_usize("--pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para), Some(pos)) = (path, list, para, pos) else {
+        eprintln!("오류: 파일과 --list --para --pos 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.char_index_at(list, para, pos) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 글자 인덱스를 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let got = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let char_index = got.get("charIndex").cloned().unwrap_or(json!(0));
+    if json_mode {
+        print_json(&envelope(
+            "char-index",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "pos": pos,
+                "charIndex": char_index,
+            }),
+            &["charIndex"],
+        ))
+    } else {
+        write_stdout(&format!("charIndex={char_index}"))
+    }
+}

--- a/src/bin/rhwp-q-kit/chart_csv.rs
+++ b/src/bin/rhwp-q-kit/chart_csv.rs
@@ -1,0 +1,151 @@
+//! 차트 데이터 CSV — `chart_extract::collect_charts` + `chart_csv::to_csv`.
+//!
+//! `--chart N` 은 1-based (`ChartRef::index + 1`).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use rhwp::document_core::queries::chart_csv::to_csv;
+use rhwp::document_core::queries::chart_extract::collect_charts;
+use serde_json::{json, Value};
+
+const USAGE: &str = "rhwp-q-kit chart-csv <파일> --chart <N> [--json]";
+
+fn strings(v: &Value) -> Vec<String> {
+    v.as_array()
+        .map(|a| {
+            a.iter()
+                .map(|x| x.as_str().unwrap_or_default().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut chart: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--chart" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --chart 뒤에 1 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                let n = match parse_usize("--chart", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                if n < 1 {
+                    eprintln!("오류: --chart 뒤에 1 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                chart = Some(n);
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(chart)) = (path, chart) else {
+        eprintln!("오류: 파일과 --chart 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let charts = collect_charts(core.document());
+    let index = chart - 1;
+    if index >= charts.len() {
+        eprintln!(
+            "오류: 차트 {} 번이 없습니다 (차트 {}개).",
+            chart,
+            charts.len()
+        );
+        return EXIT_RUNTIME;
+    }
+    let raw = match core.get_chart_data_by_index_native(index) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 차트 {chart} 데이터를 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let read = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    if read["ok"] != true {
+        eprintln!(
+            "오류: 차트 {chart} 를 읽을 수 없습니다 - {}",
+            read["invalid"][0]["message"]
+                .as_str()
+                .unwrap_or("사유 미상")
+        );
+        return EXIT_RUNTIME;
+    }
+    if read["labelsShared"] != true {
+        let axis = if read["axis"].as_str() == Some("scatter") {
+            "X 값"
+        } else {
+            "카테고리 라벨"
+        };
+        eprintln!(
+            "오류: 차트 {chart} 는 계열마다 {axis}이 달라 CSV 한 열로 안전하게 표현할 수 없습니다."
+        );
+        return EXIT_RUNTIME;
+    }
+    let labels = strings(&read["labels"]);
+    let series = read["series"].as_array().cloned().unwrap_or_default();
+    let names: Vec<String> = series
+        .iter()
+        .map(|s| s["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    let values: Vec<Vec<String>> = series.iter().map(|s| strings(&s["values"])).collect();
+    let scatter = read["axis"].as_str() == Some("scatter");
+    let csv = to_csv(&labels, &names, &values, scatter);
+    let rows = values
+        .iter()
+        .map(|s| s.len())
+        .chain(std::iter::once(labels.len()))
+        .max()
+        .unwrap_or(0);
+    if json_mode {
+        print_json(&envelope(
+            "chart-csv",
+            json!({
+                "source": path,
+                "chart": chart,
+                "rowCount": rows,
+                "colCount": names.len(),
+                "scatter": scatter,
+                "csv": csv,
+            }),
+            &["csv"],
+        ))
+    } else {
+        write_stdout(&csv)
+    }
+}

--- a/src/bin/rhwp-q-kit/chart_list.rs
+++ b/src/bin/rhwp-q-kit/chart_list.rs
@@ -1,0 +1,38 @@
+//! chart-list — `chart_extract::collect_charts` 조회. 편집 없음.
+
+use rhwp::document_core::queries::chart_extract::collect_charts;
+use serde_json::json;
+
+use crate::envelope::{
+    envelope, load_core, parse_one_file, print_json, write_stdout, EXIT_RUNTIME,
+};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit chart-list <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let charts = collect_charts(core.document());
+    let items = match serde_json::to_value(&charts) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("오류: 차트 목록 JSON 직렬화 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let payload = json!({
+        "source": opts.path,
+        "chartCount": charts.len(),
+        "charts": items,
+    });
+    if opts.json {
+        print_json(&envelope("chart-list", payload, &["charts"]))
+    } else {
+        write_stdout(&format!("charts={}", charts.len()))
+    }
+}

--- a/src/bin/rhwp-q-kit/covering_pages.rs
+++ b/src/bin/rhwp-q-kit/covering_pages.rs
@@ -1,0 +1,90 @@
+//! 문단이 걸친 쪽 — `DocumentCore::pages_covering_paragraphs`.
+
+use crate::envelope::{envelope, load_core, parse_usize, print_json, write_stdout, EXIT_USAGE};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit covering-pages <파일> --section <N> --para <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--section" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --section 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                section = Some(match parse_usize("--section", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(section), Some(para)) = (path, section, para) else {
+        eprintln!("오류: 파일과 --section --para 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let mut core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let pages = core.pages_covering_paragraphs(&[(section, para)]);
+    let covered = pages.is_some();
+    let payload = json!({
+        "source": path,
+        "section": section,
+        "para": para,
+        "covered": covered,
+        "pages": pages.clone(),
+    });
+    if json_mode {
+        print_json(&envelope("covering-pages", payload, &[]))
+    } else if let Some(list) = pages {
+        let joined = list
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        write_stdout(&format!("pages={joined}"))
+    } else {
+        write_stdout("covered=false")
+    }
+}

--- a/src/bin/rhwp-q-kit/cur_field_state.rs
+++ b/src/bin/rhwp-q-kit/cur_field_state.rs
@@ -1,0 +1,99 @@
+//! 커서 자리 필드 상태 비트 (CurFieldState).
+
+use crate::envelope::{
+    envelope, load_core, parse_u32, parse_usize, print_json, write_stdout, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit cur-field-state <파일> --list <N> --para <N> --pos <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut pos: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                pos = Some(match parse_usize("--pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para), Some(pos)) = (path, list, para, pos) else {
+        eprintln!("오류: 파일과 --list --para --pos 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let state = core.cur_field_state(list, para, pos);
+    if json_mode {
+        print_json(&envelope(
+            "cur-field-state",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "pos": pos,
+                "state": state,
+            }),
+            &[],
+        ))
+    } else {
+        write_stdout(&state.to_string())
+    }
+}

--- a/src/bin/rhwp-q-kit/cursor_in_cell.rs
+++ b/src/bin/rhwp-q-kit/cursor_in_cell.rs
@@ -1,0 +1,162 @@
+//! 셀 안 캐럿 사각형.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "cursor-in-cell";
+const USAGE: &str = "rhwp-q-kit cursor-in-cell <파일> --section <N> --para <N> --ci <N> --cell <N> --cell-para <N> --offset <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_cursor_rect_in_cell_native(
+        opts.section,
+        opts.para,
+        opts.ci,
+        opts.cell,
+        opts.cell_para,
+        opts.offset,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 셀 캐럿 사각형을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "section": opts.section,
+        "para": opts.para,
+        "ci": opts.ci,
+        "cell": opts.cell,
+        "cellPara": opts.cell_para,
+        "offset": opts.offset,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    section: usize,
+    para: usize,
+    ci: usize,
+    cell: usize,
+    cell_para: usize,
+    offset: usize,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut ci: Option<usize> = None;
+    let mut cell: Option<usize> = None;
+    let mut cell_para: Option<usize> = None;
+    let mut offset: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--section" => section = Some(take_usize(args, &mut i, "--section")?),
+            "--para" => para = Some(take_usize(args, &mut i, "--para")?),
+            "--ci" => ci = Some(take_usize(args, &mut i, "--ci")?),
+            "--cell" => cell = Some(take_usize(args, &mut i, "--cell")?),
+            "--cell-para" => cell_para = Some(take_usize(args, &mut i, "--cell-para")?),
+            "--offset" => offset = Some(take_usize(args, &mut i, "--offset")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        section: require(section, "--section")?,
+        para: require(para, "--para")?,
+        ci: require(ci, "--ci")?,
+        cell: require(cell, "--cell")?,
+        cell_para: require(cell_para, "--cell-para")?,
+        offset: require(offset, "--offset")?,
+    })
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/cursor_in_footnote.rs
+++ b/src/bin/rhwp-q-kit/cursor_in_footnote.rs
@@ -1,0 +1,157 @@
+//! 각주 안 캐럿 사각형.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "cursor-in-footnote";
+const USAGE: &str =
+    "rhwp-q-kit cursor-in-footnote <파일> --page <N> --index <N> --para <N> --offset <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_cursor_rect_in_footnote_native(
+        opts.page,
+        opts.index,
+        opts.para,
+        opts.offset,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 각주 캐럿 사각형을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "page": opts.page,
+        "index": opts.index,
+        "para": opts.para,
+        "offset": opts.offset,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+    index: usize,
+    para: usize,
+    offset: usize,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut index: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut offset: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            "--index" => index = Some(take_usize(args, &mut i, "--index")?),
+            "--para" => para = Some(take_usize(args, &mut i, "--para")?),
+            "--offset" => offset = Some(take_usize(args, &mut i, "--offset")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+        index: require(index, "--index")?,
+        para: require(para, "--para")?,
+        offset: require(offset, "--offset")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/cursor_in_hf.rs
+++ b/src/bin/rhwp-q-kit/cursor_in_hf.rs
@@ -1,0 +1,194 @@
+//! 머리말·꼬리말 캐럿 사각형.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "cursor-in-hf";
+const USAGE: &str = "rhwp-q-kit cursor-in-hf <파일> --section <N> --header|--footer --apply-to <N> --para <N> --offset <N> [--page <N>] [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_cursor_rect_in_header_footer_native(
+        opts.section,
+        opts.is_header,
+        opts.apply_to,
+        opts.para,
+        opts.offset,
+        opts.preferred_page,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 머리말·꼬리말 캐럿 사각형을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "section": opts.section,
+        "isHeader": opts.is_header,
+        "applyTo": opts.apply_to,
+        "para": opts.para,
+        "offset": opts.offset,
+        "preferredPage": opts.preferred_page,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    section: usize,
+    is_header: bool,
+    apply_to: u8,
+    para: usize,
+    offset: usize,
+    preferred_page: i32,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut is_header: Option<bool> = None;
+    let mut apply_to: Option<u8> = None;
+    let mut para: Option<usize> = None;
+    let mut offset: Option<usize> = None;
+    let mut page: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--header" => {
+                if is_header.replace(true).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                i += 1;
+            }
+            "--footer" => {
+                if is_header.replace(false).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                i += 1;
+            }
+            "--section" => section = Some(take_usize(args, &mut i, "--section")?),
+            "--apply-to" => apply_to = Some(take_apply_to(args, &mut i)?),
+            "--para" => para = Some(take_usize(args, &mut i, "--para")?),
+            "--offset" => offset = Some(take_usize(args, &mut i, "--offset")?),
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        section: require(section, "--section")?,
+        is_header: require(is_header, "--header|--footer")?,
+        apply_to: require(apply_to, "--apply-to")?,
+        para: require(para, "--para")?,
+        offset: require(offset, "--offset")?,
+        preferred_page: page.map(|p| p as i32).unwrap_or(-1),
+    })
+}
+
+fn take_apply_to(args: &[String], i: &mut usize) -> Result<u8, i32> {
+    let raw = take_val(args, *i, "--apply-to")?;
+    *i += 2;
+    let v = parse_u32("--apply-to", raw)?;
+    if v > 2 {
+        eprintln!("오류: --apply-to 는 0(양쪽)·1(짝수)·2(홀수) 만 허용합니다 - {raw}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(v as u8)
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/cursor_in_note.rs
+++ b/src/bin/rhwp-q-kit/cursor_in_note.rs
@@ -1,0 +1,156 @@
+//! 노트(각주·미주) 안 캐럿 사각형.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "cursor-in-note";
+const USAGE: &str = "rhwp-q-kit cursor-in-note <파일> --section <N> --para <N> --ci <N> --note-para <N> --offset <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_cursor_rect_in_note_native(
+        opts.section,
+        opts.para,
+        opts.ci,
+        opts.note_para,
+        opts.offset,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 노트 캐럿 사각형을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "section": opts.section,
+        "para": opts.para,
+        "ci": opts.ci,
+        "notePara": opts.note_para,
+        "offset": opts.offset,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    section: usize,
+    para: usize,
+    ci: usize,
+    note_para: usize,
+    offset: usize,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut ci: Option<usize> = None;
+    let mut note_para: Option<usize> = None;
+    let mut offset: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--section" => section = Some(take_usize(args, &mut i, "--section")?),
+            "--para" => para = Some(take_usize(args, &mut i, "--para")?),
+            "--ci" => ci = Some(take_usize(args, &mut i, "--ci")?),
+            "--note-para" => note_para = Some(take_usize(args, &mut i, "--note-para")?),
+            "--offset" => offset = Some(take_usize(args, &mut i, "--offset")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        section: require(section, "--section")?,
+        para: require(para, "--para")?,
+        ci: require(ci, "--ci")?,
+        note_para: require(note_para, "--note-para")?,
+        offset: require(offset, "--offset")?,
+    })
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/empty_doc.rs
+++ b/src/bin/rhwp-q-kit/empty_doc.rs
@@ -1,0 +1,24 @@
+//! 빈 문서 여부 — 웹한글컨트롤 `IsEmpty`.
+
+use crate::envelope::{envelope, load_core, parse_one_file, print_json, write_stdout};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit empty-doc <파일> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let empty = core.is_empty_document();
+    let payload = json!({ "source": opts.path, "empty": empty });
+    if opts.json {
+        print_json(&envelope("empty-doc", payload, &[]))
+    } else {
+        write_stdout(if empty { "true" } else { "false" })
+    }
+}

--- a/src/bin/rhwp-q-kit/envelope.rs
+++ b/src/bin/rhwp-q-kit/envelope.rs
@@ -1,0 +1,351 @@
+//! rhwp-q-kit 공통 봉투·적재. 편집 API 는 여기서 부르지 않는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::shape::ShapeObject;
+use serde_json::{json, Map, Value};
+use std::io::Write;
+
+pub const EXIT_OK: i32 = 0;
+pub const EXIT_RUNTIME: i32 = 1;
+pub const EXIT_USAGE: i32 = 2;
+pub const TOOL: &str = "rhwp-q-kit";
+
+pub fn envelope(command: &str, mut payload: Value, untrusted: &[&str]) -> Value {
+    if let Some(map) = payload.as_object_mut() {
+        map.insert(
+            "schemaVersion".into(),
+            json!(rhwp::schema_registry::ENVELOPE_SCHEMA_VERSION),
+        );
+        map.insert("tool".into(), json!(TOOL));
+        map.insert("command".into(), json!(command));
+        map.insert("version".into(), json!(rhwp::version()));
+        map.insert("untrustedContent".into(), json!(!untrusted.is_empty()));
+        map.insert("untrustedFields".into(), json!(untrusted));
+    }
+    payload
+}
+
+pub fn write_stdout(text: &str) -> i32 {
+    let stdout = std::io::stdout();
+    let mut lock = stdout.lock();
+    if let Err(e) = writeln!(lock, "{text}") {
+        eprintln!("오류: stdout 쓰기 실패 - {e}");
+        return EXIT_RUNTIME;
+    }
+    EXIT_OK
+}
+
+pub fn print_json(value: &Value) -> i32 {
+    match serde_json::to_string_pretty(value) {
+        Ok(s) => write_stdout(&s),
+        Err(e) => {
+            eprintln!("오류: JSON 직렬화 실패 - {e}");
+            EXIT_RUNTIME
+        }
+    }
+}
+
+pub fn read_file(path: &str) -> Result<Vec<u8>, i32> {
+    std::fs::read(path).map_err(|e| {
+        eprintln!("오류: 파일을 읽을 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })
+}
+
+pub fn load_core(path: &str) -> Result<DocumentCore, i32> {
+    let data = read_file(path)?;
+    DocumentCore::from_bytes(&data).map_err(|e| {
+        eprintln!("오류: 문서를 열 수 없습니다 - {path}: {e}");
+        EXIT_RUNTIME
+    })
+}
+
+pub fn parse_u32(flag: &str, raw: &str) -> Result<u32, i32> {
+    raw.parse::<u32>().map_err(|_| {
+        eprintln!("오류: {flag} 뒤에 0 이상의 정수가 필요합니다 - {raw}");
+        EXIT_USAGE
+    })
+}
+
+pub fn parse_usize(flag: &str, raw: &str) -> Result<usize, i32> {
+    raw.parse::<usize>().map_err(|_| {
+        eprintln!("오류: {flag} 뒤에 0 이상의 정수가 필요합니다 - {raw}");
+        EXIT_USAGE
+    })
+}
+
+pub fn parse_f64(flag: &str, raw: &str) -> Result<f64, i32> {
+    raw.parse::<f64>().map_err(|_| {
+        eprintln!("오류: {flag} 뒤에 실수가 필요합니다 - {raw}");
+        EXIT_USAGE
+    })
+}
+
+pub fn parse_json_string(raw: &str) -> Result<Value, i32> {
+    serde_json::from_str(raw).map_err(|e| {
+        eprintln!("오류: 코어 JSON 파싱 실패 - {e}");
+        EXIT_RUNTIME
+    })
+}
+
+pub struct FileOpts {
+    pub path: String,
+    pub json: bool,
+}
+
+pub fn parse_one_file(args: &[String], usage: &str) -> Result<FileOpts, i32> {
+    let mut path = None;
+    let mut json = false;
+    for a in args {
+        match a.as_str() {
+            "--json" => json = true,
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.replace(other.to_string()).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return Err(EXIT_USAGE);
+                }
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return Err(EXIT_USAGE);
+    };
+    Ok(FileOpts { path, json })
+}
+
+pub fn emit_items(
+    command: &str,
+    source: &str,
+    json_mode: bool,
+    items: Vec<Value>,
+    untrusted: &[&str],
+) -> i32 {
+    let count = items.len();
+    let payload = json!({
+        "source": source,
+        "count": count,
+        "items": items,
+    });
+    if json_mode {
+        print_json(&envelope(command, payload, untrusted))
+    } else {
+        write_stdout(&format!("{command}={count}"))
+    }
+}
+
+/// 컨트롤 위치. 중첩 컨테이너면 `paragraph`/`control` 은 그 컨테이너 문단 기준.
+pub struct CtrlAt<'a> {
+    pub section: usize,
+    pub paragraph: usize,
+    pub control: usize,
+    pub container: &'static str,
+    pub cell: Option<usize>,
+    pub ctrl: &'a Control,
+}
+
+pub fn loc_json(at: &CtrlAt<'_>) -> Value {
+    let mut map = Map::new();
+    map.insert("section".into(), json!(at.section));
+    map.insert("paragraph".into(), json!(at.paragraph));
+    map.insert("control".into(), json!(at.control));
+    map.insert("container".into(), json!(at.container));
+    if let Some(cell) = at.cell {
+        map.insert("cell".into(), json!(cell));
+    }
+    Value::Object(map)
+}
+
+const MAX_NEST_DEPTH: usize = 8;
+
+pub fn for_each_control(doc: &Document, mut visit: impl FnMut(CtrlAt<'_>)) {
+    for (section, sec) in doc.sections.iter().enumerate() {
+        walk_paragraphs(&sec.paragraphs, section, "body", None, 0, &mut visit);
+    }
+}
+
+fn walk_paragraphs<'a>(
+    paragraphs: &'a [Paragraph],
+    section: usize,
+    container: &'static str,
+    cell: Option<usize>,
+    depth: usize,
+    visit: &mut impl FnMut(CtrlAt<'a>),
+) {
+    if depth >= MAX_NEST_DEPTH {
+        return;
+    }
+    for (paragraph, para) in paragraphs.iter().enumerate() {
+        for (control, ctrl) in para.controls.iter().enumerate() {
+            visit(CtrlAt {
+                section,
+                paragraph,
+                control,
+                container,
+                cell,
+                ctrl,
+            });
+            walk_nested(ctrl, section, depth, visit);
+        }
+    }
+}
+
+fn walk_nested<'a>(
+    ctrl: &'a Control,
+    section: usize,
+    depth: usize,
+    visit: &mut impl FnMut(CtrlAt<'a>),
+) {
+    if depth + 1 >= MAX_NEST_DEPTH {
+        return;
+    }
+    match ctrl {
+        Control::Table(table) => {
+            for (cell, c) in table.cells.iter().enumerate() {
+                walk_paragraphs(
+                    &c.paragraphs,
+                    section,
+                    "tableCell",
+                    Some(cell),
+                    depth + 1,
+                    visit,
+                );
+            }
+            if let Some(caption) = &table.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+        }
+        Control::Header(h) => {
+            walk_paragraphs(&h.paragraphs, section, "header", None, depth + 1, visit);
+        }
+        Control::Footer(f) => {
+            walk_paragraphs(&f.paragraphs, section, "footer", None, depth + 1, visit);
+        }
+        Control::Footnote(f) => {
+            walk_paragraphs(&f.paragraphs, section, "footnote", None, depth + 1, visit);
+        }
+        Control::Endnote(e) => {
+            walk_paragraphs(&e.paragraphs, section, "endnote", None, depth + 1, visit);
+        }
+        Control::HiddenComment(hc) => {
+            walk_paragraphs(
+                &hc.paragraphs,
+                section,
+                "hiddenComment",
+                None,
+                depth + 1,
+                visit,
+            );
+        }
+        Control::Picture(pic) => {
+            if let Some(caption) = &pic.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+        }
+        Control::Shape(shape) => walk_shape(shape, section, depth, visit),
+        _ => {}
+    }
+}
+
+fn walk_shape<'a>(
+    shape: &'a ShapeObject,
+    section: usize,
+    depth: usize,
+    visit: &mut impl FnMut(CtrlAt<'a>),
+) {
+    if depth + 1 >= MAX_NEST_DEPTH {
+        return;
+    }
+    if let Some(drawing) = shape.drawing() {
+        if let Some(tb) = drawing.text_box.as_ref() {
+            walk_paragraphs(&tb.paragraphs, section, "textbox", None, depth + 1, visit);
+        }
+        if let Some(caption) = drawing.caption.as_ref() {
+            walk_paragraphs(
+                &caption.paragraphs,
+                section,
+                "caption",
+                None,
+                depth + 1,
+                visit,
+            );
+        }
+    }
+    match shape {
+        ShapeObject::Group(g) => {
+            if let Some(caption) = &g.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+            for child in &g.children {
+                walk_shape(child, section, depth + 1, visit);
+            }
+        }
+        ShapeObject::Picture(p) => {
+            if let Some(caption) = &p.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+        }
+        ShapeObject::Chart(c) => {
+            if let Some(caption) = &c.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+        }
+        ShapeObject::Ole(o) => {
+            if let Some(caption) = &o.caption {
+                walk_paragraphs(
+                    &caption.paragraphs,
+                    section,
+                    "caption",
+                    None,
+                    depth + 1,
+                    visit,
+                );
+            }
+        }
+        _ => {}
+    }
+}

--- a/src/bin/rhwp-q-kit/equations.rs
+++ b/src/bin/rhwp-q-kit/equations.rs
@@ -1,0 +1,42 @@
+//! equations — `Control::Equation` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit equations <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::Equation(eq) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["script"] = json!(&eq.script);
+        item["fontSize"] = json!(eq.font_size);
+        item["fontName"] = json!(&eq.font_name);
+        item["color"] = json!(eq.color);
+        item["baseline"] = json!(eq.baseline);
+        item["attr"] = json!(eq.attr);
+        item["width"] = json!(eq.common.width);
+        item["height"] = json!(eq.common.height);
+        item["treatAsChar"] = json!(eq.common.treat_as_char);
+        items.push(item);
+    });
+    emit_items(
+        "equations",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].script", "items[].fontName"],
+    )
+}

--- a/src/bin/rhwp-q-kit/field_by_id.rs
+++ b/src/bin/rhwp-q-kit/field_by_id.rs
@@ -1,0 +1,98 @@
+//! 필드 id 로 현재 값.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit field-by-id <파일> --id <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut id: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--id" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --id 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                id = Some(match parse_u32("--id", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(id)) = (path, id) else {
+        eprintln!("오류: 파일과 --id 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    match core.get_field_value_by_id(id) {
+        Ok(raw) => {
+            if json_mode {
+                let data = match parse_json_string(&raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                let mut payload = json!({ "source": path, "id": id, "found": true });
+                absorb(&mut payload, data);
+                print_json(&envelope("field-by-id", payload, &["value"]))
+            } else {
+                write_stdout(&raw)
+            }
+        }
+        Err(e) if e.to_string().contains("없음") => {
+            if json_mode {
+                print_json(&envelope(
+                    "field-by-id",
+                    json!({ "source": path, "id": id, "found": false, "ok": false }),
+                    &[],
+                ))
+            } else {
+                write_stdout("missing")
+            }
+        }
+        Err(e) => {
+            eprintln!("오류: 필드 값을 읽지 못했습니다 - {e}");
+            EXIT_RUNTIME
+        }
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/field_info_at.rs
+++ b/src/bin/rhwp-q-kit/field_info_at.rs
@@ -1,0 +1,111 @@
+//! 커서 자리 필드 정보 (본문 문단).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit field-info-at <파일> --list <N> --para <N> --pos <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut pos: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_usize("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                pos = Some(match parse_usize("--pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para), Some(pos)) = (path, list, para, pos) else {
+        eprintln!("오류: 파일과 --list --para --pos 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    // 사용법의 --list 는 get_field_info_at 의 section_idx 다.
+    let raw = core.get_field_info_at(list, para, pos);
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({
+            "source": path,
+            "list": list,
+            "para": para,
+            "pos": pos,
+        });
+        absorb(&mut payload, data);
+        print_json(&envelope("field-info-at", payload, &["guideName"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/field_list_json.rs
+++ b/src/bin/rhwp-q-kit/field_list_json.rs
@@ -1,0 +1,64 @@
+//! 한글 필드 리스트 JSON.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, print_json, write_stdout, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit field-list-json <파일> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = core.get_field_list_json();
+    if json_mode {
+        let fields = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let count = fields.as_array().map(|a| a.len()).unwrap_or(0);
+        print_json(&envelope(
+            "field-list-json",
+            json!({ "source": path, "count": count, "fields": fields }),
+            &[
+                "fields[].name",
+                "fields[].guide",
+                "fields[].command",
+                "fields[].value",
+            ],
+        ))
+    } else {
+        write_stdout(&raw)
+    }
+}

--- a/src/bin/rhwp-q-kit/flow_images.rs
+++ b/src/bin/rhwp-q-kit/flow_images.rs
@@ -1,0 +1,127 @@
+//! 쪽 본문 흐름 그림 ops.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "flow-images";
+const USAGE: &str = "rhwp-q-kit flow-images <파일> --page <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_page_flow_image_ops_native(opts.page) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 본문 흐름 그림을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({ "source": opts.path, "page": opts.page });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source", "images[]"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/fn_selection_rects.rs
+++ b/src/bin/rhwp-q-kit/fn_selection_rects.rs
@@ -1,0 +1,151 @@
+//! 각주 내부 선택 영역의 줄별 사각형.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit fn-selection-rects <파일> --page <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut index: usize = 0;
+    let mut start_para: usize = 0;
+    let mut start_pos: usize = 0;
+    let mut end_para: usize = 0;
+    let mut end_pos: usize = 0;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--index" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --index 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                index = match parse_usize("--index", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                i += 2;
+            }
+            "--start-para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --start-para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                start_para = match parse_usize("--start-para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                i += 2;
+            }
+            "--start-pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --start-pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                start_pos = match parse_usize("--start-pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                i += 2;
+            }
+            "--end-para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --end-para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                end_para = match parse_usize("--end-para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                i += 2;
+            }
+            "--end-pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --end-pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                end_pos = match parse_usize("--end-pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                };
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page)) = (path, page) else {
+        eprintln!("오류: 파일과 --page 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_selection_rects_in_footnote_native(
+        page, index, start_para, start_pos, end_para, end_pos,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 각주 선택 사각형을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let rects = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let payload = json!({
+            "source": path,
+            "page": page,
+            "index": index,
+            "startPara": start_para,
+            "startPos": start_pos,
+            "endPara": end_para,
+            "endPos": end_pos,
+            "rects": rects,
+        });
+        print_json(&envelope("fn-selection-rects", payload, &["rects"]))
+    } else {
+        write_stdout(&raw)
+    }
+}

--- a/src/bin/rhwp-q-kit/footnote_footholds.rs
+++ b/src/bin/rhwp-q-kit/footnote_footholds.rs
@@ -1,0 +1,87 @@
+//! 쪽에 각주 발판이 있는지.
+
+use crate::envelope::{envelope, load_core, parse_u32, print_json, write_stdout, EXIT_USAGE};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit footnote-footholds <파일> --page <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let has = core.page_has_footnote_footholds_native(opts.page);
+    let payload = json!({
+        "source": opts.path,
+        "page": opts.page,
+        "hasFootholds": has,
+    });
+    if opts.json {
+        print_json(&envelope("footnote-footholds", payload, &[]))
+    } else {
+        write_stdout(if has { "true" } else { "false" })
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return Err(EXIT_USAGE);
+            }
+            other => {
+                if path.replace(other.to_string()).is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return Err(EXIT_USAGE);
+                }
+                i += 1;
+            }
+        }
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    let Some(page) = page else {
+        eprintln!("오류: --page 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    };
+    Ok(Opts { json, path, page })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = match args.get(*i + 1) {
+        Some(v) => v,
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            return Err(EXIT_USAGE);
+        }
+    };
+    *i += 2;
+    parse_u32(flag, raw)
+}

--- a/src/bin/rhwp-q-kit/footnote_hit.rs
+++ b/src/bin/rhwp-q-kit/footnote_hit.rs
@@ -1,0 +1,146 @@
+//! 좌표가 각주 영역인지 판별.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "footnote-hit";
+const USAGE: &str = "rhwp-q-kit footnote-hit <파일> --page <N> --x <F> --y <F> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.hit_test_footnote_native(opts.page, opts.x, opts.y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 각주 히트테스트를 하지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "page": opts.page,
+        "x": opts.x,
+        "y": opts.y,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+    x: f64,
+    y: f64,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            "--x" => x = Some(take_f64(args, &mut i, "--x")?),
+            "--y" => y = Some(take_f64(args, &mut i, "--y")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+        x: require(x, "--x")?,
+        y: require(y, "--y")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_f64(args: &[String], i: &mut usize, flag: &str) -> Result<f64, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_f64(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/footnote_info.rs
+++ b/src/bin/rhwp-q-kit/footnote_info.rs
@@ -1,0 +1,141 @@
+//! 쪽 각주 참조 좌표 (`sectionIdx`·`paraIdx`·`controlIdx`).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "footnote-info";
+const USAGE: &str = "rhwp-q-kit footnote-info <파일> --page <N> --index <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_page_footnote_info_native(opts.page, opts.index) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 각주 참조를 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "page": opts.page,
+        "index": opts.index,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+    index: usize,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut index: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            "--index" => index = Some(take_usize(args, &mut i, "--index")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+        index: require(index, "--index")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/form_at.rs
+++ b/src/bin/rhwp-q-kit/form_at.rs
@@ -1,0 +1,112 @@
+//! 페이지 좌표의 양식 개체.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit form-at <파일> --page <N> --x <F> --y <F> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--x" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --x 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                x = Some(match parse_f64("--x", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--y" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --y 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                y = Some(match parse_f64("--y", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page), Some(x), Some(y)) = (path, page, x, y) else {
+        eprintln!("오류: 파일과 --page --x --y 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_form_object_at_native(page, x, y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 양식 개체를 좌표로 찾지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({ "source": path, "page": page, "x": x, "y": y });
+        absorb(&mut payload, data);
+        print_json(&envelope("form-at", payload, &["name", "caption", "text"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/form_value.rs
+++ b/src/bin/rhwp-q-kit/form_value.rs
@@ -1,0 +1,121 @@
+//! 양식 개체 값.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit form-value <파일> --section <N> --para <N> --ci <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut ci: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--section" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --section 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                section = Some(match parse_usize("--section", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--ci" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --ci 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                ci = Some(match parse_usize("--ci", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(section), Some(para), Some(ci)) = (path, section, para, ci) else {
+        eprintln!("오류: 파일과 --section --para --ci 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_form_value_native(section, para, ci) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 양식 개체 값을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({
+            "source": path,
+            "section": section,
+            "para": para,
+            "ci": ci,
+        });
+        absorb(&mut payload, data);
+        print_json(&envelope(
+            "form-value",
+            payload,
+            &["name", "text", "caption"],
+        ))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/hf_edit_target.rs
+++ b/src/bin/rhwp-q-kit/hf_edit_target.rs
@@ -1,0 +1,108 @@
+//! 쪽의 머리말·꼬리말 편집 대상 (구역, applyTo).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit hf-edit-target <파일> --page <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut is_header: Option<bool> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--header" => {
+                if is_header.replace(true).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
+            }
+            "--footer" => {
+                if is_header.replace(false).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page)) = (path, page) else {
+        eprintln!("오류: 파일과 --page 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let is_header = is_header.unwrap_or(true);
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_header_footer_edit_target_native(page, is_header) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 머리말·꼬리말 편집 대상을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({
+            "source": path,
+            "page": page,
+            "isHeader": is_header,
+        });
+        absorb(&mut payload, data);
+        print_json(&envelope("hf-edit-target", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/hidden_comments.rs
+++ b/src/bin/rhwp-q-kit/hidden_comments.rs
@@ -1,0 +1,36 @@
+//! hidden-comments — `Control::HiddenComment` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit hidden-comments <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::HiddenComment(hc) = at.ctrl else {
+            return;
+        };
+        let paragraphs: Vec<&str> = hc.paragraphs.iter().map(|p| p.text.as_str()).collect();
+        let mut item = loc_json(&at);
+        item["paragraphCount"] = json!(paragraphs.len());
+        item["paragraphs"] = json!(paragraphs);
+        items.push(item);
+    });
+    emit_items(
+        "hidden-comments",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].paragraphs"],
+    )
+}

--- a/src/bin/rhwp-q-kit/hit_fn_marker.rs
+++ b/src/bin/rhwp-q-kit/hit_fn_marker.rs
@@ -1,0 +1,112 @@
+//! 본문 인라인 각주 표식 히트테스트.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit hit-fn-marker <파일> --page <N> --x <F> --y <F> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--x" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --x 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                x = Some(match parse_f64("--x", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--y" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --y 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                y = Some(match parse_f64("--y", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page), Some(x), Some(y)) = (path, page, x, y) else {
+        eprintln!("오류: 파일과 --page --x --y 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.hit_test_body_footnote_marker_native(page, x, y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 본문 각주 표식 히트를 하지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({ "source": path, "page": page, "x": x, "y": y });
+        absorb(&mut payload, data);
+        print_json(&envelope("hit-fn-marker", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/hit_header.rs
+++ b/src/bin/rhwp-q-kit/hit_header.rs
@@ -1,0 +1,146 @@
+//! 머리말·꼬리말 히트테스트.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "hit-header";
+const USAGE: &str = "rhwp-q-kit hit-header <파일> --page <N> --x <F> --y <F> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.hit_test_header_footer_native(opts.page, opts.x, opts.y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 머리말·꼬리말 히트테스트를 하지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "page": opts.page,
+        "x": opts.x,
+        "y": opts.y,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+    x: f64,
+    y: f64,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            "--x" => x = Some(take_f64(args, &mut i, "--x")?),
+            "--y" => y = Some(take_f64(args, &mut i, "--y")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+        x: require(x, "--x")?,
+        y: require(y, "--y")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_f64(args: &[String], i: &mut usize, flag: &str) -> Result<f64, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_f64(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/hit_in_footnote.rs
+++ b/src/bin/rhwp-q-kit/hit_in_footnote.rs
@@ -1,0 +1,112 @@
+//! 각주 내부 텍스트 히트테스트.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit hit-in-footnote <파일> --page <N> --x <F> --y <F> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--x" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --x 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                x = Some(match parse_f64("--x", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--y" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --y 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                y = Some(match parse_f64("--y", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page), Some(x), Some(y)) = (path, page, x, y) else {
+        eprintln!("오류: 파일과 --page --x --y 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.hit_test_in_footnote_native(page, x, y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 각주 내부 히트를 하지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({ "source": path, "page": page, "x": x, "y": y });
+        absorb(&mut payload, data);
+        print_json(&envelope("hit-in-footnote", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/hit_in_hf.rs
+++ b/src/bin/rhwp-q-kit/hit_in_hf.rs
@@ -1,0 +1,136 @@
+//! 머리말·꼬리말 내부 텍스트 히트테스트.
+
+use crate::envelope::{
+    envelope, load_core, parse_f64, parse_json_string, parse_u32, print_json, write_stdout,
+    EXIT_RUNTIME, EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit hit-in-hf <파일> --page <N> --x <F> --y <F> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut x: Option<f64> = None;
+    let mut y: Option<f64> = None;
+    let mut is_header: Option<bool> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--header" => {
+                if is_header.replace(true).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
+            }
+            "--footer" => {
+                if is_header.replace(false).is_some() {
+                    eprintln!("오류: --header 와 --footer 중 하나만 지정합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_u32("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--x" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --x 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                x = Some(match parse_f64("--x", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--y" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --y 뒤에 실수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                y = Some(match parse_f64("--y", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page), Some(x), Some(y)) = (path, page, x, y) else {
+        eprintln!("오류: 파일과 --page --x --y 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let is_header = is_header.unwrap_or(true);
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.hit_test_in_header_footer_native(page, is_header, x, y) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 머리말·꼬리말 내부 히트를 하지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({
+            "source": path,
+            "page": page,
+            "x": x,
+            "y": y,
+            "isHeader": is_header,
+        });
+        absorb(&mut payload, data);
+        print_json(&envelope("hit-in-hf", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/hyperlinks.rs
+++ b/src/bin/rhwp-q-kit/hyperlinks.rs
@@ -1,0 +1,35 @@
+//! hyperlinks — `Control::Hyperlink` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit hyperlinks <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::Hyperlink(hl) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["url"] = json!(&hl.url);
+        item["text"] = json!(&hl.text);
+        items.push(item);
+    });
+    emit_items(
+        "hyperlinks",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].url", "items[].text"],
+    )
+}

--- a/src/bin/rhwp-q-kit/index_marks.rs
+++ b/src/bin/rhwp-q-kit/index_marks.rs
@@ -1,0 +1,35 @@
+//! index-marks — `Control::IndexMark` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit index-marks <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::IndexMark(im) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["firstKey"] = json!(&im.first_key);
+        item["secondKey"] = json!(&im.second_key);
+        items.push(item);
+    });
+    emit_items(
+        "index-marks",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].firstKey", "items[].secondKey"],
+    )
+}

--- a/src/bin/rhwp-q-kit/layer_tree.rs
+++ b/src/bin/rhwp-q-kit/layer_tree.rs
@@ -1,0 +1,79 @@
+//! layer-tree — `get_page_layer_tree_native(page)`. 조회만 한다.
+
+use serde_json::json;
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit layer-tree <파일> --page <N> [--json]";
+    let mut path = None;
+    let mut json_mode = false;
+    let mut page = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--page" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    return EXIT_USAGE;
+                };
+                match parse_u32("--page", v) {
+                    Ok(n) => page = Some(n),
+                    Err(c) => return c,
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.replace(other.to_string()).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let Some(page) = page else {
+        eprintln!("오류: --page 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_page_layer_tree_native(page) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 레이어 트리 조회 실패 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let tree = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let payload = json!({
+        "source": path,
+        "page": page,
+        "tree": tree,
+    });
+    if json_mode {
+        print_json(&envelope("layer-tree", payload, &["tree"]))
+    } else {
+        write_stdout(&format!("page={page} bytes={}", raw.len()))
+    }
+}

--- a/src/bin/rhwp-q-kit/line_starts.rs
+++ b/src/bin/rhwp-q-kit/line_starts.rs
@@ -1,0 +1,90 @@
+//! 문단 줄 시작 오프셋.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit line-starts <파일> --list <N> --para <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para)) = (path, list, para) else {
+        eprintln!("오류: 파일과 --list --para 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = core.line_starts_json(list, para);
+    if json_mode {
+        let starts = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        print_json(&envelope(
+            "line-starts",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "starts": starts,
+            }),
+            &["starts"],
+        ))
+    } else {
+        write_stdout(&raw)
+    }
+}

--- a/src/bin/rhwp-q-kit/main.rs
+++ b/src/bin/rhwp-q-kit/main.rs
@@ -1,0 +1,164 @@
+//! rhwp-q-kit — 에이전트 조회 CLI 50개. 편집 로직은 없다.
+//!
+//! 도구 이름 선점: `C:/Users/swsz9/.rhwp-cli-registry.json` (`claimed_pack50`).
+//! 이미 있는 rhwp-agent / rhwp-q-* / 진행 중 단건 PR 과 겹치지 않는다.
+
+mod envelope;
+
+mod auto_numbers;
+mod bin_data;
+mod canvaskit_preflight;
+mod caret_stops;
+mod cell_shape;
+mod char_index;
+mod chart_csv;
+mod chart_list;
+mod covering_pages;
+mod cur_field_state;
+mod cursor_in_cell;
+mod cursor_in_footnote;
+mod cursor_in_hf;
+mod cursor_in_note;
+mod empty_doc;
+mod equations;
+mod field_by_id;
+mod field_info_at;
+mod field_list_json;
+mod flow_images;
+mod fn_selection_rects;
+mod footnote_footholds;
+mod footnote_hit;
+mod footnote_info;
+mod form_at;
+mod form_value;
+mod hf_edit_target;
+mod hidden_comments;
+mod hit_fn_marker;
+mod hit_header;
+mod hit_in_footnote;
+mod hit_in_hf;
+mod hyperlinks;
+mod index_marks;
+mod layer_tree;
+mod line_starts;
+mod note_edit_info;
+mod overflow_cells;
+mod overlay_images;
+mod page_border_fill;
+mod page_hide;
+mod page_text;
+mod para_bounds;
+mod pictures;
+mod ruby;
+mod search_all;
+mod source_image_bytes;
+mod table_overlaps;
+mod word_end;
+mod word_starts;
+
+use envelope::{write_stdout, EXIT_USAGE};
+
+struct Spec {
+    name: &'static str,
+    usage: &'static str,
+    summary: &'static str,
+    handler: fn(&[String]) -> i32,
+}
+
+const COMMANDS: &[Spec] = &[
+    Spec { name: "empty-doc", usage: "rhwp-q-kit empty-doc <파일> [--json]", summary: "빈 문서 여부 (IsEmpty)", handler: empty_doc::run },
+    Spec { name: "cell-shape", usage: "rhwp-q-kit cell-shape <파일> --list <N> [--json]", summary: "셀 CellShape 파라미터셋", handler: cell_shape::run },
+    Spec { name: "overlay-images", usage: "rhwp-q-kit overlay-images <파일> --page <N> [--json]", summary: "쪽 overlay 그림", handler: overlay_images::run },
+    Spec { name: "flow-images", usage: "rhwp-q-kit flow-images <파일> --page <N> [--json]", summary: "쪽 본문 흐름 그림 ops", handler: flow_images::run },
+    Spec { name: "footnote-info", usage: "rhwp-q-kit footnote-info <파일> --page <N> --index <N> [--json]", summary: "쪽 각주 참조 좌표", handler: footnote_info::run },
+    Spec { name: "footnote-hit", usage: "rhwp-q-kit footnote-hit <파일> --page <N> --x <F> --y <F> [--json]", summary: "좌표가 각주 영역인지", handler: footnote_hit::run },
+    Spec { name: "footnote-footholds", usage: "rhwp-q-kit footnote-footholds <파일> --page <N> [--json]", summary: "쪽에 각주 발판이 있는지", handler: footnote_footholds::run },
+    Spec { name: "note-edit-info", usage: "rhwp-q-kit note-edit-info <파일> [--json]", summary: "각주·미주 편집 대상 정보", handler: note_edit_info::run },
+    Spec { name: "cursor-in-cell", usage: "rhwp-q-kit cursor-in-cell <파일> --section <N> --para <N> --ci <N> --cell <N> --cell-para <N> --offset <N> [--json]", summary: "셀 안 캐럿 사각형", handler: cursor_in_cell::run },
+    Spec { name: "cursor-in-hf", usage: "rhwp-q-kit cursor-in-hf <파일> --page <N> [--json]", summary: "머리말·꼬리말 캐럿 사각형", handler: cursor_in_hf::run },
+    Spec { name: "cursor-in-footnote", usage: "rhwp-q-kit cursor-in-footnote <파일> --page <N> [--json]", summary: "각주 안 캐럿 사각형", handler: cursor_in_footnote::run },
+    Spec { name: "cursor-in-note", usage: "rhwp-q-kit cursor-in-note <파일> --page <N> [--json]", summary: "노트 안 캐럿 사각형", handler: cursor_in_note::run },
+    Spec { name: "hit-header", usage: "rhwp-q-kit hit-header <파일> --page <N> --x <F> --y <F> [--json]", summary: "머리말·꼬리말 히트테스트", handler: hit_header::run },
+    Spec { name: "hit-in-hf", usage: "rhwp-q-kit hit-in-hf <파일> --page <N> --x <F> --y <F> [--json]", summary: "머리말·꼬리말 내부 히트", handler: hit_in_hf::run },
+    Spec { name: "hit-in-footnote", usage: "rhwp-q-kit hit-in-footnote <파일> --page <N> --x <F> --y <F> [--json]", summary: "각주 내부 히트", handler: hit_in_footnote::run },
+    Spec { name: "hit-fn-marker", usage: "rhwp-q-kit hit-fn-marker <파일> --page <N> --x <F> --y <F> [--json]", summary: "본문 각주 표식 히트", handler: hit_fn_marker::run },
+    Spec { name: "hf-edit-target", usage: "rhwp-q-kit hf-edit-target <파일> --page <N> [--json]", summary: "머리말·꼬리말 편집 대상", handler: hf_edit_target::run },
+    Spec { name: "fn-selection-rects", usage: "rhwp-q-kit fn-selection-rects <파일> --page <N> [--json]", summary: "각주 선택 사각형", handler: fn_selection_rects::run },
+    Spec { name: "field-info-at", usage: "rhwp-q-kit field-info-at <파일> --list <N> --para <N> --pos <N> [--json]", summary: "커서 자리 필드 정보", handler: field_info_at::run },
+    Spec { name: "field-by-id", usage: "rhwp-q-kit field-by-id <파일> --id <N> [--json]", summary: "필드 id로 현재 값", handler: field_by_id::run },
+    Spec { name: "field-list-json", usage: "rhwp-q-kit field-list-json <파일> [--json]", summary: "한글 필드 리스트 JSON", handler: field_list_json::run },
+    Spec { name: "cur-field-state", usage: "rhwp-q-kit cur-field-state <파일> --list <N> --para <N> --pos <N> [--json]", summary: "커서 자리 필드 상태 비트", handler: cur_field_state::run },
+    Spec { name: "form-at", usage: "rhwp-q-kit form-at <파일> --page <N> --x <F> --y <F> [--json]", summary: "좌표의 양식 개체", handler: form_at::run },
+    Spec { name: "form-value", usage: "rhwp-q-kit form-value <파일> --section <N> --para <N> --ci <N> [--json]", summary: "양식 개체 값", handler: form_value::run },
+    Spec { name: "para-bounds", usage: "rhwp-q-kit para-bounds <파일> --list <N> --para <N> [--json]", summary: "문단 경계", handler: para_bounds::run },
+    Spec { name: "line-starts", usage: "rhwp-q-kit line-starts <파일> --list <N> --para <N> [--json]", summary: "문단 줄 시작 오프셋", handler: line_starts::run },
+    Spec { name: "word-starts", usage: "rhwp-q-kit word-starts <파일> --list <N> --para <N> [--json]", summary: "문단 단어 시작", handler: word_starts::run },
+    Spec { name: "word-end", usage: "rhwp-q-kit word-end <파일> --list <N> --para <N> --pos <N> [--json]", summary: "단어 끝 오프셋", handler: word_end::run },
+    Spec { name: "caret-stops", usage: "rhwp-q-kit caret-stops <파일> --list <N> --para <N> [--json]", summary: "캐럿 정지 위치", handler: caret_stops::run },
+    Spec { name: "char-index", usage: "rhwp-q-kit char-index <파일> --list <N> --para <N> --pos <N> [--json]", summary: "스트림 위치의 글자 인덱스", handler: char_index::run },
+    Spec { name: "page-text", usage: "rhwp-q-kit page-text <파일> --page <N> [--json]", summary: "한글 스캔 쪽 텍스트", handler: page_text::run },
+    Spec { name: "bin-data", usage: "rhwp-q-kit bin-data <파일> --index <N> [--json]", summary: "임베드 바이너리 길이·종류", handler: bin_data::run },
+    Spec { name: "source-image-bytes", usage: "rhwp-q-kit source-image-bytes <파일> --key <키> [--json]", summary: "원본 그림 바이트 메타", handler: source_image_bytes::run },
+    Spec { name: "overflow-cells", usage: "rhwp-q-kit overflow-cells <파일> [--json]", summary: "넘친 셀 줄 수", handler: overflow_cells::run },
+    Spec { name: "table-overlaps", usage: "rhwp-q-kit table-overlaps <파일> [--json]", summary: "표 겹침 목록", handler: table_overlaps::run },
+    Spec { name: "page-border-fill", usage: "rhwp-q-kit page-border-fill <파일> --section <N> [--json]", summary: "구역 쪽 테두리·배경", handler: page_border_fill::run },
+    Spec { name: "covering-pages", usage: "rhwp-q-kit covering-pages <파일> --section <N> --para <N> [--json]", summary: "문단이 걸친 쪽", handler: covering_pages::run },
+    Spec { name: "chart-csv", usage: "rhwp-q-kit chart-csv <파일> --chart <N> [--json]", summary: "차트 데이터 CSV", handler: chart_csv::run },
+    Spec { name: "chart-list", usage: "rhwp-q-kit chart-list <파일> [--json]", summary: "문서 안 차트 목록", handler: chart_list::run },
+    Spec { name: "search-all", usage: "rhwp-q-kit search-all <파일> --q <문자열> [--json]", summary: "전 문단 검색 좌표", handler: search_all::run },
+    Spec { name: "canvaskit-preflight", usage: "rhwp-q-kit canvaskit-preflight <파일> [--json]", summary: "CanvasKit 문서 사전점검", handler: canvaskit_preflight::run },
+    Spec { name: "layer-tree", usage: "rhwp-q-kit layer-tree <파일> --page <N> [--json]", summary: "쪽 레이어 트리", handler: layer_tree::run },
+    Spec { name: "hyperlinks", usage: "rhwp-q-kit hyperlinks <파일> [--json]", summary: "하이퍼링크 목록 (읽기)", handler: hyperlinks::run },
+    Spec { name: "equations", usage: "rhwp-q-kit equations <파일> [--json]", summary: "수식 목록 (읽기)", handler: equations::run },
+    Spec { name: "pictures", usage: "rhwp-q-kit pictures <파일> [--json]", summary: "그림 목록 (읽기)", handler: pictures::run },
+    Spec { name: "hidden-comments", usage: "rhwp-q-kit hidden-comments <파일> [--json]", summary: "숨은 설명 목록 (읽기)", handler: hidden_comments::run },
+    Spec { name: "index-marks", usage: "rhwp-q-kit index-marks <파일> [--json]", summary: "찾아보기 표식 (읽기)", handler: index_marks::run },
+    Spec { name: "auto-numbers", usage: "rhwp-q-kit auto-numbers <파일> [--json]", summary: "자동번호 (읽기)", handler: auto_numbers::run },
+    Spec { name: "ruby", usage: "rhwp-q-kit ruby <파일> [--json]", summary: "덧말 (읽기)", handler: ruby::run },
+    Spec { name: "page-hide", usage: "rhwp-q-kit page-hide <파일> [--json]", summary: "감추기 컨트롤 (읽기)", handler: page_hide::run },
+];
+
+fn find(name: &str) -> Option<&'static Spec> {
+    COMMANDS.iter().find(|c| c.name == name)
+}
+
+fn print_help() {
+    let _ = write_stdout(&format!(
+        "rhwp-q-kit v{} — 조회 전용 CLI 50개 (선점 목록 claimed_pack50)",
+        rhwp::version()
+    ));
+    let _ = write_stdout("사용법: rhwp-q-kit <명령> [옵션]");
+    let _ = write_stdout("");
+    for c in COMMANDS {
+        let _ = write_stdout(&format!("  {}", c.usage));
+        let _ = write_stdout(&format!("      {}", c.summary));
+    }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let code = match args.first().map(String::as_str) {
+        None | Some("--help") | Some("-h") => {
+            if args.is_empty() {
+                eprintln!("오류: 명령을 지정해주세요.");
+                eprintln!("사용법: rhwp-q-kit <명령> [옵션]  ('rhwp-q-kit --help' 참고)");
+                std::process::exit(EXIT_USAGE);
+            }
+            print_help();
+            0
+        }
+        Some("--version") | Some("-V") => {
+            let _ = write_stdout(&rhwp::version());
+            0
+        }
+        Some(name) => match find(name) {
+            Some(spec) => (spec.handler)(&args[1..]),
+            None => {
+                eprintln!("오류: 알 수 없는 명령입니다 - {name}");
+                eprintln!("사용법: rhwp-q-kit <명령> [옵션]  ('rhwp-q-kit --help' 참고)");
+                EXIT_USAGE
+            }
+        },
+    };
+    std::process::exit(code);
+}

--- a/src/bin/rhwp-q-kit/note_edit_info.rs
+++ b/src/bin/rhwp-q-kit/note_edit_info.rs
@@ -1,0 +1,140 @@
+//! 각주·미주 편집 대상 정보.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "note-edit-info";
+const USAGE: &str = "rhwp-q-kit note-edit-info <파일> --section <N> --para <N> --ci <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_note_edit_info_native(opts.section, opts.para, opts.ci) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 노트 편집 정보를 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({
+        "source": opts.path,
+        "section": opts.section,
+        "para": opts.para,
+        "ci": opts.ci,
+    });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(CMD, payload, &["source"]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    section: usize,
+    para: usize,
+    ci: usize,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut para: Option<usize> = None;
+    let mut ci: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--section" => section = Some(take_usize(args, &mut i, "--section")?),
+            "--para" => para = Some(take_usize(args, &mut i, "--para")?),
+            "--ci" => ci = Some(take_usize(args, &mut i, "--ci")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        section: require(section, "--section")?,
+        para: require(para, "--para")?,
+        ci: require(ci, "--ci")?,
+    })
+}
+
+fn take_usize(args: &[String], i: &mut usize, flag: &str) -> Result<usize, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_usize(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/overflow_cells.rs
+++ b/src/bin/rhwp-q-kit/overflow_cells.rs
@@ -1,0 +1,32 @@
+//! 넘친 셀 줄 수 — `DocumentCore::take_overflow_cell_lines`.
+//!
+//! 카운터를 읽고 리셋하므로 방금 연 코어의 잔여값만 보고한다.
+
+use crate::envelope::{envelope, load_core, parse_one_file, print_json, write_stdout};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit overflow-cells <파일> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let count = core.take_overflow_cell_lines();
+    if opts.json {
+        print_json(&envelope(
+            "overflow-cells",
+            json!({
+                "source": opts.path,
+                "overflowCellLines": count,
+            }),
+            &[],
+        ))
+    } else {
+        write_stdout(&format!("overflowCellLines={count}"))
+    }
+}

--- a/src/bin/rhwp-q-kit/overlay_images.rs
+++ b/src/bin/rhwp-q-kit/overlay_images.rs
@@ -1,0 +1,131 @@
+//! 쪽 overlay 그림 (BehindText / InFrontOfText).
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::{json, Value};
+
+const CMD: &str = "overlay-images";
+const USAGE: &str = "rhwp-q-kit overlay-images <파일> --page <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse(args) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_page_overlay_images_native(opts.page) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: overlay 그림을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let native = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let mut payload = json!({ "source": opts.path, "page": opts.page });
+    merge_object(&mut payload, native);
+    if opts.json {
+        print_json(&envelope(
+            CMD,
+            payload,
+            &["source", "behind[].base64", "front[].base64"],
+        ))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+struct Opts {
+    json: bool,
+    path: String,
+    page: u32,
+}
+
+fn parse(args: &[String]) -> Result<Opts, i32> {
+    let mut json = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<u32> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json = true;
+                i += 1;
+            }
+            "--page" => page = Some(take_u32(args, &mut i, "--page")?),
+            other if other.starts_with('-') => unknown(other)?,
+            other => {
+                set_path(&mut path, other)?;
+                i += 1;
+            }
+        }
+    }
+    Ok(Opts {
+        json,
+        path: require_path(path)?,
+        page: require(page, "--page")?,
+    })
+}
+
+fn take_u32(args: &[String], i: &mut usize, flag: &str) -> Result<u32, i32> {
+    let raw = take_val(args, *i, flag)?;
+    *i += 2;
+    parse_u32(flag, raw)
+}
+
+fn take_val<'a>(args: &'a [String], i: usize, flag: &str) -> Result<&'a str, i32> {
+    match args.get(i + 1) {
+        Some(v) => Ok(v),
+        None => {
+            eprintln!("오류: {flag} 뒤에 값이 필요합니다.");
+            eprintln!("사용법: {USAGE}");
+            Err(EXIT_USAGE)
+        }
+    }
+}
+
+fn require<T>(v: Option<T>, flag: &str) -> Result<T, i32> {
+    v.ok_or_else(|| {
+        eprintln!("오류: {flag} 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn require_path(path: Option<String>) -> Result<String, i32> {
+    path.ok_or_else(|| {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        EXIT_USAGE
+    })
+}
+
+fn set_path(path: &mut Option<String>, other: &str) -> Result<(), i32> {
+    if path.replace(other.to_string()).is_some() {
+        eprintln!("오류: 파일이 너무 많습니다 - {other}");
+        eprintln!("사용법: {USAGE}");
+        return Err(EXIT_USAGE);
+    }
+    Ok(())
+}
+
+fn unknown(flag: &str) -> Result<(), i32> {
+    eprintln!("오류: 알 수 없는 옵션입니다 - {flag}");
+    eprintln!("사용법: {USAGE}");
+    Err(EXIT_USAGE)
+}
+
+fn merge_object(payload: &mut Value, native: Value) {
+    if let (Some(dst), Value::Object(src)) = (payload.as_object_mut(), native) {
+        for (k, v) in src {
+            dst.insert(k, v);
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/page_border_fill.rs
+++ b/src/bin/rhwp-q-kit/page_border_fill.rs
@@ -1,0 +1,80 @@
+//! 구역 쪽 테두리·배경 — `DocumentCore::get_page_border_fill_native`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit page-border-fill <파일> --section <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut section: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--section" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --section 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                section = Some(match parse_usize("--section", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(section)) = (path, section) else {
+        eprintln!("오류: 파일과 --section 이 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.get_page_border_fill_native(section) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 쪽 테두리·배경을 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    let fill = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let payload = json!({
+        "source": path,
+        "section": section,
+        "pageBorderFill": fill,
+    });
+    if json_mode {
+        print_json(&envelope("page-border-fill", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}

--- a/src/bin/rhwp-q-kit/page_hide.rs
+++ b/src/bin/rhwp-q-kit/page_hide.rs
@@ -1,0 +1,33 @@
+//! page-hide — `Control::PageHide` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit page-hide <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::PageHide(ph) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["hideHeader"] = json!(ph.hide_header);
+        item["hideFooter"] = json!(ph.hide_footer);
+        item["hideMasterPage"] = json!(ph.hide_master_page);
+        item["hideBorder"] = json!(ph.hide_border);
+        item["hideFill"] = json!(ph.hide_fill);
+        item["hidePageNum"] = json!(ph.hide_page_num);
+        items.push(item);
+    });
+    emit_items("page-hide", &opts.path, opts.json, items, &[])
+}

--- a/src/bin/rhwp-q-kit/page_text.rs
+++ b/src/bin/rhwp-q-kit/page_text.rs
@@ -1,0 +1,86 @@
+//! 한글 스캔 쪽 텍스트 — `DocumentCore::page_text`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_usize, print_json, write_stdout, EXIT_RUNTIME,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit page-text <파일> --page <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut page: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--page" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --page 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                page = Some(match parse_usize("--page", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(page)) = (path, page) else {
+        eprintln!("오류: 파일과 --page 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let escaped = match core.page_text(page) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 쪽 텍스트를 읽지 못했습니다 - {e}");
+            return EXIT_RUNTIME;
+        }
+    };
+    // `page_text` 는 따옴표 없는 JSON 이스케이프 본문을 돌려준다.
+    let text = match parse_json_string(&format!("\"{escaped}\"")) {
+        Ok(v) => v.as_str().unwrap_or("").to_string(),
+        Err(c) => return c,
+    };
+    let chars = text.chars().count();
+    if json_mode {
+        print_json(&envelope(
+            "page-text",
+            json!({
+                "source": path,
+                "page": page,
+                "text": text,
+                "chars": chars,
+            }),
+            &["text"],
+        ))
+    } else {
+        write_stdout(&text)
+    }
+}

--- a/src/bin/rhwp-q-kit/para_bounds.rs
+++ b/src/bin/rhwp-q-kit/para_bounds.rs
@@ -1,0 +1,93 @@
+//! 문단 캐럿 경계.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+pub fn run(args: &[String]) -> i32 {
+    let usage = "rhwp-q-kit para-bounds <파일> --list <N> --para <N> [--json]";
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {usage}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다.");
+                    eprintln!("사용법: {usage}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para)) = (path, list, para) else {
+        eprintln!("오류: 파일과 --list --para 가 필요합니다.");
+        eprintln!("사용법: {usage}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = core.para_bounds_json(list, para);
+    if json_mode {
+        let data = match parse_json_string(&raw) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let mut payload = json!({ "source": path, "list": list, "para": para });
+        absorb(&mut payload, data);
+        print_json(&envelope("para-bounds", payload, &[]))
+    } else {
+        write_stdout(&raw)
+    }
+}
+
+fn absorb(payload: &mut serde_json::Value, native: serde_json::Value) {
+    if let (Some(map), Some(obj)) = (payload.as_object_mut(), native.as_object()) {
+        for (k, v) in obj {
+            map.insert(k.clone(), v.clone());
+        }
+    } else if let Some(map) = payload.as_object_mut() {
+        map.insert("data".into(), native);
+    }
+}

--- a/src/bin/rhwp-q-kit/pictures.rs
+++ b/src/bin/rhwp-q-kit/pictures.rs
@@ -1,0 +1,44 @@
+//! pictures — `Control::Picture` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit pictures <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::Picture(pic) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["href"] = json!(&pic.href);
+        item["binDataId"] = json!(pic.image_attr.bin_data_id);
+        item["instanceId"] = json!(pic.instance_id);
+        item["width"] = json!(pic.common.width);
+        item["height"] = json!(pic.common.height);
+        item["treatAsChar"] = json!(pic.common.treat_as_char);
+        item["reverse"] = json!(pic.reverse);
+        item["lock"] = json!(pic.lock);
+        item["imgDim"] = json!([pic.img_dim.0, pic.img_dim.1]);
+        item["transparency"] = json!(pic.image_attr.transparency);
+        item["externalPath"] = json!(&pic.image_attr.external_path);
+        items.push(item);
+    });
+    emit_items(
+        "pictures",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].href", "items[].externalPath"],
+    )
+}

--- a/src/bin/rhwp-q-kit/ruby.rs
+++ b/src/bin/rhwp-q-kit/ruby.rs
@@ -1,0 +1,40 @@
+//! ruby — `Control::Ruby` 열거. 읽기 전용.
+
+use rhwp::model::control::Control;
+use serde_json::json;
+
+use crate::envelope::{emit_items, for_each_control, load_core, loc_json, parse_one_file};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str = "rhwp-q-kit ruby <파일> [--json]";
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let mut items = Vec::new();
+    for_each_control(core.document(), |at| {
+        let Control::Ruby(ruby) = at.ctrl else {
+            return;
+        };
+        let mut item = loc_json(&at);
+        item["mainText"] = json!(&ruby.main_text);
+        item["rubyText"] = json!(&ruby.ruby_text);
+        item["posType"] = json!(ruby.pos_type);
+        item["align"] = json!(ruby.align);
+        item["szRatio"] = json!(ruby.sz_ratio);
+        item["option"] = json!(ruby.option);
+        item["styleIdRef"] = json!(ruby.style_id_ref);
+        items.push(item);
+    });
+    emit_items(
+        "ruby",
+        &opts.path,
+        opts.json,
+        items,
+        &["items[].mainText", "items[].rubyText"],
+    )
+}

--- a/src/bin/rhwp-q-kit/search_all.rs
+++ b/src/bin/rhwp-q-kit/search_all.rs
@@ -1,0 +1,85 @@
+//! search-all — `search_all_text_native`. 조회만 한다.
+
+use serde_json::json;
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, print_json, write_stdout, EXIT_USAGE,
+};
+
+pub fn run(args: &[String]) -> i32 {
+    const USAGE: &str =
+        "rhwp-q-kit search-all <파일> --q <문자열> [--ignore-case] [--include-cells] [--json]";
+    let mut path = None;
+    let mut query = None;
+    let mut json_mode = false;
+    let mut case_sensitive = true;
+    let mut include_cells = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => json_mode = true,
+            "--ignore-case" => case_sensitive = false,
+            "--include-cells" => include_cells = true,
+            "--q" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    eprintln!("오류: --q 뒤에 검색어가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                query = Some(v.clone());
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.replace(other.to_string()).is_some() {
+                    eprintln!("오류: 입력 파일은 하나만 지정할 수 있습니다: {other}");
+                    return EXIT_USAGE;
+                }
+            }
+        }
+        i += 1;
+    }
+    let Some(path) = path else {
+        eprintln!("오류: 파일 경로가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let Some(query) = query else {
+        eprintln!("오류: --q 검색어가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let raw = match core.search_all_text_native(&query, case_sensitive, include_cells) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("오류: 검색 실패 - {e}");
+            return crate::envelope::EXIT_RUNTIME;
+        }
+    };
+    let matches = match parse_json_string(&raw) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let match_count = matches.as_array().map(|a| a.len()).unwrap_or(0);
+    let payload = json!({
+        "source": path,
+        "query": query,
+        "caseSensitive": case_sensitive,
+        "includeCells": include_cells,
+        "matchCount": match_count,
+        "matches": matches,
+    });
+    if json_mode {
+        print_json(&envelope("search-all", payload, &["query", "matches"]))
+    } else {
+        write_stdout(&format!("matches={match_count}"))
+    }
+}

--- a/src/bin/rhwp-q-kit/source_image_bytes.rs
+++ b/src/bin/rhwp-q-kit/source_image_bytes.rs
@@ -1,0 +1,95 @@
+//! 원본 그림 바이트 메타 — `DocumentCore::get_source_image_bytes_native`.
+
+use crate::envelope::{envelope, load_core, print_json, write_stdout, EXIT_USAGE};
+use base64::Engine;
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit source-image-bytes <파일> --key <키> [--include-bytes] [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut include_bytes = false;
+    let mut path: Option<String> = None;
+    let mut key: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--include-bytes" => {
+                include_bytes = true;
+                i += 1;
+            }
+            "--key" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --key 뒤에 그림 키가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                key = Some(raw.clone());
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(key)) = (path, key) else {
+        eprintln!("오류: 파일과 --key 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let got = core.get_source_image_bytes_native(&key);
+    let present = got.is_some();
+    let mime = got.as_ref().map(|(m, _)| *m);
+    let len = got.as_ref().map(|(_, b)| b.len()).unwrap_or(0);
+    let mut payload = json!({
+        "source": path,
+        "key": key,
+        "present": present,
+        "mime": mime,
+        "len": len,
+    });
+    let mut untrusted: Vec<&str> = vec!["key"];
+    if include_bytes {
+        if let Some((_, data)) = got.as_ref() {
+            payload["bytesBase64"] = json!(base64::engine::general_purpose::STANDARD.encode(data));
+            untrusted.push("bytesBase64");
+        }
+    }
+    if json_mode {
+        print_json(&envelope("source-image-bytes", payload, &untrusted))
+    } else {
+        let mime_s = mime.unwrap_or("");
+        let line = format!("present={present} mime={mime_s} len={len}");
+        if include_bytes {
+            if let Some((_, data)) = got.as_ref() {
+                write_stdout(&format!(
+                    "{line} bytesBase64={}",
+                    base64::engine::general_purpose::STANDARD.encode(data)
+                ))
+            } else {
+                write_stdout(&line)
+            }
+        } else {
+            write_stdout(&line)
+        }
+    }
+}

--- a/src/bin/rhwp-q-kit/table_overlaps.rs
+++ b/src/bin/rhwp-q-kit/table_overlaps.rs
@@ -1,0 +1,50 @@
+//! 표 겹침 목록 — `DocumentCore::take_table_overlaps`.
+//!
+//! 목록을 읽고 비우므로 방금 연 코어의 잔여값만 보고한다.
+
+use crate::envelope::{envelope, load_core, parse_one_file, print_json, write_stdout};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit table-overlaps <파일> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let opts = match parse_one_file(args, USAGE) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    let core = match load_core(&opts.path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let overlaps = core.take_table_overlaps();
+    let rows: Vec<serde_json::Value> = overlaps
+        .iter()
+        .map(|o| {
+            json!({
+                "page": o.page_index,
+                "section": o.section_index,
+                "paraA": o.para_a,
+                "paraB": o.para_b,
+                "aY0": o.a_y0,
+                "aY1": o.a_y1,
+                "bY0": o.b_y0,
+                "bY1": o.b_y1,
+                "overlapPx": o.overlap_px,
+            })
+        })
+        .collect();
+    let count = rows.len();
+    if opts.json {
+        print_json(&envelope(
+            "table-overlaps",
+            json!({
+                "source": opts.path,
+                "count": count,
+                "overlaps": rows,
+            }),
+            &[],
+        ))
+    } else {
+        write_stdout(&format!("overlaps={count}"))
+    }
+}

--- a/src/bin/rhwp-q-kit/word_end.rs
+++ b/src/bin/rhwp-q-kit/word_end.rs
@@ -1,0 +1,104 @@
+//! 단어 끝 오프셋 — `DocumentCore::word_end_json`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit word-end <파일> --list <N> --para <N> --pos <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut pos: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--pos" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --pos 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                pos = Some(match parse_usize("--pos", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para), Some(pos)) = (path, list, para, pos) else {
+        eprintln!("오류: 파일과 --list --para --pos 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let end = match parse_json_string(&core.word_end_json(list, para, pos)) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    if json_mode {
+        print_json(&envelope(
+            "word-end",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "pos": pos,
+                "end": end,
+            }),
+            &["end"],
+        ))
+    } else {
+        write_stdout(&end.to_string())
+    }
+}

--- a/src/bin/rhwp-q-kit/word_starts.rs
+++ b/src/bin/rhwp-q-kit/word_starts.rs
@@ -1,0 +1,90 @@
+//! 문단 단어 시작 오프셋 — `DocumentCore::word_starts_json`.
+
+use crate::envelope::{
+    envelope, load_core, parse_json_string, parse_u32, parse_usize, print_json, write_stdout,
+    EXIT_USAGE,
+};
+use serde_json::json;
+
+const USAGE: &str = "rhwp-q-kit word-starts <파일> --list <N> --para <N> [--json]";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut json_mode = false;
+    let mut path: Option<String> = None;
+    let mut list: Option<u32> = None;
+    let mut para: Option<usize> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json" => {
+                json_mode = true;
+                i += 1;
+            }
+            "--list" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --list 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                list = Some(match parse_u32("--list", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            "--para" => {
+                let Some(raw) = args.get(i + 1) else {
+                    eprintln!("오류: --para 뒤에 0 이상의 정수가 필요합니다.");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                };
+                para = Some(match parse_usize("--para", raw) {
+                    Ok(v) => v,
+                    Err(c) => return c,
+                });
+                i += 2;
+            }
+            other if other.starts_with('-') => {
+                eprintln!("오류: 알 수 없는 옵션입니다 - {other}");
+                eprintln!("사용법: {USAGE}");
+                return EXIT_USAGE;
+            }
+            other => {
+                if path.is_some() {
+                    eprintln!("오류: 파일이 너무 많습니다 - {other}");
+                    eprintln!("사용법: {USAGE}");
+                    return EXIT_USAGE;
+                }
+                path = Some(other.to_string());
+                i += 1;
+            }
+        }
+    }
+    let (Some(path), Some(list), Some(para)) = (path, list, para) else {
+        eprintln!("오류: 파일과 --list --para 가 필요합니다.");
+        eprintln!("사용법: {USAGE}");
+        return EXIT_USAGE;
+    };
+    let core = match load_core(&path) {
+        Ok(c) => c,
+        Err(c) => return c,
+    };
+    let starts = match parse_json_string(&core.word_starts_json(list, para)) {
+        Ok(v) => v,
+        Err(c) => return c,
+    };
+    if json_mode {
+        print_json(&envelope(
+            "word-starts",
+            json!({
+                "source": path,
+                "list": list,
+                "para": para,
+                "starts": starts,
+            }),
+            &["starts"],
+        ))
+    } else {
+        write_stdout(&starts.to_string())
+    }
+}

--- a/tests/cases/agent_q_kit_contract.rs
+++ b/tests/cases/agent_q_kit_contract.rs
@@ -1,0 +1,136 @@
+//! rhwp-q-kit 50명령 계약. 실제 바이너리를 실행한다.
+//! 제품 소스에 #[cfg(test)] 를 두지 않는다 (CONTRIBUTING / rust-unit-test-tiers).
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/form-01.hwp";
+const TOOL: &str = "rhwp-q-kit";
+
+fn bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp-q-kit")
+        .unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp-q-kit").to_string())
+}
+
+fn sample(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(bin())
+        .args(args)
+        .output()
+        .expect("rhwp-q-kit 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: {TOOL} {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn stdout_json(args: &[&str], output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout 이 순수 JSON 이 아닙니다 ({e}).\n{}",
+            describe(args, output)
+        )
+    })
+}
+
+fn assert_envelope(v: &serde_json::Value, command: &str) {
+    assert!(v["schemaVersion"].is_string(), "{v}");
+    assert_eq!(v["tool"], TOOL, "{v}");
+    assert_eq!(v["command"], command, "{v}");
+    assert!(v["untrustedContent"].is_boolean(), "{v}");
+    assert!(v["untrustedFields"].is_array(), "{v}");
+}
+
+#[test]
+fn help_lists_fifty_commands() {
+    let output = run(&["--help"]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&["--help"], &output)
+    );
+    let text = String::from_utf8_lossy(&output.stdout);
+    for name in [
+        "empty-doc",
+        "hyperlinks",
+        "equations",
+        "pictures",
+        "search-all",
+        "page-hide",
+        "layer-tree",
+        "chart-csv",
+        "field-by-id",
+        "overlay-images",
+    ] {
+        assert!(text.contains(name), "help 에 {name} 없음:\n{text}");
+    }
+}
+
+#[test]
+fn unknown_command_is_usage() {
+    let output = run(&["not-a-real-command"]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&["not-a-real-command"], &output)
+    );
+}
+
+#[test]
+fn empty_doc_json_on_form01() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8");
+    let args = ["empty-doc", "--json", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    assert_envelope(&v, "empty-doc");
+    assert!(v["empty"].is_boolean(), "{v}");
+}
+
+#[test]
+fn hyperlinks_json_on_form01() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8");
+    let args = ["hyperlinks", "--json", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&args, &output)
+    );
+    let v = stdout_json(&args, &output);
+    assert_envelope(&v, "hyperlinks");
+    assert!(v["items"].is_array(), "{v}");
+}
+
+#[test]
+fn unknown_flag_on_pictures_is_usage() {
+    let path = sample(SAMPLE);
+    let source = path.to_str().expect("utf-8");
+    let args = ["pictures", "--nope", source];
+    let output = run(&args);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "{}",
+        describe(&args, &output)
+    );
+}


### PR DESCRIPTION
> **PR base 브랜치가 `devel` 인지 확인해주세요** (`main` 아님 — GitHub 기본 선택이 main 일 수 있습니다).
> 작업 브랜치는 최신 `upstream/devel` 에서 생성합니다.

## 변경 요약

에이전트가 아직 못 부르는 DocumentCore **읽기 전용** 조회 50개를 `rhwp-q-kit` 한 바이너리에 모았습니다. 이름은 공유 선점 목록(`claimed_pack50`)에 적어, 이미 있는 `rhwp-agent`·`rhwp-q-*`·진행 중 단건 PR과 겹치지 않습니다. 편집 API·더미 JSON 코퍼스·`src` `#[cfg(test)]`는 없습니다.

## 관련 이슈

closes #5667

## 테스트

- [x] **`cargo fmt --all -- --check` 통과** (변경 파일 rustfmt Unix. CI는 `--prepare` 뒤 Format check)
- [x] `node scripts/rust-unit-test-tiers.mjs --check --base-ref upstream/devel` 통과 (4225 tests / 298 modules)
- [ ] `node scripts/rust-test-suite-manifest.mjs --check` — 기여자는 `--prepare`/`--generate`로 하네스를 등록하지 않음. `tests/cases/agent_q_kit_contract.rs` 원본만 추가
- [x] `cargo check --bin rhwp-q-kit` 통과
- [x] `rhwp-q-kit empty-doc --json samples/form-01.hwp` exit 0, `empty: false`
- [ ] `cargo clippy -- -D warnings`
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)
- [x] (에이전트 보조 작업) `--json` 봉투 원문: `empty-doc` on `samples/form-01.hwp`

## 성능 영향 및 측정 결과 (해당하는 경우)

- 예상 영향: 영향 없음 (조회 전용 실험 바이너리, `src/main.rs` 미변경)
- 재현·측정: 미측정
