### PR TITLE
fix: lpaiu-cs Studio undo 변경 3건을 통합한다

### DIFF
--- a/mydocs/orders/20260819.md
+++ b/mydocs/orders/20260819.md
@@ -141,3 +141,10 @@ date: 2026-08-19
 - 로컬 `release-test` 전체 7,869건, 신규 및 보정 focused 회귀, native-Skia, 직접 PDF, doctest, clippy, unit-tier policy·contract, Docker 없는 WASM build를 통과했다. 새 HWPX fixture 두 건의 SVG와 layout-anomaly는 모두 이상 신호 0건이었다.
 - code candidate CI의 Build & Test, Lint, Native Skia, Canvas visual diff, CodeQL Rust 분석, archive, regular·slow shard, Proptest, Adapter inter-diff가 성공했다. 이 오늘할일과 원 PR별 [#5611](../pr/archives/pr_5611_review.md), [#5612](../pr/archives/pr_5612_review.md), [#5618](../pr/archives/pr_5618_review.md), [#5635](../pr/archives/pr_5635_review.md), [#5646](../pr/archives/pr_5646_review.md), [#5649](../pr/archives/pr_5649_review.md), [#5651](../pr/archives/pr_5651_review.md) 검토 기록을 같은 trailing commit으로 push한다.
 - 최신 문서 head의 fast-pass CI와 mergeability를 확인한 뒤 승인 절차에 따라 병합하고, 원 PR 댓글·close와 원격 head branch 정리를 후속 절차로 수행한다.
+
+## #5670 lpaiu-cs Studio undo 변경 3건 통합
+
+- 통합 PR은 [#5670](https://github.com/edwardkim/rhwp/pull/5670)이며, 최신 `upstream/devel` 위에 #5615, #5653, #5654를 번호순으로 충돌 없이 체리픽했다.
+- 로컬 focused Studio regression, 전체 Studio test `1,017 passed, 1 skipped`, production build와 headless browser undo·object-selection E2E를 통과했다. 초기 E2E의 이전 VM Chrome CDP 연결 실패는 로컬 dev server headless 재실행으로 분리했다.
+- code candidate CI의 Frontend package gate, Canvas visual diff, CodeQL 세 분석, Proptest, Adapter inter-diff, Build & Test aggregate가 성공했다.
+- 이 오늘할일과 원 PR별 [#5615](../pr/archives/pr_5615_review.md), [#5653](../pr/archives/pr_5653_review.md), [#5654](../pr/archives/pr_5654_review.md) 검토 기록을 같은 trailing commit으로 push한다. 최신 문서 head의 fast-pass CI와 mergeability를 확인한 뒤 병합 후속 절차를 수행한다.

--- a/mydocs/pr/archives/pr_5615_review.md
+++ b/mydocs/pr/archives/pr_5615_review.md
@@ -1,0 +1,29 @@
+---
+kind: pr-review
+status: approved-pending-ci
+pr: 5615
+author: lpaiu-cs
+base: devel
+---
+
+# PR #5615 검토: #3230 개체 속성 역연산·양식 모드 보정
+
+PR: [#5615](https://github.com/edwardkim/rhwp/pull/5615)  
+원본 head: `5b59b96c77a26a242b4fac9ce618efa65f29a7ff`  
+통합 PR: [#5670](https://github.com/edwardkim/rhwp/pull/5670)  
+통합 브랜치: `integration/lpaiu-cs-20260819`
+
+## 검토 결론
+
+**승인, trailing 문서 head CI 대기.** 최신 `upstream/devel` 위에 번호순 체리픽했으며 충돌은 없었다. 구현 차단 결함은 발견하지 못했다.
+
+## 검토 근거
+
+- 원 PR과 통합 후보의 Studio command·cursor·input 상태 전이를 검토했다.
+- `issue-3230-object-props-inverse.test.ts`를 포함한 Studio 전체 테스트는 1,017 passed, 1 skipped였다.
+- Studio production build 및 headless browser undo·object-selection E2E를 통과했다.
+- code candidate CI의 Frontend package gate, Canvas visual diff, CodeQL, Proptest, Adapter inter-diff, Build & Test가 통과했다.
+
+## 병합 조건과 후속 처리
+
+이 trailing 문서 commit의 fast-pass CI와 mergeability를 확인한 뒤 #5670를 병합한다. 병합 후 원 PR #5615에 통합 근거를 댓글로 남기고 close하며, 원격 통합 branch와 로컬 검토 branch를 정리한다.

--- a/mydocs/pr/archives/pr_5653_review.md
+++ b/mydocs/pr/archives/pr_5653_review.md
@@ -1,0 +1,29 @@
+---
+kind: pr-review
+status: approved-pending-ci
+pr: 5653
+author: lpaiu-cs
+base: devel
+---
+
+# PR #5653 검토: #3351 메뉴 개체 조작 undo/redo 캐럿 착지
+
+PR: [#5653](https://github.com/edwardkim/rhwp/pull/5653)  
+원본 head: `0208dad41be50cb9cee7321558fec008786c66e3`  
+통합 PR: [#5670](https://github.com/edwardkim/rhwp/pull/5670)  
+통합 브랜치: `integration/lpaiu-cs-20260819`
+
+## 검토 결론
+
+**승인, trailing 문서 head CI 대기.** 최신 `upstream/devel` 위에 번호순 체리픽했으며 충돌은 없었다. 구현 차단 결함은 발견하지 못했다.
+
+## 검토 근거
+
+- 원 PR과 통합 후보의 Studio command·cursor·input 상태 전이를 검토했다.
+- `issue-3351-object-caret-landing.test.ts`를 포함한 Studio 전체 테스트는 1,017 passed, 1 skipped였다.
+- Studio production build 및 headless browser undo·object-selection E2E를 통과했다.
+- code candidate CI의 Frontend package gate, Canvas visual diff, CodeQL, Proptest, Adapter inter-diff, Build & Test가 통과했다.
+
+## 병합 조건과 후속 처리
+
+이 trailing 문서 commit의 fast-pass CI와 mergeability를 확인한 뒤 #5670를 병합한다. 병합 후 원 PR #5653에 통합 근거를 댓글로 남기고 close하며, 원격 통합 branch와 로컬 검토 branch를 정리한다.

--- a/mydocs/pr/archives/pr_5654_review.md
+++ b/mydocs/pr/archives/pr_5654_review.md
@@ -1,0 +1,29 @@
+---
+kind: pr-review
+status: approved-pending-ci
+pr: 5654
+author: lpaiu-cs
+base: devel
+---
+
+# PR #5654 검토: #3416 선택 삭제 undo 뒤 선택 범위 복원
+
+PR: [#5654](https://github.com/edwardkim/rhwp/pull/5654)  
+원본 head: `449904c4db9577681ef8ec0ddb0c6dc3b5d163ae`  
+통합 PR: [#5670](https://github.com/edwardkim/rhwp/pull/5670)  
+통합 브랜치: `integration/lpaiu-cs-20260819`
+
+## 검토 결론
+
+**승인, trailing 문서 head CI 대기.** 최신 `upstream/devel` 위에 번호순 체리픽했으며 충돌은 없었다. 구현 차단 결함은 발견하지 못했다.
+
+## 검토 근거
+
+- 원 PR과 통합 후보의 Studio command·cursor·input 상태 전이를 검토했다.
+- `issue-3416-selection-restore.test.ts`를 포함한 Studio 전체 테스트는 1,017 passed, 1 skipped였다.
+- Studio production build 및 headless browser undo·object-selection E2E를 통과했다.
+- code candidate CI의 Frontend package gate, Canvas visual diff, CodeQL, Proptest, Adapter inter-diff, Build & Test가 통과했다.
+
+## 병합 조건과 후속 처리
+
+이 trailing 문서 commit의 fast-pass CI와 mergeability를 확인한 뒤 #5670를 병합한다. 병합 후 원 PR #5654에 통합 근거를 댓글로 남기고 close하며, 원격 통합 branch와 로컬 검토 branch를 정리한다.

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -642,7 +642,15 @@ function recordObjectMutation(
   mutate: (wasm: WasmBridge) => boolean | void,
   opts?: { refresh?: RefreshPolicy },
 ): void {
-  const pos = ih.getCursorPosition();
+  // [Task #3351] 개체 선택은 `cursor.position` 을 옮기지 않는다. 그래서 여기서 그냥
+  // `getCursorPosition()` 을 잡으면 **개체를 선택하기 직전 캐럿**이 기록되고, undo/redo 가
+  // 조작과 무관한 자리(문서 상단일 수도 있다)로 착지한다.
+  //
+  // 한컴 2024 실측: 개체 선택은 캐럿을 앵커로 끌고 가고, 캐럿을 다른 문단으로 옮기면 선택이
+  // 풀린다 — "캐럿은 딴 곳, 개체는 선택" 이라는 상태 자체가 없다. 삭제·undo·redo 내내 캐럿은
+  // 개체 인접 문단에 머문다. Delete 키 경로(`performDelete`)가 이미 그렇게 하고 있으므로
+  // 메뉴 경로도 같은 자리를 기록한다.
+  const pos = ih.getPositionOutsideSelectedPicture() ?? ih.getCursorPosition();
   ih.executeOperation({
     kind: 'snapshot',
     operationType,

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -44,6 +44,17 @@ export interface EditCommand {
    * 시 이 값을 읽어 HF/FN 모드 재진입 + 커서 위치를 복원하고 본문 moveTo 를 건너뛴다.
    */
   editContext?(): EditContext | null;
+  /**
+   * [Task #3416] 이 명령이 실행되기 **직전의 선택 범위**. undo 후 그 선택을 되살리는 데 쓴다.
+   *
+   * 한컴 2024 실측: 선택을 지운 뒤 undo 하면 지우기 전 범위가 그대로 복원되고(캐럿은 선택 끝),
+   * redo 하면 해제된다. 반면 선택 위에 타이핑해서 대체한 경우의 undo 는 복원하지 않는다.
+   * 그래서 이것은 **선택 삭제 계열만 구현한다** — 미구현이면 종전대로 해제된다.
+   *
+   * 반환값은 "그때 그랬다" 는 기록일 뿐 지금 유효하다는 보장이 아니다. 복원하는 쪽이 현재
+   * 문서에서 유효한지 반드시 확인해야 한다(#2339).
+   */
+  selectionBefore?(): { start: DocumentPosition; end: DocumentPosition } | null;
 }
 
 /**
@@ -845,8 +856,10 @@ export class DeleteSelectionCommand implements EditCommand {
    * 양식 모드 선택 삭제가 게이트에서 드롭돼 무언 폐기가 된다.
    */
   private readonly snapshot: SnapshotCommand;
+  private readonly selection: { start: DocumentPosition; end: DocumentPosition };
 
   constructor(start: DocumentPosition, end: DocumentPosition) {
+    this.selection = { start: { ...start }, end: { ...end } };
     // 삭제 후 커서는 선택 시작으로 모이고, undo 후에는 선택 끝으로 되돌아간다.
     this.snapshot = new SnapshotCommand('deleteSelection', end, start, (wasm) => {
       if (isCell(start)) {
@@ -876,6 +889,16 @@ export class DeleteSelectionCommand implements EditCommand {
   }
 
   mergeWith(): null { return null; }
+
+  /**
+   * [Task #3416] 지우기 전 선택 범위. undo 뒤 이 범위를 되살린다.
+   *
+   * undo 가 돌려주는 커서가 이미 `end`(선택 끝)라, 여기에 anchor(`start`)만 더하면 한컴과
+   * 같은 상태가 된다 — 실측에서 undo 후 선택은 `(0,0,18)~(0,0,22)`, 캐럿은 `(0,0,22)` 였다.
+   */
+  selectionBefore(): { start: DocumentPosition; end: DocumentPosition } {
+    return this.selection;
+  }
 
   snapshotResourceCount(): number {
     return this.snapshot.snapshotResourceCount();

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1981,6 +1981,26 @@ export class SetObjectPropsCommand implements EditCommand {
   }
 
   /**
+   * 적용해도 달라질 것이 없으면 무변경이다 (#2370 규약).
+   *
+   * 히스토리는 커맨드에게 이 질문을 하고(`history.ts` 의 `command.isNoOp?.()`), 답하지 않으면
+   * "항상 바꾼다" 로 읽는다. before 와 after 가 같은데 침묵하면 그 자체가 거짓 응답이고,
+   * 팬텀 엔트리가 Ctrl+Z 한 번을 무효과로 소모하며 redo 스택까지 파기한다.
+   *
+   * 지금 호출부(±90° 회전·`!cur` 토글)는 항상 before ≠ after 라 이 분기를 타지 않는다. 그래도
+   * 답은 커맨드가 해야 한다 — before/after 를 아는 것은 이 객체뿐이고, 호출부마다 같은 비교를
+   * 되풀이하는 것은 판정을 소비자로 흘리는 일이다.
+   *
+   * `after` 의 키만 본다. `execute` 가 적용하는 것이 그것뿐이므로 `before` 에만 있는 키는
+   * 이 연산의 결과를 바꾸지 않는다.
+   */
+  isNoOp(): boolean {
+    const keys = Object.keys(this.after);
+    if (keys.length === 0) return true;
+    return keys.every((key) => Object.is(this.before[key], this.after[key]));
+  }
+
+  /**
    * 병합하지 않는다. 회전 15° 를 네 번 누른 것과 60° 를 한 번 누른 것은 한컴에서도 undo
    * 횟수가 다르다 — 묶으면 되돌리기 단위가 사용자가 누른 단위와 어긋난다.
    */

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1680,17 +1680,44 @@ export class CursorState {
     return this.selectedPictureRefs.length > 1;
   }
 
+  /**
+   * 선택된 개체 **밖**(인접 문단)의 위치. 커서를 옮기지도, 선택을 풀지도 않는다 (Task #3351).
+   *
+   * `moveOutOfSelectedPicture` 가 쓰던 규칙을 그대로 꺼낸 것이다. 개체 조작을 히스토리에
+   * 기록하는 쪽은 **위치만** 필요한데, 그러자고 선택을 푸는 메서드를 부를 수는 없기 때문이다.
+   * 규칙이 갈라지면 Delete 키 경로와 메뉴 경로의 착지가 또 어긋난다.
+   *
+   * 인접 문단을 잡을 수 없으면(개체가 든 문단이 유일) `null` 이다.
+   */
+  positionOutsideSelectedPicture(): DocumentPosition | null {
+    if (!this.selectedPictureRef) return null;
+    const { sec, ppi } = this.selectedPictureRef;
+    return this.positionOutsideObject(sec, ppi);
+  }
+
+  /**
+   * `sec` 구역 `ppi` 문단에 놓인 개체 **밖**의 위치 (Task #3351).
+   *
+   * 선택 상태를 읽지 않고 ref 만 받는다 — 클릭으로 z순서를 바꾸는 경로처럼 **선택 진입 전에**
+   * 기록해야 하는 자리가 있기 때문이다. 인접 문단을 잡을 수 없으면 `null`.
+   */
+  positionOutsideObject(sec: number, ppi: number): DocumentPosition | null {
+    const paraCount = this.wasm.getParagraphCount(sec);
+    if (ppi + 1 < paraCount) {
+      return { sectionIndex: sec, paragraphIndex: ppi + 1, charOffset: 0 };
+    }
+    if (ppi > 0) {
+      const prevLen = this.wasm.getParagraphLength(sec, ppi - 1);
+      return { sectionIndex: sec, paragraphIndex: ppi - 1, charOffset: prevLen };
+    }
+    return null;
+  }
+
   /** 개체 객체 선택 상태에서 개체 밖으로 커서를 이동한다. */
   moveOutOfSelectedPicture(): void {
     if (!this.selectedPictureRef) return;
-    const { sec, ppi } = this.selectedPictureRef;
-    const paraCount = this.wasm.getParagraphCount(sec);
-    if (ppi + 1 < paraCount) {
-      this.position = { sectionIndex: sec, paragraphIndex: ppi + 1, charOffset: 0 };
-    } else if (ppi > 0) {
-      const prevLen = this.wasm.getParagraphLength(sec, ppi - 1);
-      this.position = { sectionIndex: sec, paragraphIndex: ppi - 1, charOffset: prevLen };
-    }
+    const outside = this.positionOutsideSelectedPicture();
+    if (outside) this.position = outside;
     this.exitPictureObjectSelection();
     this.updateRect();
   }

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -177,6 +177,21 @@ export class CursorState {
     }
   }
 
+  /**
+   * 선택 범위를 명시적으로 세운다 — anchor 는 `start`, 커서는 `end` (Task #3416).
+   *
+   * `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 이미 anchor 가 있으면 아무것도 하지
+   * 않는다. undo 뒤 복원처럼 **범위 전체를 지정해야 하는** 자리에는 쓸 수 없어 따로 둔다.
+   *
+   * 호출부가 범위의 유효성을 먼저 확인해야 한다 — 문서에 없는 범위를 세우면 이후 Bold·
+   * Backspace 가 유령 범위를 만지게 된다(#2339 가 막아 둔 그 경로).
+   */
+  selectRange(start: DocumentPosition, end: DocumentPosition): void {
+    this.anchor = { ...start };
+    this.position = { ...end };
+    this.updateRect();
+  }
+
   /** 선택을 해제한다 */
   clearSelection(): void {
     this.anchor = null;

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -1977,7 +1977,12 @@ function bringShapeToFront(this: any, picHit: any): void {
       // [Task #2759] 선택 시 z순서 변경도 문서 뮤테이션 — 메뉴 정렬(insert.ts:427 등)의
       // recordObjectMutation 과 동형으로 snapshot 기록해 undo 가능·redo 무효화·스냅샷 undo
       // 동반 파괴를 막는다. UI 후처리(선택 진입·재렌더)는 호출부가 기존대로 수행한다.
-      const pos = this.getCursorPosition();
+      // [Task #3351] 메뉴 경로와 같은 이유로 캐럿은 **개체 인접**을 기록한다. 여기서
+      // `getCursorPosition()` 을 잡으면 클릭 직전 캐럿(문서 상단일 수도 있다)이 남아 undo 가
+      // 조작과 무관한 자리로 착지한다. 이 지점은 선택 진입 **전**이라 선택 상태를 읽을 수 없어
+      // 클릭된 개체의 ref 로 위치를 구한다.
+      const pos = this.cursor.positionOutsideObject(picHit.sec, picHit.ppi)
+        ?? this.getCursorPosition();
       this.executeOperation({
         kind: 'snapshot',
         operationType: 'changeZOrder',

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2523,6 +2523,9 @@ export class InputHandler {
       this.resetDerivedStateAfterHistoryJump();
       // [Task #2337] 방금 되돌린 커맨드가 HF/FN 편집이면 그 커서 모드로 복원(본문 moveTo 대신).
       this.restoreEditContextAfterHistory(this.history.peekRedoTop(), newPos);
+      // [Task #3416] 그 위에 "지우기 전 선택" 을 되살린다 — 커서 위치가 정해진 뒤라야
+      // anchor 만 더해 범위가 완성된다. redo 쪽에는 두지 않는다(한컴도 redo 는 해제).
+      this.restoreSelectionAfterUndo(this.history.peekRedoTop());
       this.afterEdit();
     }
   }
@@ -2641,6 +2644,49 @@ export class InputHandler {
     this.cellSelectionRenderer?.clear();
     // [#2339] 외부 위치-기반 파생 상태(find currentHit 등)를 구독으로 정리하는 확장점.
     this.eventBus.emit('history-jumped');
+  }
+
+  /**
+   * [Task #3416] undo 뒤 "지우기 전 선택" 을 되살린다.
+   *
+   * 한컴 2024 실측 — 선택을 지우고 undo 하면 지우기 전 범위가 그대로 복원되고(캐럿은 선택 끝),
+   * redo 하면 해제된다. 선택 위에 타이핑해 대체한 경우의 undo 는 복원하지 않는다. 그래서 이
+   * 복원은 `selectionBefore()` 를 구현한 커맨드(선택 삭제)에만 걸리고, 나머지는
+   * `resetDerivedStateAfterHistoryJump` 의 해제가 그대로 최종 상태다.
+   *
+   * **복원 전에 현재 문서에서 유효한 범위인지 반드시 확인한다.** #2339 가 해제를 넣은 이유가
+   * 유령 범위이기 때문이다 — 문서에 없는 anchor/focus 를 세우면 이후 Bold·Backspace 가 본 적
+   * 없는 범위를 만진다. 유효하지 않으면 해제된 상태로 둔다(종전 동작).
+   */
+  private restoreSelectionAfterUndo(cmd: EditCommand | null): void {
+    const range = cmd?.selectionBefore?.();
+    if (!range) return;
+    if (!this.isRestorableBodySelection(range.start, range.end)) return;
+    this.cursor.selectRange(range.start, range.end);
+  }
+
+  /**
+   * 되살려도 되는 본문 선택 범위인가 (Task #3416).
+   *
+   * 셀 안 범위(`parentParaIndex` 보유)는 되살리지 않는다 — 유효성 확인이 중첩 셀 경로
+   * (`cellPath`)를 따라가는 별도 축이고, 한컴 실측도 본문에서만 했다. 확인할 수 없는 범위를
+   * 세우느니 해제로 남기는 쪽이 #2339 의 판단과 같다.
+   */
+  private isRestorableBodySelection(start: DocumentPosition, end: DocumentPosition): boolean {
+    if (start.parentParaIndex !== undefined || end.parentParaIndex !== undefined) return false;
+    if (start.sectionIndex !== end.sectionIndex) return false;
+    try {
+      const paraCount = this.wasm.getParagraphCount(start.sectionIndex);
+      for (const pos of [start, end]) {
+        if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
+        const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
+        if (pos.charOffset < 0 || pos.charOffset > len) return false;
+      }
+    } catch {
+      // 조회 자체가 실패하면 그 범위를 유효하다고 말할 수 없다.
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -4007,6 +4007,15 @@ export class InputHandler {
   /** 선택된 그림/글상자 참조 반환 ([Task #825] headerFooter 동반 시 머리말/꼬리말 picture marker) */
   getSelectedPictureRef(): { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' | 'line' | 'ole'; cellIdx?: number; cellParaIdx?: number; outerTableControlIdx?: number; cellPath?: Array<{ controlIndex: number; cellIndex: number; cellParaIndex: number }>; noteRef?: any; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } } | null { return this.cursor.getSelectedPictureRef(); }
 
+  /**
+   * 선택된 개체 밖(인접 문단)의 위치 — 커서를 옮기지 않는다 (Task #3351).
+   *
+   * 개체 조작을 기록하는 쪽이 "그 조작이 일어난 자리" 를 캐럿으로 남기기 위해 쓴다.
+   */
+  getPositionOutsideSelectedPicture(): DocumentPosition | null {
+    return this.cursor.positionOutsideSelectedPicture();
+  }
+
   /** 다중 선택된 개체 목록 */
   getSelectedPictureRefs(): { sec: number; ppi: number; ci: number; type: string }[] { return this.cursor.getSelectedPictureRefs(); }
 

--- a/rhwp-studio/src/engine/object-props.ts
+++ b/rhwp-studio/src/engine/object-props.ts
@@ -1,11 +1,14 @@
 /**
  * 선택 개체의 속성 조회·변경 라우팅 (Task #3230).
  *
- * 개체는 어디에 있느냐에 따라 setter/getter 가 넷으로 갈린다 — 본문 도형, 본문 그림, 셀 안
+ * 개체는 어디에 있느냐에 따라 setter/getter 가 갈린다 — 본문 도형, 본문 그림, 셀 안
  * (`cellPath`), 머리말/꼬리말(`headerFooter`, [Task #831]). 이 분기는 지금까지
  * `command/commands/insert.ts` 안에만 있었는데, **역연산 커맨드도 undo 시점에 같은 분기가
  * 필요하다.** 커맨드는 `services` 가 아니라 `WasmBridge` 만 받으므로 여기서 `wasm` 기준으로
  * 두고 양쪽이 함께 쓴다.
+ *
+ * 원본의 분기 구조를 조건·인자 순서까지 그대로 옮겼다. 그래서 원본이 갖고 있던 비대칭
+ * (도형 분기가 `headerFooter` 를 보지 않는 것)도 그대로다 — `getObjectProps` 주석 참고.
  *
  * 분기가 갈라지면 적용과 되돌리기가 서로 다른 개체를 만지게 된다 — HF 그림이 그 예다
  * (본문 lookup 으로 떨어지면 조용히 아무것도 안 바뀐다).
@@ -24,7 +27,17 @@ export type ObjectPropsRef = {
   headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number };
 };
 
-/** 선택 개체의 현재 속성. */
+/**
+ * 선택 개체의 현재 속성.
+ *
+ * **분기가 대칭이 아니다** — `type === 'shape'` 는 `cellPath` 만 보고 `headerFooter` 는 보지
+ * 않는다(그림 분기는 본다). 머리말/꼬리말 안의 도형은 본문 lookup 으로 떨어질 수 있다.
+ * 이 비대칭은 `command/commands/insert.ts` 에 있던 원본 그대로이며(옮기면서 조건·인자 순서를
+ * 바꾸지 않았다) 이 모듈이 만든 것이 아니다. 고치려면 HF 안에 도형이 실제로 놓이는지와
+ * `getSelectedPictureRef` 가 도형에 `headerFooter` 를 채우는 경로가 있는지부터 확인해야 해서
+ * 별건으로 둔다. `setObjectProps` 도 같은 비대칭을 그대로 갖는다 — 조회와 적용이 갈리면
+ * 되돌리기가 다른 개체를 만지므로 **둘은 반드시 같은 모양이어야 한다.**
+ */
 export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<string, unknown> {
   if (ref.type === 'shape') {
     if (ref.cellPath && ref.cellPath.length > 0) {
@@ -49,7 +62,12 @@ export function getObjectProps(wasm: WasmBridge, ref: ObjectPropsRef): Record<st
   return wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
 }
 
-/** 선택 개체에 속성을 적용한다. `getObjectProps` 와 같은 분기를 쓴다. */
+/**
+ * 선택 개체에 속성을 적용한다.
+ *
+ * `getObjectProps` 와 **같은 분기**를 쓴다(HF 비대칭까지 포함해서). 조회 경로와 적용 경로가
+ * 갈리면 before 를 읽은 개체와 되돌리는 개체가 달라진다.
+ */
 export function setObjectProps(
   wasm: WasmBridge,
   ref: ObjectPropsRef,

--- a/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
+++ b/rhwp-studio/tests/issue-3230-object-props-inverse.test.ts
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
 
@@ -88,6 +90,46 @@ test('[#3230] 스냅샷 예산을 쓰지 않는다', () => {
     '역연산 커맨드가 예산을 쓰면 스냅샷에서 옮긴 의미가 없다',
   );
   assert.equal(cmd.discard, undefined, '해제할 WASM 스냅샷 id 가 없어야 한다');
+});
+
+test('[#3230] 달라질 것이 없으면 무변경으로 답한다', () => {
+  // 히스토리는 `command.isNoOp?.()` 로 묻고, 답이 없으면 "항상 바꾼다" 로 읽는다(#2370).
+  // 같은 값을 넣는 커맨드가 침묵하면 Ctrl+Z 한 번을 무효과로 소모하는 팬텀 엔트리가 남는다.
+  const same = new SetObjectPropsCommand(bodyImage, { rotationAngle: 90 }, { rotationAngle: 90 });
+  assert.equal(same.isNoOp(), true);
+
+  const changed = new SetObjectPropsCommand(bodyImage, { rotationAngle: 0 }, { rotationAngle: 90 });
+  assert.equal(changed.isNoOp(), false);
+
+  const flipSame = new SetObjectPropsCommand(bodyImage, { horzFlip: true }, { horzFlip: true });
+  assert.equal(flipSame.isNoOp(), true);
+
+  // `before` 에만 있는 키는 `execute` 가 적용하지 않으므로 판정에 넣지 않는다.
+  const extraBefore = new SetObjectPropsCommand(
+    bodyImage, { rotationAngle: 90, vertFlip: false }, { rotationAngle: 90 },
+  );
+  assert.equal(extraBefore.isNoOp(), true);
+
+  // 적용할 것이 아예 없는 커맨드도 무변경이다.
+  assert.equal(new SetObjectPropsCommand(bodyImage, {}, {}).isNoOp(), true);
+});
+
+test('[#3230] 양식 모드에서 setObjectProps 는 허용 목록에 없다', () => {
+  // `4c668b93` 이 kind:'record' → kind:'command' 로 옮긴 이유가 이것이다 — command 라우팅은
+  // `isOperationAllowedInEditMode` 를 거치고, 그 switch 의 default 가 막는다. 허용 목록에
+  // 'setObjectProps' 가 추가되면 양식 모드에서 개체 회전/대칭이 다시 통과한다.
+  const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+  const start = src.indexOf('private isOperationAllowedInEditMode');
+  assert.notEqual(start, -1, 'isOperationAllowedInEditMode 가 있어야 함');
+  const body = src.slice(start, src.indexOf('\n  }', start));
+
+  assert.doesNotMatch(
+    body,
+    /case\s*'setObjectProps'/,
+    "'setObjectProps' 를 허용하면 양식 모드 개체 편집 차단이 뚫린다",
+  );
+  assert.match(body, /default:\s*\n?\s*return false;/, 'command 는 기본적으로 막혀야 함');
 });
 
 test('[#3230] 회전 15° 를 네 번 눌러도 병합하지 않는다', () => {

--- a/rhwp-studio/tests/issue-3351-object-caret-landing.test.ts
+++ b/rhwp-studio/tests/issue-3351-object-caret-landing.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { balancedFrom, functionBodyFrom } from './support/source-guard.ts';
+
+// [#3351] 메뉴 개체 조작의 undo/redo 캐럿이 조작과 무관한 자리로 착지하던 결함.
+//
+// 개체 선택(`enterPictureObjectSelectionDirect`)은 `cursor.position` 을 옮기지 않는다. 그래서
+// 기록 시점에 `getCursorPosition()` 을 잡으면 **개체를 선택하기 직전 캐럿**이 남고, 문단 0 에서
+// 스크롤해 문단 10 의 개체를 지우면 undo/redo 가 문서 상단으로 점프한다.
+//
+// 한컴 오피스 2024 실측(COM):
+//  - `FindCtrl` 로 개체를 선택하면 캐럿이 앵커로 이동한다((0,0,16) → (0,10,5)).
+//  - 그 뒤 캐럿을 다른 문단으로 옮기면 **개체 선택이 풀린다**(이후 Delete 가 개체를 못 지움).
+//    즉 "캐럿은 딴 곳, 개체는 선택" 이라는 상태가 한컴에는 없다.
+//  - 삭제 → Undo → Redo 내내 캐럿은 개체 인접 문단((0,10,0))에 머문다.
+//
+// 따라서 정답은 "개체 인접" 이고, Delete 키 경로(`performDelete`)가 이미 그렇게 한다.
+// 여기서 고정하는 것은 메뉴 경로와 클릭 z순서 경로도 같은 자리를 기록한다는 것이다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const studioRoot = rootDir;
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#3351] 인접 위치 규칙은 한 곳에만 있다', () => {
+  const cursor = src('src/engine/cursor.ts');
+
+  // 규칙 본체는 ref 를 받는 쪽이다.
+  const rule = functionBodyFrom(cursor, 'positionOutsideObject(sec: number, ppi: number)');
+  assert.match(rule, /ppi \+ 1 < paraCount/, '다음 문단 우선');
+  assert.match(rule, /getParagraphLength\(sec, ppi - 1\)/, '마지막 문단이면 이전 문단 끝');
+
+  // 선택 기반 조회는 그 규칙에 위임한다 — 복제하면 Delete 키 경로와 착지가 어긋난다.
+  const bySelection = functionBodyFrom(cursor, 'positionOutsideSelectedPicture()');
+  assert.match(bySelection, /this\.positionOutsideObject\(sec, ppi\)/, '규칙을 위임해야 한다');
+  assert.doesNotMatch(bySelection, /getParagraphCount/, '규칙을 복제하면 안 된다');
+
+  // 커서를 실제로 옮기는 쪽도 같은 규칙을 쓴다.
+  const move = functionBodyFrom(cursor, 'moveOutOfSelectedPicture()');
+  assert.match(move, /this\.positionOutsideSelectedPicture\(\)/, '이동도 같은 규칙');
+  assert.match(move, /this\.exitPictureObjectSelection\(\)/, '이동은 선택도 푼다(종전 동작)');
+});
+
+test('[#3351] 조회는 커서를 옮기지도 선택을 풀지도 않는다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const rule = functionBodyFrom(cursor, 'positionOutsideObject(sec: number, ppi: number)');
+  const bySelection = functionBodyFrom(cursor, 'positionOutsideSelectedPicture()');
+  for (const [name, body] of [['positionOutsideObject', rule], ['positionOutsideSelectedPicture', bySelection]] as const) {
+    assert.doesNotMatch(body, /this\.position\s*=/, `${name} 는 커서를 옮기면 안 된다`);
+    assert.doesNotMatch(body, /exitPictureObjectSelection/, `${name} 는 선택을 풀면 안 된다`);
+  }
+});
+
+test('[#3351] 메뉴 개체 조작은 개체 인접을 기록한다', () => {
+  const insert = src('src/command/commands/insert.ts');
+  const body = functionBodyFrom(insert, 'function recordObjectMutation');
+  assert.match(
+    body,
+    /getPositionOutsideSelectedPicture\(\)/,
+    '개체 선택은 cursor.position 을 옮기지 않는다 — 그냥 읽으면 선택 직전 캐럿이 기록된다',
+  );
+});
+
+test('[#3351] 클릭 z순서도 개체 인접을 기록한다', () => {
+  const mouse = src('src/engine/input-handler-mouse.ts');
+  const body = balancedFrom(mouse, 'function bringShapeToFront', '{');
+  assert.match(
+    body,
+    /positionOutsideObject\(picHit\.sec, picHit\.ppi\)/,
+    '선택 진입 전이라 ref 로 위치를 구해야 한다',
+  );
+});
+
+test('[#3351] 인접 문단 계산 — 실제 규칙 동작', async () => {
+  const vite = await createServer({
+    root: studioRoot,
+    appType: 'custom',
+    logLevel: 'silent',
+    server: { middlewareMode: true },
+  });
+  try {
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const make = (paraCount: number, lengths: Record<number, number>) => {
+      const wasm: any = {
+        getParagraphCount: () => paraCount,
+        getParagraphLength: (_s: number, p: number) => lengths[p] ?? 0,
+      };
+      return new CursorState(wasm) as any;
+    };
+
+    // 개체가 문단 10, 뒤에 문단이 더 있으면 다음 문단 시작.
+    assert.deepEqual(
+      make(13, {}).positionOutsideObject(0, 10),
+      { sectionIndex: 0, paragraphIndex: 11, charOffset: 0 },
+    );
+    // 개체가 마지막 문단이면 이전 문단 끝.
+    assert.deepEqual(
+      make(11, { 9: 7 }).positionOutsideObject(0, 10),
+      { sectionIndex: 0, paragraphIndex: 9, charOffset: 7 },
+    );
+    // 문단이 하나뿐이면 인접이 없다.
+    assert.equal(make(1, {}).positionOutsideObject(0, 0), null);
+  } finally {
+    await vite.close();
+  }
+});

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+import { functionBodyFrom } from './support/source-guard.ts';
+
+// [#3416] undo 뒤 "지우기 전 선택" 복원.
+//
+// 한컴 오피스 2024 실측(COM, `GetSelectedPosBySet`):
+//
+//  | 연산                | Undo 후 선택                          |
+//  |---------------------|---------------------------------------|
+//  | 선택 삭제(Delete)   | (0,0,18)~(0,0,22) — 지우기 전 범위 복원 |
+//  | 선택 위 타이핑 대체 | 없음 — 캐럿만 선택 끝(0,0,19)          |
+//  | 선택 서식(Bold)     | 애초에 유지(잃지 않음)                 |
+//
+//  Redo 는 선택을 해제한다(삭제 직후 상태).
+//
+// 그래서 복원은 **선택 삭제 계열만** 이고, 나머지는 #2339 의 해제가 그대로 최종 상태다.
+// 그리고 복원 전에 현재 문서에서 유효한 범위인지 확인해야 한다 — #2339 가 해제를 넣은 이유가
+// 유령 범위이기 때문이다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+test('[#3416] 선택 삭제 커맨드가 지우기 전 범위를 들고 있다', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const { DeleteSelectionCommand } = await vite.ssrLoadModule('/src/engine/command.ts');
+    const start = { sectionIndex: 0, paragraphIndex: 0, charOffset: 18 };
+    const end = { sectionIndex: 0, paragraphIndex: 0, charOffset: 22 };
+    const cmd: any = new DeleteSelectionCommand(start, end);
+
+    assert.deepEqual(cmd.selectionBefore(), { start, end });
+
+    // 호출부가 넘긴 객체를 그대로 들고 있으면 이후 변형이 기록을 오염시킨다.
+    start.charOffset = 999;
+    assert.equal(cmd.selectionBefore().start.charOffset, 18, '복사해서 보관해야 한다');
+  } finally {
+    await vite.close();
+  }
+});
+
+test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const undo = functionBodyFrom(handler, 'private handleUndo()');
+  const redo = functionBodyFrom(handler, 'private handleRedo()');
+
+  assert.match(undo, /this\.restoreSelectionAfterUndo\(/, 'undo 는 복원을 시도해야 한다');
+  assert.doesNotMatch(redo, /restoreSelectionAfterUndo/, '한컴은 redo 에서 선택을 해제한다');
+
+  // 해제가 먼저, 복원이 나중이어야 한다 — 순서가 뒤집히면 복원한 선택을 곧바로 지운다.
+  const idxReset = undo.indexOf('resetDerivedStateAfterHistoryJump');
+  const idxRestore = undo.indexOf('restoreSelectionAfterUndo');
+  assert.ok(idxReset !== -1 && idxRestore !== -1 && idxReset < idxRestore,
+    '해제 뒤에 복원해야 한다');
+});
+
+test('[#3416] 복원 전에 유효성을 확인한다 (#2339 유령 범위 방지)', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /isRestorableBodySelection\(/, '유효성 확인을 거쳐야 한다');
+  // 확인보다 먼저 selectRange 를 부르면 유령 범위가 그대로 선다.
+  const idxCheck = restore.indexOf('isRestorableBodySelection');
+  const idxSelect = restore.indexOf('selectRange');
+  assert.ok(idxCheck !== -1 && idxSelect !== -1 && idxCheck < idxSelect,
+    '확인이 selectRange 보다 먼저여야 한다');
+});
+
+test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const reset = functionBodyFrom(handler, 'private resetDerivedStateAfterHistoryJump');
+  assert.match(reset, /exitBlockSelectionMode\(\)/, '#2339 의 해제가 유지돼야 한다');
+  assert.match(reset, /exitCellSelectionMode\(\)/);
+  assert.match(reset, /exitPictureObjectSelection\(\)/);
+});
+
+test('[#3416] 범위 유효성 판정 — 실제 동작', async () => {
+  const vite = await createServer({
+    root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
+  });
+  try {
+    const mod = await vite.ssrLoadModule('/src/engine/input-handler.ts');
+    const InputHandler: any = mod.InputHandler;
+    // 판정은 wasm 조회에만 의존하므로 프로토타입 메서드를 최소 컨텍스트로 부른다.
+    const check = InputHandler.prototype['isRestorableBodySelection'];
+    assert.equal(typeof check, 'function', 'isRestorableBodySelection 이 있어야 함');
+
+    const ctx = (paraCount: number, len: number) => ({
+      wasm: {
+        getParagraphCount: () => paraCount,
+        getParagraphLength: () => len,
+      },
+    });
+    const p = (para: number, off: number) => ({ sectionIndex: 0, paragraphIndex: para, charOffset: off });
+
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 6)), true, '문서 안 범위는 복원 가능');
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(5, 6)), false, '문단이 사라졌으면 불가');
+    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 99)), false, '오프셋이 길이를 넘으면 불가');
+    assert.equal(
+      check.call(ctx(3, 10), p(0, 2), { sectionIndex: 1, paragraphIndex: 0, charOffset: 1 }),
+      false,
+      '구역이 다르면 불가',
+    );
+    // 셀 안 범위는 확인 축이 달라 복원하지 않는다.
+    assert.equal(
+      check.call(ctx(3, 10), { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)),
+      false,
+      '셀 범위는 복원 대상이 아니다',
+    );
+    // 조회가 던지면 유효하다고 말할 수 없다.
+    const throwing = { wasm: { getParagraphCount: () => { throw new Error('gone'); } } };
+    assert.equal(check.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 불가로 판정');
+  } finally {
+    await vite.close();
+  }
+});


### PR DESCRIPTION
## 통합 대상

`lpaiu-cs` 기여자의 현재 open PR 3건을 최신 `upstream/devel` 위에 번호순으로 적용합니다.

- #5615 #3230 개체 속성 역연산·양식 모드·그림 회전 저장 회귀 보정
- #5653 #3351 메뉴 개체 조작 undo/redo 캐럿 착지
- #5654 #3416 선택 삭제 undo 뒤 선택 범위 복원

## 검토와 로컬 검증

- 세 원 PR은 충돌 없이 체리픽됐으며, 차단 결함은 발견하지 못했습니다.
- focused Studio regressions와 전체 Studio test: 1,017 passed, 1 skipped
- Studio production build: passed
- headless browser `e2e:undo`, `e2e:undo-object-selection`: passed

원 PR별 검토 기록과 오늘할일은 이 code candidate CI가 성공한 뒤 같은 PR에 trailing commit으로 추가합니다.
