### PR TITLE
fix(#3230): 통합에서 빠진 양식 모드 차단·그림 회전 회귀 수정을 재적용한다

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -693,31 +693,26 @@ function changeZOrder(
   ih.exitPictureObjectSelectionAndAfterEdit();
 }
 
-function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
-  return setObjectProps(services.wasm, ref, props);
-}
-
 /**
- * [Task #3230] 절대 속성 하나를 바꾸고 **역연산으로** 기록한다.
+ * [Task #3230] 절대 속성 하나를 **역연산 커맨드로** 적용하고 기록한다.
  *
- * 스냅샷(`recordObjectMutation`)이 아니라 `kind:'record'` 를 쓴다 — 되돌릴 것이 스칼라 하나인데
+ * 스냅샷(`recordObjectMutation`) 대신 `kind:'command'`를 쓴다 — 되돌릴 것이 스칼라 하나인데
  * `Document` 통째 클론 2개(문서에 따라 최대 21 MB)를 스택에 얹을 이유가 없다. 호출부가 이미
- * 적용 전 값을 읽어 두었으므로 before 가 정확하다.
+ * 적용 전 값을 읽어 두었으므로 before 가 정확하다. setter를 라우터 전에 직접 호출하지 않아야
+ * 양식 모드의 편집 허용 검사가 실제 변경보다 먼저 실행된다.
  *
- * refresh 를 'full' 로 명시한다 — `kind:'record'` 의 기본은 'none' 이고, 종전 스냅샷 라우팅의
- * 'full' 이 `afterEdit()` → `document-changed` 를 대신 emit 해 주고 있었다(그래서 호출부의 수동
- * emit 이 [undo P3 정리] 에서 제거됐다). 명시하지 않으면 회전이 화면에 반영되지 않는다.
+ * refresh 를 'full' 로 명시한다 — command 라우팅의 자동 판정에 맡기면 개체 회전/대칭의 화면 반영이
+ * 보장되지 않는다. 종전 스냅샷 라우팅의 'full' 이 `afterEdit()` → `document-changed` 를 대신
+ * emit 해 주고 있었다(그래서 호출부의 수동 emit 이 [undo P3 정리] 에서 제거됐다).
  */
-function recordAbsolutePropChange(
-  services: import('../types').CommandServices,
+function executeAbsolutePropChange(
   ih: InputHandler,
   ref: PictureRef,
   before: Record<string, unknown>,
   after: Record<string, unknown>,
 ): void {
-  setProps(services, ref, after);
   ih.executeOperation({
-    kind: 'record',
+    kind: 'command',
     command: new SetObjectPropsCommand(ref, before, after),
     meta: { refresh: 'full' },
   });
@@ -738,7 +733,7 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   if (next > 180) next -= 360;
   // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
   // 절대값이라 되돌리기가 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -751,5 +746,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  recordAbsolutePropChange(services, ih, ref, { [key]: cur }, { [key]: !cur });
+  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -721,6 +721,45 @@ function executeAbsolutePropChange(
   });
 }
 
+/**
+ * [Task #3230] 속성 왕복이 **참인 역연산인 대상**인지.
+ *
+ * 도형은 참이다 — `rotationAngle` 은 평범한 필드 대입이고 flip 은 비트를 대칭으로 set/clear
+ * 한다(`document_core/commands/object_ops/shape.rs`). 같은 값을 다시 넣으면 원래 상태다.
+ *
+ * **그림·OLE 는 아니다.** `rotationAngle` 이 섞이면 `refresh_picture_rotation_layout_for_save`
+ * 가 각도와 무관하게 — 0 으로 되돌리는 경우까지 — `rotate_image = true` 와
+ * `flip |= 0x0008_0000` 을 세운다(`object_ops/picture.rs:242-243`). 이 둘을 다시 내리는 경로는
+ * 저장소에 없어서, 90° 돌렸다 되돌린 그림은 화면은 같아도 저장 바이트가 원본과 달라진다
+ * (HWPX `hp:rotationInfo rotateimage`·HWP5 `HWPTAG_SHAPE_COMPONENT` 의 flip 비트).
+ * 대칭도 `TRANSFORM_KEYS`(picture.rs:176-184)에 걸려 `raw_rendering`·`render_*` 캐시를
+ * 기본값으로 리셋한다.
+ *
+ * 속성 bag 만으로는 이것들을 복원할 수 없다. 문서를 통째로 되돌리는 스냅샷이라야 정확하므로
+ * 그림·OLE 는 종전 경로를 유지한다 — 되돌리기의 정확성이 스냅샷 비용보다 앞선다.
+ */
+function absolutePropChangeIsInvertible(ref: PictureRef): boolean {
+  return ref.type === 'shape';
+}
+
+/** 역연산이 참이면 커맨드로, 아니면 종전 스냅샷으로 기록한다. */
+function applyAbsolutePropChange(
+  services: import('../types').CommandServices,
+  ih: InputHandler,
+  ref: PictureRef,
+  operationType: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): void {
+  if (absolutePropChangeIsInvertible(ref)) {
+    executeAbsolutePropChange(ih, ref, before, after);
+    return;
+  }
+  recordObjectMutation(ih, operationType, (wasm) => {
+    setObjectProps(wasm, ref, after);
+  });
+}
+
 /** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
@@ -734,9 +773,11 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  // [Task #3230] 스냅샷 → 역연산. `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가
-  // 절대값이라 되돌리기가 자명하다.
-  executeAbsolutePropChange(ih, ref, { rotationAngle: cur }, { rotationAngle: next });
+  // [Task #3230] 도형은 역연산, 그림·OLE 는 스냅샷 유지(`absolutePropChangeIsInvertible`).
+  // `cur` 는 이미 위에서 읽은 적용 전 각도이고 setter 가 절대값이라 되돌리기가 자명하다.
+  applyAbsolutePropChange(
+    services, ih, ref, 'rotateObject', { rotationAngle: cur }, { rotationAngle: next },
+  );
 }
 
 /** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
@@ -749,5 +790,5 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   if (props.sizeProtect) return;
   const cur = !!props[key];
   // 위 rotate 와 동일 — 토글이지만 setter 에 넘기는 값은 절대값(`!cur`)이라 역연산이 자명하다.
-  executeAbsolutePropChange(ih, ref, { [key]: cur }, { [key]: !cur });
+  applyAbsolutePropChange(services, ih, ref, 'flipObject', { [key]: cur }, { [key]: !cur });
 }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -15,7 +15,7 @@ import type { CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { InputHandler } from '@/engine/input-handler';
 import { SetObjectPropsCommand, type RefreshPolicy } from '@/engine/command';
-import { getObjectProps, type ObjectPropsRef } from '@/engine/object-props';
+import { getObjectProps, setObjectProps, type ObjectPropsRef } from '@/engine/object-props';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -454,7 +454,10 @@ export const insertCommands: CommandDef[] = [
           captionIncludeMargin: false,
         };
         let result: any;
-        result = setProps(services, ref, captionProps);
+        // [Task #3230] `setProps` 래퍼가 사라져 공유 라우팅을 직접 부른다. 이 경로는 종전부터
+        // 라우터를 거치지 않고 직접 적용하고 `document-changed` 를 스스로 emit 한다 —
+        // 회전/대칭과 달리 이번 변경 대상이 아니라 종전 동작 그대로 둔다.
+        result = setObjectProps(services.wasm, ref, captionProps);
         // "그림 N " 끝 위치를 Rust가 반환
         charOffset = result?.captionCharOffset ?? 4;
         services.eventBus.emit('document-changed');

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,19 +77,36 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /applyAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /applyAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
-    /\bsetProps\s*\(/,
+    /\bsetProps\s*\(|setObjectProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
+});
+
+// [Task #3230 후속] 역연산은 **왕복이 참인 대상에만** 쓴다. 그림·OLE 는
+// `refresh_picture_rotation_layout_for_save` 가 각도와 무관하게 `rotate_image`·flip 0x80000 을
+// 세우고 되돌리는 경로가 없어(object_ops/picture.rs:242-243) 속성 bag 으로 복원되지 않는다.
+test('그림·OLE 는 스냅샷을 유지한다 — 속성 왕복이 참인 역연산이 아니다', () => {
+  const gate = functionBodyFrom(insertSrc, 'function absolutePropChangeIsInvertible');
+  assert.match(
+    gate,
+    /ref\.type === 'shape'/,
+    "역연산 대상은 도형뿐 — 그림·OLE 로 넓히면 rotate_image 가 되돌아가지 않는다",
+  );
+
+  const apply = functionBodyFrom(insertSrc, 'function applyAbsolutePropChange');
+  assert.match(apply, /absolutePropChangeIsInvertible\(ref\)/, '대상 판정을 거쳐야 한다');
+  assert.match(apply, /executeAbsolutePropChange\(/, '참이면 역연산 커맨드');
+  assert.match(apply, /recordObjectMutation\(/, '아니면 종전 스냅샷');
 });
 
 test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -77,14 +77,14 @@ test('services.wasm 을 별칭으로 빼내 가드를 우회할 수 없다', () 
 // "히스토리를 우회하지 않는다". 우회 형태만 달라졌으므로(직접 setProps 호출) 그것을 본다.
 test('회전/대칭은 역연산으로 기록한다', () => {
   const rot = balancedFrom(insertSrc, 'function applyRotationDelta', '{');
-  assert.match(rot, /recordAbsolutePropChange\(/, '회전을 히스토리에 기록');
+  assert.match(rot, /executeAbsolutePropChange\(/, '회전을 히스토리에 기록');
   assert.doesNotMatch(
     rot,
     /\bsetProps\s*\(/,
     '적용은 기록 헬퍼 안에서만 — 직접 적용하면 히스토리를 우회한다',
   );
   const flip = balancedFrom(insertSrc, 'function toggleFlip', '{');
-  assert.match(flip, /recordAbsolutePropChange\(/, '대칭을 히스토리에 기록');
+  assert.match(flip, /executeAbsolutePropChange\(/, '대칭을 히스토리에 기록');
   assert.doesNotMatch(
     flip,
     /\bsetProps\s*\(/,
@@ -92,13 +92,14 @@ test('회전/대칭은 역연산으로 기록한다', () => {
   );
 });
 
-test('recordAbsolutePropChange 는 역연산 커맨드로 위임한다', () => {
-  const block = functionBodyFrom(insertSrc, 'function recordAbsolutePropChange');
-  assert.match(block, /kind:\s*'record'/, '스냅샷이 아니라 역연산 기록');
+test('executeAbsolutePropChange 는 라우터에서 역연산 커맨드를 실행한다', () => {
+  const block = functionBodyFrom(insertSrc, 'function executeAbsolutePropChange');
+  assert.match(block, /kind:\s*'command'/, '속성 적용도 편집 허용 검사를 거치는 command 라우터에서 실행');
   assert.match(block, /new SetObjectPropsCommand\(/, 'before/after 를 든 커맨드로 기록');
   assert.match(
     block,
     /refresh:\s*'full'/,
-    "kind:'record' 의 기본 refresh 는 'none' — 명시하지 않으면 회전이 화면에 반영되지 않는다",
+    '개체 회전/대칭 뒤 전체 화면 갱신을 유지한다',
   );
+  assert.doesNotMatch(block, /\bsetProps\s*\(/, 'setter를 라우터 전에 호출하면 양식 모드 편집 차단을 우회한다');
 });


### PR DESCRIPTION
관련 이슈: #3230

## 문제

`devel`(`c2a36398d`)에 결함 두 건이 살아 있습니다. 둘 다 #5615 에서 이미 고쳤던 것이고, 통합
과정에서 커밋이 빠지면서 되돌아왔습니다.

**① 양식 모드에서 개체 편집이 차단되지 않습니다.** 양식 모드로 문서를 열고 도형·그림을 선택해
메뉴에서 회전(±90°)이나 좌우/상하 대칭을 실행하면 그대로 적용됩니다. 양식 모드는 누름틀 안
텍스트만 편집할 수 있어야 합니다.

**② 그림을 회전했다 되돌리면 저장 바이트가 원본과 달라집니다.** 그림을 90° 돌리고 -90° 로
되돌리면(또는 대칭을 두 번) 화면은 원래대로 보이지만 저장한 파일이 원본과 다릅니다.

## 원인

두 결함 모두 `insert.ts` 의 `recordAbsolutePropChange` 한 자리에서 나옵니다.

**①** 이 함수가 `setProps(services, ref, after)` 를 **라우터보다 먼저** 호출합니다. 즉 편집 허용
검사가 돌기 전에 뮤테이션이 이미 끝납니다. 이어지는 기록도 `kind:'record'` 인데,
`isOperationAllowedInEditMode` 는 `desc.kind === 'record'` 를 무조건 통과시킵니다
(`input-handler.ts:4016` — "이미 적용된 뮤테이션은 항상 기록한다"는 #2337-review 의 규약).
적용과 기록 양쪽 모두 게이트를 지나지 않습니다.

**②** 같은 함수가 `image` 에도 걸립니다. 그림은 속성 왕복이 참인 역연산이 아닙니다 —
`rotationAngle` 이 섞이면 `refresh_picture_rotation_layout_for_save` 가 각도와 무관하게(0 으로
되돌리는 경우까지) `rotate_image = true` 와 `flip |= 0x0008_0000` 을 세웁니다
(`document_core/commands/object_ops/picture.rs:242-243`). 이 둘을 다시 내리는 경로가 저장소에
없어서, 속성 bag 만 되돌리는 역연산으로는 저장 상태를 복원할 수 없습니다(HWPX
`hp:rotationInfo rotateimage` · HWP5 `HWPTAG_SHAPE_COMPONENT` 의 flip 비트). 대칭도
`TRANSFORM_KEYS`(`picture.rs:176-184`)에 걸려 `raw_rendering`·`render_*` 캐시를 리셋합니다.

②는 제가 #5570 에서 역연산 라우팅을 넣으며 만든 회귀입니다.

### 왜 지금 devel 에 있는가

#5615 는 이 두 건을 고친 커밋 3개와 리뷰 대응 1개, 모두 4개였습니다. 통합 PR #5670 이 그중
**맨 위 1개만** 체리픽했습니다.

| 커밋 | 내용 | author | devel |
|---|---|---|---|
| `5b59b96c7` | 리뷰 대응(`isNoOp`·계약 문서) | lpaiu-cs | ✅ |
| `42f59eb1e` | 역연산 대상을 도형으로 좁힘 (②) | lpaiu-cs | ❌ |
| `ddf813fd3` | 캡션 경로 빌드 수정 | lpaiu-cs | ❌ |
| `178d0e66a` | 양식 모드 차단 복원 (①) | **jangster77** | ❌ |

머지된 `5b59b96c7` 의 커밋 메시지가 이 상태를 스스로 가리킵니다 — "`4c668b93` 이
kind:'record'→'command' 로 옮겨 닫은 구멍이라, 허용 목록이 넓어지면 그대로 다시 열린다" 고
적혀 있는데, 그 `4c668b93`(=`178d0e66a` 로 재적용된 메인테이너 수정)이 devel 에 없습니다.

같은 3개가 #5607 에서도 빠졌었고, 그것을 되돌리려고 만든 것이 #5615 였습니다.

## 변경

떨어진 3개를 **의미 단위 그대로** 재적용합니다. 새로 쓴 코드는 없습니다 — 세 커밋 모두
`cherry-pick -x` 이고 `178d0e66a` 는 원 author(`jangster77`)와 트레일러를 보존했습니다.

1. **양식 모드 개체 편집 차단 복원**(`jangster77`) — `setProps` 선호출을 없애고 `kind:'record'`
   를 `kind:'command'` 로 옮깁니다. 적용이 라우터 안에서 일어나므로 허용 검사가 실제 변경보다
   먼저 돕니다.
2. **캡션 경로의 `setProps` 호출 복구** — 1 이 `setProps` 래퍼를 지우면서 `insert.ts` 의 캡션
   경로가 미정의 심볼을 참조해 빌드가 깨집니다. 공유 라우팅(`setObjectProps`)을 직접 부릅니다.
   이 경로는 종전부터 라우터를 거치지 않고 `document-changed` 를 스스로 emit 하며, 이번 변경
   대상이 아니라 종전 동작 그대로 둡니다.
3. **역연산 대상을 도형으로 좁힘** — `absolutePropChangeIsInvertible(ref)` 를 두고 도형만
   커맨드로, 그림·OLE 는 종전 스냅샷 경로로 보냅니다. 도형은 참인 역연산입니다 —
   `rotationAngle` 이 평범한 필드 대입이고 flip 은 비트를 대칭으로 set/clear 합니다
   (`object_ops/shape.rs`). 되돌리기의 정확성이 스냅샷 비용보다 앞섭니다.

## 검증

devel `c2a36398d` 기준.

- **수정 전 실패 증명**: devel 소스에서 `insert.ts:719` 가 `setProps(services, ref, after)` 를
  `executeOperation` 앞에서 호출하고 `kind: 'record'` 로 기록합니다. `absolutePropChangeIsInvertible`
  는 devel 에 존재하지 않아 `image` 도 같은 경로를 탑니다. 이 브랜치에서 `kind: 'command'` 이고
  `setProps` 래퍼가 없으며 그림·OLE 는 스냅샷으로 갈립니다.
- 소스 가드 `rhwp-studio/tests/undo-menu-object-ops.test.ts` — 양식 모드 허용 목록과 역연산
  대상 분기를 고정합니다. `issue-3230-object-props-inverse.test.ts` 와 함께 15개 통과.
- `npm --prefix rhwp-studio run test` — **1019 tests, 0 fail**(skipped 1 은 기존 테스트).
- `npx tsc --noEmit` 대신 `./node_modules/.bin/tsc --noEmit` — exit 0.
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

## 범위 외

- **#3230 의 나머지 축** — 이 PR 은 이미 합의된 수정의 재적용이라 새 라우팅을 넓히지 않습니다.
  스냅샷 예산·역연산 확대는 이슈에 남습니다(현재 자동 종료된 상태라 재오픈을 요청드립니다).
- **머리말/꼬리말 안 도형의 조회 비대칭** — `object-props.ts` 에 문서화만 돼 있는 선재 항목이고
  이 PR 이 만든 것이 아닙니다. HF 안에 도형이 실제로 놓이는 경로부터 확인해야 해서 별건입니다.
