### PR TITLE
refactor(#3416): 선택 범위 유효성을 소유자인 selectRange 안에서 강제한다

### DIFF
--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -183,13 +183,37 @@ export class CursorState {
    * `setAnchor()` 는 "현재 위치에서 선택을 시작한다" 이고 이미 anchor 가 있으면 아무것도 하지
    * 않는다. undo 뒤 복원처럼 **범위 전체를 지정해야 하는** 자리에는 쓸 수 없어 따로 둔다.
    *
-   * 호출부가 범위의 유효성을 먼저 확인해야 한다 — 문서에 없는 범위를 세우면 이후 Bold·
-   * Backspace 가 유령 범위를 만지게 된다(#2339 가 막아 둔 그 경로).
+   * **두 끝이 모두 현재 문서에서 확인될 때만 세운다.** anchor/focus 의 소유자가 여기이므로
+   * "선택은 실재하는 위치를 가리킨다"(#2339)를 지키는 것도 여기 몫이다 — 호출부의 선의에
+   * 맡기면 호출부가 하나 늘 때마다 유령 범위가 되살아난다. 세우지 못하면 아무것도 바꾸지
+   * 않고 `false` 를 돌려준다(종전 선택 상태 그대로).
    */
-  selectRange(start: DocumentPosition, end: DocumentPosition): void {
+  selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
+    if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
     this.anchor = { ...start };
     this.position = { ...end };
     this.updateRect();
+    return true;
+  }
+
+  /**
+   * 본문 좌표계에서 **실재가 확인된** 위치인가 (Task #3416).
+   *
+   * 셀 안 위치(`parentParaIndex`)는 `false` 다 — 확인이 중첩 셀 경로(`cellPath`)를 따라가는
+   * 별도 축이라 이 산술로는 실재를 말할 수 없다. "없다" 가 아니라 "이 판정으로는 확인할 수
+   * 없다" 는 뜻이고, 확인할 수 없는 위치를 세우지 않는 것이 #2339 의 판단과 같다.
+   */
+  private isVerifiedBodyPosition(pos: DocumentPosition): boolean {
+    if (pos.parentParaIndex !== undefined) return false;
+    try {
+      const paraCount = this.wasm.getParagraphCount(pos.sectionIndex);
+      if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
+      const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
+      return pos.charOffset >= 0 && pos.charOffset <= len;
+    } catch {
+      // 조회 자체가 실패하면 그 위치를 실재한다고 말할 수 없다.
+      return false;
+    }
   }
 
   /** 선택을 해제한다 */

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2661,32 +2661,12 @@ export class InputHandler {
   private restoreSelectionAfterUndo(cmd: EditCommand | null): void {
     const range = cmd?.selectionBefore?.();
     if (!range) return;
-    if (!this.isRestorableBodySelection(range.start, range.end)) return;
+    // 구역을 걸치는 범위는 되살리지 않는다 — 한컴 실측을 한 구역 안에서만 했다. 이건 실재
+    // 여부가 아니라 "어디까지 맞출지" 의 판단이라 여기 남는다.
+    if (range.start.sectionIndex !== range.end.sectionIndex) return;
+    // 범위가 현재 문서에 실재하는지는 `selectRange` 가 판정하고 거절한다(#2339 유령 범위
+    // 차단은 anchor/focus 소유자의 계약이다). 거절되면 해제된 상태 그대로 둔다.
     this.cursor.selectRange(range.start, range.end);
-  }
-
-  /**
-   * 되살려도 되는 본문 선택 범위인가 (Task #3416).
-   *
-   * 셀 안 범위(`parentParaIndex` 보유)는 되살리지 않는다 — 유효성 확인이 중첩 셀 경로
-   * (`cellPath`)를 따라가는 별도 축이고, 한컴 실측도 본문에서만 했다. 확인할 수 없는 범위를
-   * 세우느니 해제로 남기는 쪽이 #2339 의 판단과 같다.
-   */
-  private isRestorableBodySelection(start: DocumentPosition, end: DocumentPosition): boolean {
-    if (start.parentParaIndex !== undefined || end.parentParaIndex !== undefined) return false;
-    if (start.sectionIndex !== end.sectionIndex) return false;
-    try {
-      const paraCount = this.wasm.getParagraphCount(start.sectionIndex);
-      for (const pos of [start, end]) {
-        if (pos.paragraphIndex < 0 || pos.paragraphIndex >= paraCount) return false;
-        const len = this.wasm.getParagraphLength(pos.sectionIndex, pos.paragraphIndex);
-        if (pos.charOffset < 0 || pos.charOffset > len) return false;
-      }
-    } catch {
-      // 조회 자체가 실패하면 그 범위를 유효하다고 말할 수 없다.
-      return false;
-    }
-    return true;
   }
 
   /**

--- a/rhwp-studio/tests/issue-3416-selection-restore.test.ts
+++ b/rhwp-studio/tests/issue-3416-selection-restore.test.ts
@@ -19,8 +19,9 @@ import { functionBodyFrom } from './support/source-guard.ts';
 //  Redo 는 선택을 해제한다(삭제 직후 상태).
 //
 // 그래서 복원은 **선택 삭제 계열만** 이고, 나머지는 #2339 의 해제가 그대로 최종 상태다.
-// 그리고 복원 전에 현재 문서에서 유효한 범위인지 확인해야 한다 — #2339 가 해제를 넣은 이유가
-// 유령 범위이기 때문이다.
+// 그리고 실재하지 않는 범위는 서지 않아야 한다 — #2339 가 해제를 넣은 이유가 유령 범위이기
+// 때문이다. 그 판정은 anchor/focus 소유자인 `CursorState.selectRange` 가 하고, 호출부는
+// "어디까지 맞출지"(구역·커맨드 종류)만 정한다.
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
@@ -60,15 +61,22 @@ test('[#3416] undo 경로가 선택을 되살린다 — redo 경로에는 없다
     '해제 뒤에 복원해야 한다');
 });
 
-test('[#3416] 복원 전에 유효성을 확인한다 (#2339 유령 범위 방지)', () => {
+test('[#3416] 유효성은 호출부가 아니라 selectRange 안에서 판정된다', () => {
+  const cursor = src('src/engine/cursor.ts');
+  const select = functionBodyFrom(cursor, 'selectRange(start: DocumentPosition, end: DocumentPosition)');
+
+  // 확인이 대입보다 먼저여야 한다 — 뒤면 유령 범위가 이미 선 뒤다.
+  const idxCheck = select.indexOf('isVerifiedBodyPosition');
+  const idxAssign = select.indexOf('this.anchor =');
+  assert.ok(idxCheck !== -1 && idxAssign !== -1 && idxCheck < idxAssign,
+    '두 끝을 확인한 뒤에 anchor/position 을 세워야 한다');
+  assert.match(select, /return false/, '세우지 못하면 그 사실을 돌려줘야 한다');
+
+  // 호출부에 같은 판정을 두면 계약이 두 곳으로 갈라진다 — 그때부터 한쪽만 고쳐진다.
   const handler = src('src/engine/input-handler.ts');
   const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
-  assert.match(restore, /isRestorableBodySelection\(/, '유효성 확인을 거쳐야 한다');
-  // 확인보다 먼저 selectRange 를 부르면 유령 범위가 그대로 선다.
-  const idxCheck = restore.indexOf('isRestorableBodySelection');
-  const idxSelect = restore.indexOf('selectRange');
-  assert.ok(idxCheck !== -1 && idxSelect !== -1 && idxCheck < idxSelect,
-    '확인이 selectRange 보다 먼저여야 한다');
+  assert.doesNotMatch(restore, /getParagraphCount|getParagraphLength|parentParaIndex/,
+    '실재 판정을 호출부가 되풀이하면 안 된다');
 });
 
 test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향상이다', () => {
@@ -79,43 +87,61 @@ test('[#3416] 해제는 그대로 남는다 — 복원은 그 위에 얹는 향�
   assert.match(reset, /exitPictureObjectSelection\(\)/);
 });
 
-test('[#3416] 범위 유효성 판정 — 실제 동작', async () => {
+test('[#3416] selectRange 는 실재하지 않는 범위를 거절한다 — 실제 동작', async () => {
   const vite = await createServer({
     root: rootDir, appType: 'custom', logLevel: 'silent', server: { middlewareMode: true },
   });
   try {
-    const mod = await vite.ssrLoadModule('/src/engine/input-handler.ts');
-    const InputHandler: any = mod.InputHandler;
-    // 판정은 wasm 조회에만 의존하므로 프로토타입 메서드를 최소 컨텍스트로 부른다.
-    const check = InputHandler.prototype['isRestorableBodySelection'];
-    assert.equal(typeof check, 'function', 'isRestorableBodySelection 이 있어야 함');
+    const { CursorState } = await vite.ssrLoadModule('/src/engine/cursor.ts');
+    const selectRange = CursorState.prototype.selectRange;
 
-    const ctx = (paraCount: number, len: number) => ({
-      wasm: {
-        getParagraphCount: () => paraCount,
-        getParagraphLength: () => len,
+    // 판정은 wasm 조회에만 의존한다. 생성자는 렌더러까지 요구하므로 프로토타입 위에
+    // 최소 상태만 얹어 부른다(내부 helper 도 프로토타입에서 찾아야 하므로 Object.create).
+    const ctx = (paraCount: number, len: number) => Object.assign(
+      Object.create(CursorState.prototype),
+      {
+        anchor: null, position: null,
+        wasm: { getParagraphCount: () => paraCount, getParagraphLength: () => len },
+        updateRect() { /* 기하 갱신은 이 판정과 무관 */ },
       },
-    });
+    );
     const p = (para: number, off: number) => ({ sectionIndex: 0, paragraphIndex: para, charOffset: off });
 
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 6)), true, '문서 안 범위는 복원 가능');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(5, 6)), false, '문단이 사라졌으면 불가');
-    assert.equal(check.call(ctx(3, 10), p(0, 2), p(0, 99)), false, '오프셋이 길이를 넘으면 불가');
-    assert.equal(
-      check.call(ctx(3, 10), p(0, 2), { sectionIndex: 1, paragraphIndex: 0, charOffset: 1 }),
-      false,
-      '구역이 다르면 불가',
-    );
-    // 셀 안 범위는 확인 축이 달라 복원하지 않는다.
-    assert.equal(
-      check.call(ctx(3, 10), { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)),
-      false,
-      '셀 범위는 복원 대상이 아니다',
-    );
-    // 조회가 던지면 유효하다고 말할 수 없다.
-    const throwing = { wasm: { getParagraphCount: () => { throw new Error('gone'); } } };
-    assert.equal(check.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 불가로 판정');
+    const ok = ctx(3, 10);
+    assert.equal(selectRange.call(ok, p(0, 2), p(0, 6)), true, '문서 안 범위는 세운다');
+    assert.deepEqual(ok.anchor, p(0, 2), 'anchor 는 start');
+    assert.deepEqual(ok.position, p(0, 6), '커서는 end');
+
+    // 거절할 때는 **아무것도 바꾸지 않아야** 한다 — 반쯤 세우면 그게 유령 범위다.
+    for (const [why, start, end] of [
+      ['문단이 사라졌으면', p(0, 2), p(5, 6)],
+      ['오프셋이 길이를 넘으면', p(0, 2), p(0, 99)],
+      ['셀 안 위치는', { ...p(0, 2), parentParaIndex: 1 }, p(0, 6)],
+    ] as Array<[string, any, any]>) {
+      const c = ctx(3, 10);
+      assert.equal(selectRange.call(c, start, end), false, `${why} 거절한다`);
+      assert.equal(c.anchor, null, `${why} anchor 를 건드리지 않는다`);
+      assert.equal(c.position, null, `${why} 커서를 건드리지 않는다`);
+    }
+
+    // 조회가 던지면 실재한다고 말할 수 없다.
+    const throwing = Object.assign(Object.create(CursorState.prototype), {
+      anchor: null, position: null,
+      wasm: { getParagraphCount: () => { throw new Error('gone'); } },
+      updateRect() {},
+    });
+    assert.equal(selectRange.call(throwing, p(0, 2), p(0, 6)), false, '조회 실패는 거절');
+    assert.equal(throwing.anchor, null, '조회 실패에도 상태를 건드리지 않는다');
   } finally {
     await vite.close();
   }
+});
+
+test('[#3416] 구역을 걸치는 범위는 복원 대상이 아니다 (실측 범위 밖)', () => {
+  const handler = src('src/engine/input-handler.ts');
+  const restore = functionBodyFrom(handler, 'private restoreSelectionAfterUndo');
+  assert.match(restore, /sectionIndex !== range\.end\.sectionIndex/, '구역 정책은 호출부가 갖는다');
+  const idxPolicy = restore.indexOf('sectionIndex !==');
+  const idxSelect = restore.indexOf('selectRange');
+  assert.ok(idxPolicy !== -1 && idxPolicy < idxSelect, '정책 판정이 먼저다');
 });


### PR DESCRIPTION
관련 이슈: #3416

## 문제

`cursor.selectRange(start, end)` 가 **실재하지 않는 선택 범위를 그대로 세울 수 있습니다.**
지금 호출부가 하나뿐이라 실제 오동작은 나지 않지만, 계약이 지켜지는 자리가 소유자가 아닙니다.

#3416 이 undo 뒤 선택 복원을 넣으면서 이 메서드를 만들었고(`c2a36398d` 에 포함), 유효성 확인은
호출부인 `input-handler.ts` 의 `isRestorableBodySelection` 에 두고 `selectRange` 주석에는
"호출부가 범위의 유효성을 먼저 확인해야 한다" 를 적어 두었습니다. 그 전제를 강제하는 것은
주석뿐입니다.

## 원인

`selectRange` 는 anchor/focus 의 **소유자이자 뮤테이션 지점**입니다. "선택은 현재 문서에
실재하는 위치를 가리킨다"(#2339)를 지켜야 할 자리가 여기인데, 판정을 소비자에게 맡겼습니다.

- 두 번째 호출부가 생기면 #2339 가 막아 둔 유령 범위가 조용히 되살아납니다. 되돌리기로 문서가
  줄어든 뒤의 anchor/focus 는 이후 Bold·Backspace 에서 WASM 예외나 본 적 없는 범위의 무언
  삭제를 일으킵니다 — 그것이 #2339 가 해제를 넣은 이유입니다.
- 제가 함께 넣은 소스 가드도 **불변식이 아니라 그 한 호출부의 순서**만 잠급니다. 새 호출부가
  생겨도 기존 테스트는 그대로 통과합니다.

저장소에는 이미 반대 방향의 규약이 있습니다. #3438 이 "존재하는 반환 계약만 검사하고 없는
신호는 발명하지 않는다" 로 정리하면서, 실패를 **생산자가 판정하고 결과로 알리는** 형태를
택했습니다 — `update_style` 의 `false`, `SnapshotCommand` 의 `operation → null`. 이 자리만
그 규약에서 벗어나 있었습니다.

## 변경

판정을 소유자 안으로 옮깁니다. **복원되는 범위는 종전과 같습니다** — 판정이 사는 층만 바뀝니다.

```ts
selectRange(start: DocumentPosition, end: DocumentPosition): boolean {
  if (!this.isVerifiedBodyPosition(start) || !this.isVerifiedBodyPosition(end)) return false;
  this.anchor = { ...start };
  this.position = { ...end };
  this.updateRect();
  return true;
}
```

- 두 끝이 확인될 때만 세우고, 못 세우면 **아무것도 바꾸지 않고** `false` 를 돌려줍니다.
  반쯤 세운 상태가 곧 유령 범위이므로 거절 경로는 anchor·position 을 건드리지 않습니다.
- 문단이 아직 있는지, 오프셋이 문단 길이 안인지 보고, 조회 자체가 던지면 실재한다고 말할 수
  없으므로 거절합니다.
- 셀 안 위치(`parentParaIndex`)는 확인이 중첩 셀 경로(`cellPath`)를 따라가는 별도 축이라 이
  산술로는 실재를 말할 수 없어 거절합니다. **"없다" 가 아니라 "이 판정으로는 확인할 수 없다"**
  이고, 확인하지 못한 위치를 세우지 않는 것이 #2339 의 판단과 같습니다. 그래서 이름도
  `isVerifiedBodyPosition` 입니다.

호출부(`restoreSelectionAfterUndo`)에서는 같은 판정을 걷어냅니다. 남는 것은 실재 여부가 아니라
**어디까지 맞출지의 판단**뿐입니다 — 구역을 걸치는 범위는 한컴 실측을 한 구역 안에서만 했으므로
복원하지 않습니다.

### 테스트

`rhwp-studio/tests/issue-3416-selection-restore.test.ts` 를 호출 순서 가드에서 불변식 가드로
바꿉니다(6개).

- 유효성 판정이 `selectRange` **안**에 있고 확인이 대입보다 먼저다 + 호출부가 같은 판정을
  되풀이하지 않는다(계약이 두 곳으로 갈라지면 그때부터 한쪽만 고쳐진다)
- `selectRange` 의 실제 동작 — 문서 안 범위는 세우고, 문단 사라짐 / 오프셋 초과 / 셀 안 위치 /
  조회 실패는 거절하며 **거절할 때 anchor·position 을 건드리지 않는다**
- 구역을 걸치는 범위는 호출부 정책으로 복원 대상이 아니다
- 기존 3개(커맨드가 지우기 전 범위를 복사해 보관 / undo 에만 복원하고 redo 에는 없으며 해제
  뒤에 복원 / #2339 의 해제가 그대로 남아 있다)는 그대로 유지

## 검증

devel `c2a36398d` 기준.

- **수정 전 실패 증명**: 이 PR 의 테스트를 devel 소스에 그대로 걸면 **6개 중 3개 실패**
  (`selectRange` 가 판정을 갖지 않고, 호출부가 실재 판정을 되풀이하며, 거절 경로 자체가 없음).
  이 브랜치에서 6개 전부 통과.
- `npm --prefix rhwp-studio run test` — **1019 tests, 0 fail**(skipped 1 은 기존 테스트).
- `./node_modules/.bin/tsc --noEmit` — exit 0.
- `npm --prefix rhwp-studio run build`(`tsc && vite build`) — exit 0.
- Rust 를 건드리지 않으므로 `cargo` 게이트는 영향 없습니다.

## 범위 외

- **복원 대상의 확대** — 선택 삭제 계열만 복원한다는 #3416 의 결론은 그대로입니다. 이 PR 은
  같은 동작을 다른 층에서 강제할 뿐입니다.
- **셀 안 선택 범위의 복원** — 확인 축이 다르고 한컴 오라클도 없습니다.
- **F3 확장 단계·F5 셀 블록** — 두 모드의 한컴 동작은 재지 않았습니다(#3416 에 남습니다).
